### PR TITLE
[Extractors] Fix map conversion summary wording

### DIFF
--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -1373,8 +1373,8 @@ void ExtractMapsFromMpq(uint32 build, const int locale)
 		}
 	}
 	printf("\n\nMap extraction complete!\n");
-	printf("Successfully converted: %u maps\n", success_count);
-	printf("Failed to convert: %u maps\n", failed_count);
+	printf("Successfully converted: %u tiles\n", success_count);
+	printf("Failed to convert: %u tiles\n", failed_count);
     delete [] areas;
     delete [] map_ids;
 }


### PR DESCRIPTION
The success/failure counters in `ExtractMapsFromMpq` tally ADT **tiles** (one `ConvertADT` call per tile, up to 64×64 per map), not maps — so the final summary's "maps" label is misleading. Relabel the two summary lines to "tiles".

Two-line wording-only change; no behavioral effect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/2)
<!-- Reviewable:end -->
