### PR TITLE
[Build] Complete the loadlib relocation out of dep/

### DIFF
--- a/dep/CMakeLists.txt
+++ b/dep/CMakeLists.txt
@@ -41,5 +41,4 @@ endif()
 
 if(BUILD_TOOLS)
     add_subdirectory(StormLib)
-    add_subdirectory(loadlib)
 endif()

--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -380,7 +380,7 @@ float GridMap::getHeightFromFlat(float /*x*/, float /*y*/) const
 // 64-bit high_res_holes map (MCNK flag 0x10000); supporting it needs a 64-bit
 // hole store here, a wider .map holes block, and a .map version bump. ENTANGLED:
 // the extractor side can't read those holes in isolation - they live at MCNK +0x14
-// where M3 reads the height offset (see dep/loadlib/sl/adt.h B1), so MoP holes are
+// where M3 reads the height offset (see src/tools/Extractor_projects/loadlib/adt.h B1), so MoP holes are
 // part of the broader 5.3+ MCNK header rework, not a holes-only change. MOP_READINESS (B3).
 bool GridMap::isHole(int row, int col) const
 {

--- a/src/tools/Extractor_projects/CMakeLists.txt
+++ b/src/tools/Extractor_projects/CMakeLists.txt
@@ -26,6 +26,10 @@ set(SHARED_SRCS
     shared/ExtractorCommon.h
 )
 
+# mangos's own ADT/WDT/MPQ client-format reader, used by all extractors.
+# Relocated out of dep/ (third-party only) into the extractor tree.
+add_subdirectory(loadlib)
+
 #=======================================================#
 #map-extractor
 #=======================================================#

--- a/src/tools/Extractor_projects/map-extractor/System.cpp
+++ b/src/tools/Extractor_projects/map-extractor/System.cpp
@@ -31,10 +31,10 @@
 
 #include "dbcfile.h"
 // The following is a temp fix until the extractor is merged with the unified extractor
-#include "../loadlib/sl/adt.h"
+#include "../loadlib/adt.h"
 //#include "sl/adt.h"
 // The following is a temp fix until the extractor is merged with the unified extractor
-#include "../loadlib/sl/wdt.h"
+#include "../loadlib/wdt.h"
 //#include "sl/wdt.h"
 #include "../shared/ExtractorCommon.h"
 #ifndef WIN32

--- a/src/tools/Extractor_projects/map-extractor/dbcfile.cpp
+++ b/src/tools/Extractor_projects/map-extractor/dbcfile.cpp
@@ -24,7 +24,7 @@
 
 #include "dbcfile.h"
 // The following is a temp fix until the extractor is merged with the unified extractor
-#include "../loadlib/sl/loadlib.h"
+#include "../loadlib/loadlib.h"
 
 #include <cstdio>
 

--- a/src/tools/Extractor_projects/shared/ExtractorCommon.h
+++ b/src/tools/Extractor_projects/shared/ExtractorCommon.h
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <sstream>
 // The following is a temp fix until the extractor is merged with the unified extractor
-#include "../loadlib/sl/loadlib.h"
+#include "../loadlib/loadlib.h"
 
 FILE* openWoWExe();
 int getBuildNumber();


### PR DESCRIPTION
The earlier "move loadlib out of `dep/`" change landed the file move but not the build wiring, so `master` currently can't configure or compile the extractors:

- `dep/CMakeLists.txt` still ran `add_subdirectory(loadlib)` for the now-removed `dep/loadlib/`, so CMake configure errors out.
- `src/tools/Extractor_projects/CMakeLists.txt` was missing the `add_subdirectory(loadlib)` that defines the relocated target — so all three extractors linked an undefined `loadlib` (no StormLib include propagation).
- Four includes still pointed at the old `../loadlib/sl/X.h` path (`map-extractor/System.cpp` ×2, `map-extractor/dbcfile.cpp`, `shared/ExtractorCommon.h`).

This completes the relocation:
- drop the dangling `dep/` `add_subdirectory(loadlib)`
- add `add_subdirectory(loadlib)` in the extractor tree
- fix the four `../loadlib/sl/X.h` → `../loadlib/X.h` includes
- refresh a stale `dep/loadlib/sl/adt.h` reference in a `GridMap` comment

**Verified:** `map-extractor`, `vmap-extractor`, and `mmap-extractor` all build green again (MSVC, Release).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/3)
<!-- Reviewable:end -->
