### PR TITLE
[Extractors] Zero WMOLiquidHeader padding before writing it

### DIFF
--- a/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
+++ b/src/tools/Extractor_projects/vmap-extractor/wmo.cpp
@@ -277,7 +277,11 @@ bool WMOGroup::open()
         else if (!strcmp(fourcc, "MLIQ"))
         {
             liquflags |= 1;
-            hlq = new WMOLiquidHeader;
+            // Value-initialize so the 2 padding bytes after `type` are zeroed:
+            // the read below fills only the 30 (0x1E) data bytes, but the whole
+            // struct (sizeof = 32) is later written out, so stale padding made
+            // the extracted .wmo bytes non-deterministic run-to-run.
+            hlq = new WMOLiquidHeader();
             f.read(hlq, 0x1E);
             LiquEx_size = sizeof(WMOLiquidVert) * hlq->xverts * hlq->yverts;
             int nLiquBytes = hlq->xtiles * hlq->ytiles;


### PR DESCRIPTION
`WMOLiquidHeader` holds 30 bytes of data (4 ints + 3 floats + 1 `short` = `0x1E`), but `sizeof` is 32 — there are 2 padding bytes after `type`. `WMOGroup::open()` allocated it uninitialized (`new WMOLiquidHeader`) and reads only the 30 data bytes (`f.read(hlq, 0x1E)`), yet the **whole 32-byte struct** is written out later (`fwrite(hlq, sizeof(WMOLiquidHeader), 1, output)`). So the 2 padding bytes carried **stale heap memory** into the extracted `.wmo` files, making them non-deterministic run-to-run.

Fix: value-initialize the header (`new WMOLiquidHeader()`) so the padding is a deterministic zero. The reader expects the full 32 bytes (the `LIQU` chunk size also uses `sizeof`), so shrinking the write isn't an option — zeroing is.

**Verified:** two full client extractions now produce **byte-for-byte identical** `.wmo` files (all 2830); before, ~8 in every 200 differed. The final assembled vmaps were already unaffected (the raw liquid header isn't copied into the `.vmo`), so this is a clean intermediate-file determinism fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/6)
<!-- Reviewable:end -->
