### PR TITLE
MoP 5.4.8 login (Phase 2): wire framing + handshake — fixes the "Connected." stall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,8 @@ message("")
 
 project(MaNGOS VERSION 0.22.0)
 
+enable_testing()
+
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/install CACHE PATH "Default install directory" FORCE)
 endif()

--- a/src/game/CMakeLists.txt
+++ b/src/game/CMakeLists.txt
@@ -311,3 +311,5 @@ if(PLAYERBOTS)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/aiplayerbot.conf.dist
     DESTINATION ${CONF_INSTALL_DIR})
 endif()
+
+add_subdirectory(Server/tests)

--- a/src/game/Server/MopFrameReader.h
+++ b/src/game/Server/MopFrameReader.h
@@ -10,6 +10,14 @@ class MopFrameReader
         enum Status { NEED_MORE, FRAME_READY, MALFORMED };
         /// Bounded reason for a MALFORMED result (for a diagnostic log - never reveals payload).
         enum MalformedReason { MF_NONE, MF_DECRYPT, MF_BAD_SIZE, MF_BAD_COMMAND };
+        /// Inbound header width is STATE-driven, not a simple pre/post-crypt bool:
+        ///   HDR_GREETING  - 4 bytes {uint16 size; uint16 cmd}, size = payload + 2. ONLY the client's
+        ///                   MSG_WOW_CONNECTION reply. Symmetric with the server's own greeting header.
+        ///   HDR_PRECRYPT  - 6 bytes {uint16 size; uint32 cmd}, size = payload + 4. CMSG_AUTH_SESSION onward.
+        ///   HDR_POSTCRYPT - 4 bytes packed (size<<13)|(cmd&0x1FFF), after crypt init.
+        /// Chosen by WorldSocket from (m_Crypt.IsInitialized(), m_connState) and passed PER CALL -- the
+        /// reader stores no codec state of its own.
+        enum HeaderKind { HDR_GREETING, HDR_PRECRYPT, HDR_POSTCRYPT };
         typedef bool (*DecryptFn)(void* ctx, uint8_t* header, size_t len);   ///< in-place ARC4 on the HEADER only
         typedef bool (*CmdValidFn)(void* ctx, uint32_t cmd, bool preCrypt);  ///< game rule; false => reject
         struct Frame { uint32_t cmd; std::vector<uint8_t> payload; };
@@ -19,31 +27,39 @@ class MopFrameReader
             m_reason(MF_NONE), m_hdrLen(0), m_hdrPreCrypt(false) {}
         void Push(const uint8_t* data, size_t len) { m_buf.insert(m_buf.end(), data, data + len); compact(); }
 
-        /// postCrypt is m_Crypt.IsInitialized() - the SOLE codec authority - passed each call; it may change
-        /// between frames (never mid-frame: crypt inits only after a full frame is processed).
-        Status TryFrame(Frame& out, bool postCrypt, void* ctx, DecryptFn decrypt, CmdValidFn cmdValid)
+        /// kind is derived fresh from (m_Crypt.IsInitialized(), m_connState) - the SOLE codec authority -
+        /// and passed each call; it may change between frames (never mid-frame: crypt inits and state
+        /// advances only after a full frame is processed).
+        Status TryFrame(Frame& out, HeaderKind kind, void* ctx, DecryptFn decrypt, CmdValidFn cmdValid)
         {
+            const bool preCrypt = (kind != HDR_POSTCRYPT);
             if (!m_haveHeader)
             {
-                const size_t hlen = postCrypt ? 4u : 6u;
+                const size_t hlen = (kind == HDR_PRECRYPT) ? 6u : 4u;
                 if (avail() < hlen) { return NEED_MORE; }               // NO decrypt call before a complete header
                 uint8_t hdr[6];
                 for (size_t i = 0; i < hlen; ++i) { hdr[i] = m_buf[m_rpos + i]; }
-                if (decrypt && !decrypt(ctx, hdr, hlen)) { return fail(MF_DECRYPT, hdr, hlen, !postCrypt); }
+                if (decrypt && !decrypt(ctx, hdr, hlen)) { return fail(MF_DECRYPT, hdr, hlen, preCrypt); }
                 uint16_t payloadSize = 0;
-                if (postCrypt)
+                if (kind == HDR_POSTCRYPT)
                 {
                     uint16_t c16 = 0;
-                    if (!MopWire::ReadClientPostCryptHeader(hdr, payloadSize, c16)) { return fail(MF_BAD_SIZE, hdr, hlen, false); }
+                    if (!MopWire::ReadClientPostCryptHeader(hdr, payloadSize, c16)) { return fail(MF_BAD_SIZE, hdr, hlen, preCrypt); }
                     m_cmd = c16;
+                }
+                else if (kind == HDR_GREETING)
+                {
+                    uint32_t c32 = 0;
+                    if (!MopWire::ReadClientGreetingHeader(hdr, payloadSize, c32)) { return fail(MF_BAD_SIZE, hdr, hlen, preCrypt); }
+                    m_cmd = c32;
                 }
                 else
                 {
                     uint32_t c32 = 0;
-                    if (!MopWire::ReadClientPreCryptHeader(hdr, payloadSize, c32)) { return fail(MF_BAD_SIZE, hdr, hlen, true); }
+                    if (!MopWire::ReadClientPreCryptHeader(hdr, payloadSize, c32)) { return fail(MF_BAD_SIZE, hdr, hlen, preCrypt); }
                     m_cmd = c32;
                 }
-                if (cmdValid && !cmdValid(ctx, m_cmd, !postCrypt)) { return fail(MF_BAD_COMMAND, hdr, hlen, !postCrypt); }
+                if (cmdValid && !cmdValid(ctx, m_cmd, preCrypt)) { return fail(MF_BAD_COMMAND, hdr, hlen, preCrypt); }
                 m_rpos += hlen; m_need = payloadSize; m_haveHeader = true;
             }
             if (avail() < m_need) { return NEED_MORE; }

--- a/src/game/Server/MopFrameReader.h
+++ b/src/game/Server/MopFrameReader.h
@@ -1,3 +1,27 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
 #ifndef MANGOS_MOP_FRAME_READER_H
 #define MANGOS_MOP_FRAME_READER_H
 #include "MopWireCodec.h"

--- a/src/game/Server/MopFrameReader.h
+++ b/src/game/Server/MopFrameReader.h
@@ -1,0 +1,86 @@
+#ifndef MANGOS_MOP_FRAME_READER_H
+#define MANGOS_MOP_FRAME_READER_H
+#include "MopWireCodec.h"
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+class MopFrameReader
+{
+    public:
+        enum Status { NEED_MORE, FRAME_READY, MALFORMED };
+        /// Bounded reason for a MALFORMED result (for a diagnostic log - never reveals payload).
+        enum MalformedReason { MF_NONE, MF_DECRYPT, MF_BAD_SIZE, MF_BAD_COMMAND };
+        typedef bool (*DecryptFn)(void* ctx, uint8_t* header, size_t len);   ///< in-place ARC4 on the HEADER only
+        typedef bool (*CmdValidFn)(void* ctx, uint32_t cmd, bool preCrypt);  ///< game rule; false => reject
+        struct Frame { uint32_t cmd; std::vector<uint8_t> payload; };
+
+        MopFrameReader()
+          : m_rpos(0), m_haveHeader(false), m_cmd(0), m_need(0),
+            m_reason(MF_NONE), m_hdrLen(0), m_hdrPreCrypt(false) {}
+        void Push(const uint8_t* data, size_t len) { m_buf.insert(m_buf.end(), data, data + len); compact(); }
+
+        /// postCrypt is m_Crypt.IsInitialized() - the SOLE codec authority - passed each call; it may change
+        /// between frames (never mid-frame: crypt inits only after a full frame is processed).
+        Status TryFrame(Frame& out, bool postCrypt, void* ctx, DecryptFn decrypt, CmdValidFn cmdValid)
+        {
+            if (!m_haveHeader)
+            {
+                const size_t hlen = postCrypt ? 4u : 6u;
+                if (avail() < hlen) { return NEED_MORE; }               // NO decrypt call before a complete header
+                uint8_t hdr[6];
+                for (size_t i = 0; i < hlen; ++i) { hdr[i] = m_buf[m_rpos + i]; }
+                if (decrypt && !decrypt(ctx, hdr, hlen)) { return fail(MF_DECRYPT, hdr, hlen, !postCrypt); }
+                uint16_t payloadSize = 0;
+                if (postCrypt)
+                {
+                    uint16_t c16 = 0;
+                    if (!MopWire::ReadClientPostCryptHeader(hdr, payloadSize, c16)) { return fail(MF_BAD_SIZE, hdr, hlen, false); }
+                    m_cmd = c16;
+                }
+                else
+                {
+                    uint32_t c32 = 0;
+                    if (!MopWire::ReadClientPreCryptHeader(hdr, payloadSize, c32)) { return fail(MF_BAD_SIZE, hdr, hlen, true); }
+                    m_cmd = c32;
+                }
+                if (cmdValid && !cmdValid(ctx, m_cmd, !postCrypt)) { return fail(MF_BAD_COMMAND, hdr, hlen, !postCrypt); }
+                m_rpos += hlen; m_need = payloadSize; m_haveHeader = true;
+            }
+            if (avail() < m_need) { return NEED_MORE; }
+            out.cmd = m_cmd;
+            out.payload.assign(m_buf.begin() + m_rpos, m_buf.begin() + m_rpos + m_need);
+            m_rpos += m_need; m_haveHeader = false; compact();
+            return FRAME_READY;
+        }
+
+        MalformedReason LastReason() const { return m_reason; }
+        /// Copy of the offending header (<=6 bytes) captured at the MALFORMED point; never contains payload.
+        const uint8_t* LastHeader(size_t& len, bool& preCrypt) const { len = m_hdrLen; preCrypt = m_hdrPreCrypt; return m_lastHeader; }
+    private:
+        Status fail(MalformedReason r, const uint8_t* hdr, size_t len, bool preCrypt)
+        {
+            m_reason = r; m_hdrLen = (len < 6u ? len : 6u); m_hdrPreCrypt = preCrypt;
+            for (size_t i = 0; i < m_hdrLen; ++i) { m_lastHeader[i] = hdr[i]; }
+            return MALFORMED;
+        }
+        size_t avail() const { return m_buf.size() - m_rpos; }
+        void compact()
+        {
+            if (m_rpos && m_rpos == m_buf.size()) { m_buf.clear(); m_rpos = 0; }
+            else if (m_rpos > 4096) { m_buf.erase(m_buf.begin(), m_buf.begin() + m_rpos); m_rpos = 0; }
+        }
+        std::vector<uint8_t> m_buf; size_t m_rpos; bool m_haveHeader; uint32_t m_cmd; size_t m_need;
+        MalformedReason m_reason; uint8_t m_lastHeader[6]; size_t m_hdrLen; bool m_hdrPreCrypt;
+};
+/// Bounded, payload-free name for a malformed reason (for diagnostic logs).
+inline const char* MalformedReasonName(MopFrameReader::MalformedReason r)
+{
+    switch (r)
+    {
+        case MopFrameReader::MF_DECRYPT:     return "DECRYPT_FAILURE";
+        case MopFrameReader::MF_BAD_SIZE:    return "BAD_SIZE";
+        case MopFrameReader::MF_BAD_COMMAND: return "BAD_COMMAND";
+        default:                             return "NONE";
+    }
+}
+#endif

--- a/src/game/Server/MopHandshake.h
+++ b/src/game/Server/MopHandshake.h
@@ -22,6 +22,17 @@ namespace MopHs
     }
     inline bool RateLimitElapsed(int64_t lastSec, int64_t nowSec) { return (nowSec - lastSec) >= 1; }
     typedef bool (*RandomBytesFn)(uint8_t* out, size_t len);
-    // bool BuildAuthChallengePayload(RandomBytesFn, std::vector<uint8_t>& out, uint32_t& seed);  // Task 2.4
+    inline bool BuildAuthChallengePayload(RandomBytesFn rng, std::vector<uint8_t>& out, uint32_t& seed)
+    {
+        uint8_t field[32], s[4];
+        if (!rng(field, sizeof(field)) || !rng(s, sizeof(s))) { out.clear(); return false; }
+        seed = uint32_t(s[0]) | (uint32_t(s[1])<<8) | (uint32_t(s[2])<<16) | (uint32_t(s[3])<<24);
+        out.clear(); out.reserve(39);
+        out.push_back(0); out.push_back(0);
+        out.insert(out.end(), field, field + 32);
+        out.push_back(1);
+        out.insert(out.end(), s, s + 4);                      // LE bytes == input bytes (identity)
+        return true;
+    }
 }
 #endif

--- a/src/game/Server/MopHandshake.h
+++ b/src/game/Server/MopHandshake.h
@@ -1,0 +1,27 @@
+#ifndef MANGOS_MOP_HANDSHAKE_H
+#define MANGOS_MOP_HANDSHAKE_H
+#include <cstdint>
+#include <cstddef>
+#include <vector>
+namespace MopHs
+{
+    enum ConnectionState { CONN_GREETING, CONN_CHALLENGED, CONN_AUTHENTICATING, CONN_AUTHED };
+    /// Production maps a raw opcode -> a class. Handshake opcodes only in their state; EVERYTHING ELSE
+    /// (ping/keepalive/disconnect/normal) is AUTHED-only, preventing pre-auth socket pinning. If a gate-2b
+    /// capture proves the client sends ping/keepalive pre-auth, add a class + relax (documented).
+    enum OpcodeClass { OPC_GREETING, OPC_AUTH_SESSION, OPC_NORMAL };
+    inline bool IsHandshakeOpcodeLegal(ConnectionState st, OpcodeClass cl)
+    {
+        switch (cl)
+        {
+            case OPC_GREETING:     return st == CONN_GREETING;
+            case OPC_AUTH_SESSION: return st == CONN_CHALLENGED;
+            case OPC_NORMAL:       return st == CONN_AUTHED;      // Phase 2 never AUTHED -> all rejected pre-auth
+        }
+        return false;
+    }
+    inline bool RateLimitElapsed(int64_t lastSec, int64_t nowSec) { return (nowSec - lastSec) >= 1; }
+    typedef bool (*RandomBytesFn)(uint8_t* out, size_t len);
+    // bool BuildAuthChallengePayload(RandomBytesFn, std::vector<uint8_t>& out, uint32_t& seed);  // Task 2.4
+}
+#endif

--- a/src/game/Server/MopHandshake.h
+++ b/src/game/Server/MopHandshake.h
@@ -1,3 +1,27 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
 #ifndef MANGOS_MOP_HANDSHAKE_H
 #define MANGOS_MOP_HANDSHAKE_H
 #include <cstdint>

--- a/src/game/Server/MopWireCodec.h
+++ b/src/game/Server/MopWireCodec.h
@@ -23,6 +23,20 @@ namespace MopWire
         }
         return true;
     }
+    /// Greeting reply header: 4 bytes {uint16 size LE; uint16 cmd LE}, size = payload + 2 -- i.e. the
+    /// SAME shape the server emits for its own greeting (the exchange is symmetric). Confirmed on the
+    /// wire by the live gate: the client sent `30 00 57 4F 52 4C ...` = size 48, cmd 0x4F57
+    /// (MSG_WOW_CONNECTION -- "WO" in LE), payload "RLD OF WARCRAFT CONNECTION - CLIENT TO SERVER\0"
+    /// (46 bytes; 46 + 2 == 48). Reading this as the 6-byte auth header swallows "RL" into cmd and
+    /// yields 0x4C524F57 -> BAD_COMMAND. Only the greeting uses this width; CMSG_AUTH_SESSION and
+    /// later pre-crypt packets use ReadClientPreCryptHeader's 6-byte form.
+    inline bool ReadClientGreetingHeader(const uint8_t in[4], uint16_t& payloadSize, uint32_t& cmd)
+    {
+        uint32_t size=uint32_t(in[0])|(uint32_t(in[1])<<8);
+        cmd=uint32_t(in[2])|(uint32_t(in[3])<<8);                // 16-bit cmd; caller range-checks
+        if (size<2 || size>10240) { return false; }
+        payloadSize=uint16_t(size-2); return true;
+    }
     inline bool ReadClientPreCryptHeader(const uint8_t in[6], uint16_t& payloadSize, uint32_t& cmd)
     {
         uint32_t size=uint32_t(in[0])|(uint32_t(in[1])<<8);

--- a/src/game/Server/MopWireCodec.h
+++ b/src/game/Server/MopWireCodec.h
@@ -1,3 +1,27 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
 #ifndef MANGOS_MOP_WIRE_CODEC_H
 #define MANGOS_MOP_WIRE_CODEC_H
 #include <cstdint>

--- a/src/game/Server/MopWireCodec.h
+++ b/src/game/Server/MopWireCodec.h
@@ -1,0 +1,40 @@
+#ifndef MANGOS_MOP_WIRE_CODEC_H
+#define MANGOS_MOP_WIRE_CODEC_H
+#include <cstdint>
+#include <cstddef>
+namespace MopWire
+{
+    inline void WriteServerPreCryptHeader(uint8_t out[4], uint16_t size, uint16_t cmd)
+    { out[0]=uint8_t(size); out[1]=uint8_t(size>>8); out[2]=uint8_t(cmd); out[3]=uint8_t(cmd>>8); }
+    inline void WriteServerPostCryptHeader(uint8_t out[4], uint32_t size, uint16_t cmd)
+    { uint32_t v=(size<<13)|(uint32_t(cmd)&0x1FFF); out[0]=uint8_t(v); out[1]=uint8_t(v>>8); out[2]=uint8_t(v>>16); out[3]=uint8_t(v>>24); }
+    /// Validate wide (size_t/uint32) THEN narrow. false => reject (do not send).
+    inline bool BuildServerHeader(bool postCrypt, size_t payloadSize, uint32_t cmd, uint8_t out[4])
+    {
+        if (postCrypt)
+        {
+            if (payloadSize > 0x7FFFF || cmd > 0x1FFF) { return false; }
+            WriteServerPostCryptHeader(out, uint32_t(payloadSize), uint16_t(cmd));
+        }
+        else
+        {
+            if (payloadSize > 65533 || cmd > 0xFFFF) { return false; }
+            WriteServerPreCryptHeader(out, uint16_t(payloadSize + 2), uint16_t(cmd));
+        }
+        return true;
+    }
+    inline bool ReadClientPreCryptHeader(const uint8_t in[6], uint16_t& payloadSize, uint32_t& cmd)
+    {
+        uint32_t size=uint32_t(in[0])|(uint32_t(in[1])<<8);
+        cmd=uint32_t(in[2])|(uint32_t(in[3])<<8)|(uint32_t(in[4])<<16)|(uint32_t(in[5])<<24);
+        if (size<4 || size>10240) { return false; }
+        payloadSize=uint16_t(size-4); return true;               // FULL 32-bit cmd out; caller range-checks
+    }
+    inline bool ReadClientPostCryptHeader(const uint8_t in[4], uint16_t& size, uint16_t& cmd)
+    {
+        uint32_t v=uint32_t(in[0])|(uint32_t(in[1])<<8)|(uint32_t(in[2])<<16)|(uint32_t(in[3])<<24);
+        uint32_t s=v>>13; if (s>10236) { return false; }
+        size=uint16_t(s); cmd=uint16_t(v&0x1FFF); return true;
+    }
+}
+#endif

--- a/src/game/Server/MopWireCodec.h
+++ b/src/game/Server/MopWireCodec.h
@@ -33,6 +33,23 @@ namespace MopWire
     inline void WriteServerPostCryptHeader(uint8_t out[4], uint32_t size, uint16_t cmd)
     { uint32_t v=(size<<13)|(uint32_t(cmd)&0x1FFF); out[0]=uint8_t(v); out[1]=uint8_t(v>>8); out[2]=uint8_t(v>>16); out[3]=uint8_t(v>>24); }
     /// Validate wide (size_t/uint32) THEN narrow. false => reject (do not send).
+    ///
+    /// PRE-CRYPT writes {uint16 size LE; uint16 cmd LE}, size = payload + 2, UNENCRYPTED.
+    /// The size field is LITTLE-endian. Confirmed by the live 5.4.8.18414 gate: the client decoded
+    /// our `29 00 49 09` (size 0x0029 = 41 = 39 + 2, cmd 0x0949 SMSG_AUTH_CHALLENGE) and replied
+    /// with CMSG_AUTH_SESSION. The client's OWN greeting reply uses the same LE shape (`30 00` = 48
+    /// for a 50-byte frame; big-endian that would be 12288, absurd). DO NOT byte-swap this to match
+    /// the deleted Cata-era ServerPktHeader -- that baseline wrote the size big-endian and is the
+    /// direct cause of the "Connected." stall this replaced; no MoP client ever framed against it.
+    ///
+    /// SEQUENCING CONSTRAINT -- PHASE 1b MUST LAND BEFORE PHASE 3 INITIALIZES CRYPT.
+    /// The post-crypt header packs (size << 13) | (cmd & 0x1FFF), so the opcode field is physically
+    /// 13 bits: a cmd > 0x1FFF CANNOT be represented and is rejected here (SendPacket logs
+    /// "frame out of range" and returns -1 -- never silent). 536 values in Opcodes.h still exceed
+    /// 0x1FFF (279 of them SMSG, e.g. SMSG_MESSAGECHAT = 0x2026) because they retain their 4.3.4
+    /// values. This is UNREACHABLE for all of Phase 2 (crypt is never initialized, so postCrypt is
+    /// always false), but once Phase 3 calls m_Crypt.Init() those sends begin failing unless the
+    /// Phase 1b opcode-table migration has already remapped them into the 13-bit space.
     inline bool BuildServerHeader(bool postCrypt, size_t payloadSize, uint32_t cmd, uint8_t out[4])
     {
         if (postCrypt)
@@ -61,6 +78,19 @@ namespace MopWire
         if (size<2 || size>10240) { return false; }
         payloadSize=uint16_t(size-2); return true;
     }
+    /// 6-byte auth-era header {uint16 size LE; uint32 cmd LE}, size = payload + 4. Used for
+    /// CMSG_AUTH_SESSION onward; the greeting uses ReadClientGreetingHeader's 4-byte form instead.
+    ///
+    /// The size field is LITTLE-endian, and the arithmetic is decisive. The live 5.4.8.18414 gate
+    /// captured the client emitting `b7 01 b2 00 00 00` for a 441-byte frame:
+    ///     LE: size = 0x01B7 = 439 = 435 + 4, and the 435-byte body parsed cleanly.  <- correct
+    ///     BE: size = 0xB701 = 46849, which trips the `size > 10240` reject below and would kill
+    ///         the connection before authentication could start.
+    /// Those bytes are the CLIENT's own encoding, not our interpretation of them.
+    ///
+    /// DO NOT "restore" a byte-swap here. The deleted Cata-era parser applied
+    /// EndianConvertReverse(header.size); that path is precisely what never got a MoP client past
+    /// "Connected.", so it cannot serve as evidence of the correct byte order.
     inline bool ReadClientPreCryptHeader(const uint8_t in[6], uint16_t& payloadSize, uint32_t& cmd)
     {
         uint32_t size=uint32_t(in[0])|(uint32_t(in[1])<<8);

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -341,21 +341,6 @@ int WorldSocket::open(void* a)
         return -1;
     }
 
-    // Send startup packet.
-    WorldPacket packet (SMSG_AUTH_CHALLENGE, 37);
-    for (uint32 i = 0; i < 8; i++)
-    {
-        packet << uint32(0);
-    }
-
-    packet << m_Seed;
-    packet << uint8(1);
-
-    if (SendPacket(packet) == -1)
-    {
-        return -1;
-    }
-
     // Register with ACE Reactor
     if (reactor()->register_handler(this, ACE_Event_Handler::READ_MASK | ACE_Event_Handler::WRITE_MASK) == -1)
     {

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -658,8 +658,17 @@ int WorldSocket::handle_input_missing_data(void)
     MopFrameReader::Frame frame;
     for (;;)
     {
+        // Header width is state-driven, derived fresh every frame (no stored codec flag):
+        //   crypt live            -> 4-byte packed
+        //   still awaiting greet  -> 4-byte {size, cmd16}; the client's MSG_WOW_CONNECTION reply is
+        //                            symmetric with the greeting we sent (size = payload + 2)
+        //   otherwise (pre-crypt) -> 6-byte {size, cmd32}; CMSG_AUTH_SESSION onward (size = payload + 4)
+        const MopFrameReader::HeaderKind kind =
+            m_Crypt.IsInitialized()             ? MopFrameReader::HDR_POSTCRYPT :
+            (m_connState == MopHs::CONN_GREETING) ? MopFrameReader::HDR_GREETING :
+                                                    MopFrameReader::HDR_PRECRYPT;
         const MopFrameReader::Status s =
-            m_frameReader.TryFrame(frame, m_Crypt.IsInitialized(), this, &DecryptHeaderHook, &CmdValidHook);
+            m_frameReader.TryFrame(frame, kind, this, &DecryptHeaderHook, &CmdValidHook);
 
         if (s == MopFrameReader::NEED_MORE)
         {

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -356,7 +356,14 @@ int WorldSocket::HandleWowConnection(WorldPacket& recvPacket)
     std::string ClientToServerMsg;
     recvPacket >> ClientToServerMsg;
     DEBUG_LOG("Received MSG_WOW_CONNECTION FROM %s", m_Session ? m_Session->GetRemoteAddress().c_str() : "<unk>");
-    if (strcmp(ClientToServerMsg.c_str(), "D OF WARCRAFT CONNECTION - CLIENT TO SERVER") != 0)
+    // Mirror of the greeting we send ("RLD OF WARCRAFT CONNECTION - SERVER TO CLIENT"): the leading
+    // "WO" of "WORLD" is carried by the header's cmd field (0x4F57 == "WO" little-endian), so the
+    // payload legitimately begins at "RLD".
+    // NOTE: this previously expected "D OF WARCRAFT ..." -- that constant was compensating for the
+    // Cata-era 6-byte {uint16 size; uint32 cmd} read of the greeting, which swallowed "WORL" into cmd
+    // and left the payload starting at 'D' (the garbage cmd then truncated to 0x4F57 and dispatched
+    // here by accident). With the greeting parsed at its true 4-byte width, the payload is "RLD...".
+    if (strcmp(ClientToServerMsg.c_str(), "RLD OF WARCRAFT CONNECTION - CLIENT TO SERVER") != 0)
     {
         sLog.outError("WorldSocket::ProcessIncoming: received wrong data in MSG_WOW_CONNECTION.");
         return -1;

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -764,6 +764,20 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
         sLog.outWorldPacketDump(uint32(get_handle()), opcode, LookupOpcodeName(DIR_CLIENT, opcode), new_pct, true);
     }
 
+    // Handshake state legality allowlist. MUST run before the MSG_WOW_CONNECTION early-return below,
+    // otherwise a client could resend the greeting after already being CONN_CHALLENGED (duplicate-greeting
+    // bypass). OPC_NORMAL is AUTHED-only; Phase 2 never reaches CONN_AUTHED, so all non-handshake opcodes
+    // are rejected pre-auth (prevents pre-auth socket pinning). Phase 3 sets CONN_AUTHED and opens that gate.
+    MopHs::OpcodeClass cls =
+        (opcode == MSG_WOW_CONNECTION) ? MopHs::OPC_GREETING :
+        (opcode == CMSG_AUTH_SESSION)  ? MopHs::OPC_AUTH_SESSION : MopHs::OPC_NORMAL;
+    if (!MopHs::IsHandshakeOpcodeLegal(m_connState, cls))
+    {
+        sLog.outError("WorldSocket::ProcessIncoming: opcode 0x%.4X illegal in state %d from %s; closing.",
+                      opcode, int(m_connState), GetRemoteAddress().c_str());
+        return -1;
+    }
+
     // Greeting is out-of-band: 0x4F57 is outside the 13-bit table, resolved by name only.
     if (opcode == MSG_WOW_CONNECTION)
     {
@@ -785,22 +799,11 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
             case CMSG_PING:
                 return HandlePing(*new_pct);
             case CMSG_AUTH_SESSION:
-                if (m_Session)
-                {
-                    sLog.outError("WorldSocket::ProcessIncoming: Player send CMSG_AUTH_SESSION again");
-                    return -1;
-                }
-
-#ifdef ENABLE_ELUNA
-                if (Eluna* e = sWorld.GetEluna())
-                {
-                    if (!e->OnPacketReceive(m_Session, *new_pct))
-                    {
-                        return 0;
-                    }
-                }
-#endif /* ENABLE_ELUNA */
-                return HandleAuthSession(*new_pct);
+                // Phase 2: framing proven. Do NOT enter the legacy auth path (HandleAuthSession -> m_Crypt.Init).
+                // The allowlist (Step 1) guarantees we are in CONN_CHALLENGED here, so this is the LEGAL transition.
+                m_connState = MopHs::CONN_AUTHENTICATING;
+                DEBUG_LOG("WorldSocket: CMSG_AUTH_SESSION accepted; CONN_CHALLENGED -> CONN_AUTHENTICATING; auth deferred to Phase 3 (framing OK, len %zu, body redacted); closing.", new_pct->size());
+                return -1;
             case CMSG_KEEP_ALIVE:
                 DEBUG_LOG("CMSG_KEEP_ALIVE ,size: %zu ", new_pct->size());
 

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -167,8 +167,13 @@ const std::string& WorldSocket::GetRemoteAddress(void) const
  * @param pct The packet to send.
  * @return int Zero on success; otherwise -1.
  */
-int WorldSocket::SendPacket(const WorldPacket& pct)
+int WorldSocket::SendPacket(const WorldPacket& pct, bool* sent)
 {
+    if (sent)
+    {
+        *sent = false;
+    }
+
     ACE_GUARD_RETURN(LockType, Guard, m_OutBufferLock, -1);
 
     if (closing_)
@@ -196,6 +201,10 @@ int WorldSocket::SendPacket(const WorldPacket& pct)
     {
         if (!e->OnPacketSend(m_Session, pct))
         {
+            if (sent)
+            {
+                *sent = false;
+            }
             return 0;
         }
     }
@@ -252,6 +261,10 @@ int WorldSocket::SendPacket(const WorldPacket& pct)
         }
     }
 
+    if (sent)
+    {
+        *sent = true;
+    }
     return 0;
 }
 
@@ -365,9 +378,15 @@ int WorldSocket::SendAuthChallenge()
     }
     WorldPacket packet(SMSG_AUTH_CHALLENGE, uint32(payload.size()));
     packet.append(payload.data(), payload.size());
-    if (SendPacket(packet) == -1)
+    bool sent = false;
+    if (SendPacket(packet, &sent) == -1)
     {
         return -1;
+    }
+    if (!sent)
+    {
+        sLog.outError("WorldSocket::SendAuthChallenge: challenge was suppressed (not sent); closing.");
+        return -1;                                            // never advance state on a challenge the client never got
     }
     m_Seed = seed;                                            // only after the challenge is actually on the wire
     m_connState = MopHs::CONN_CHALLENGED;                     // member exists since Task 2.1
@@ -636,9 +655,9 @@ int WorldSocket::handle_input_missing_data(void)
 
     m_frameReader.Push((const uint8*)buf, size_t(n));
 
+    MopFrameReader::Frame frame;
     for (;;)
     {
-        MopFrameReader::Frame frame;
         const MopFrameReader::Status s =
             m_frameReader.TryFrame(frame, m_Crypt.IsInitialized(), this, &DecryptHeaderHook, &CmdValidHook);
 
@@ -670,7 +689,8 @@ int WorldSocket::handle_input_missing_data(void)
             return -1;
         }
 
-        WorldPacket* pct = new WorldPacket(OpcodesList(uint16(frame.cmd)), uint32(frame.payload.size()));
+        WorldPacket* pct = NULL;
+        ACE_NEW_RETURN(pct, WorldPacket(OpcodesList(uint16(frame.cmd)), uint32(frame.payload.size())), -1);
         if (!frame.payload.empty())
         {
             pct->append(frame.payload.data(), frame.payload.size());
@@ -785,7 +805,7 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
     // otherwise a client could resend the greeting after already being CONN_CHALLENGED (duplicate-greeting
     // bypass). OPC_NORMAL is AUTHED-only; Phase 2 never reaches CONN_AUTHED, so all non-handshake opcodes
     // are rejected pre-auth (prevents pre-auth socket pinning). Phase 3 sets CONN_AUTHED and opens that gate.
-    MopHs::OpcodeClass cls =
+    const MopHs::OpcodeClass cls =
         (opcode == MSG_WOW_CONNECTION) ? MopHs::OPC_GREETING :
         (opcode == CMSG_AUTH_SESSION)  ? MopHs::OPC_AUTH_SESSION : MopHs::OPC_NORMAL;
     if (!MopHs::IsHandshakeOpcodeLegal(m_connState, cls))
@@ -817,7 +837,9 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
                 return HandlePing(*new_pct);
             case CMSG_AUTH_SESSION:
                 // Phase 2: framing proven. Do NOT enter the legacy auth path (HandleAuthSession -> m_Crypt.Init).
-                // The allowlist (Step 1) guarantees we are in CONN_CHALLENGED here, so this is the LEGAL transition.
+                // The allowlist above guarantees we are in CONN_CHALLENGED here, so this is the LEGAL transition.
+                // The ENABLE_ELUNA OnPacketReceive hook for this opcode is intentionally NOT invoked here;
+                // it is deferred to Phase 3 along with the rest of the auth path.
                 m_connState = MopHs::CONN_AUTHENTICATING;
                 DEBUG_LOG("WorldSocket: CMSG_AUTH_SESSION accepted; CONN_CHALLENGED -> CONN_AUTHENTICATING; auth deferred to Phase 3 (framing OK, len %zu, body redacted); closing.", new_pct->size());
                 return -1;
@@ -876,15 +898,24 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
             }
             else
             {
-                const size_t cap = 64, m = new_pct->size() < cap ? new_pct->size() : cap;
-                char hex[cap * 3 + 1];
-                for (size_t i = 0; i < m; ++i)
+                const size_t cap = 64;
+                const size_t dumpLen = new_pct->size() < cap ? new_pct->size() : cap;
+                if (sLog.HasLogLevelOrHigher(LOG_LVL_DEBUG))
                 {
-                    snprintf(hex + i * 3, 4, "%02X ", new_pct->contents()[i]);
+                    char hex[cap * 3 + 1];
+                    for (size_t i = 0; i < dumpLen; ++i)
+                    {
+                        snprintf(hex + i * 3, 4, "%02X ", new_pct->contents()[i]);
+                    }
+                    hex[dumpLen ? dumpLen * 3 - 1 : 0] = '\0';
+                    sLog.outError("WorldSocket: decode failure opcode 0x%.4X (%s) from %s; first %zu bytes: %s",
+                                  opcode, LookupOpcodeName(DIR_CLIENT, opcode), GetRemoteAddress().c_str(), dumpLen, hex);
                 }
-                hex[m ? m * 3 - 1 : 0] = '\0';
-                sLog.outError("WorldSocket: decode failure opcode 0x%.4X (%s) from %s; first %zu bytes: %s",
-                              opcode, LookupOpcodeName(DIR_CLIENT, opcode), GetRemoteAddress().c_str(), m, hex);
+                else
+                {
+                    sLog.outError("WorldSocket: decode failure opcode 0x%.4X (%s) from %s.",
+                                  opcode, LookupOpcodeName(DIR_CLIENT, opcode), GetRemoteAddress().c_str());
+                }
             }
         }
 

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -292,7 +292,7 @@ long WorldSocket::RemoveReference(void)
 }
 
 /**
- * @brief Opens the socket handler and sends the authentication challenge.
+ * @brief Opens the socket handler and sends the connection greeting; the auth challenge is sent later via HandleWowConnection -> SendAuthChallenge().
  *
  * @param a The ACE open hook parameter.
  * @return int Zero on success; otherwise -1.

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -54,6 +54,8 @@
 #include <ace/Reactor.h>
 #include <ace/Auto_Ptr.h>
 
+#include <cstdio>
+
 #include "WorldSocket.h"
 #include "Common.h"
 #include "MopWireCodec.h"
@@ -75,29 +77,6 @@
 #endif /* ENABLE_ELUNA */
 #include <openssl/rand.h>
 
-#if defined( __GNUC__ )
-#pragma pack(1)
-#else
-#pragma pack(push,1)
-#endif
-
-/**
- * @brief Client packet header structure
- *
- * Header for packets sent from client to server.
- */
-struct ClientPktHeader
-{
-    uint16 size; ///< Packet size
-    uint32 cmd;  ///< Opcode
-};
-
-#if defined( __GNUC__ )
-#pragma pack()
-#else
-#pragma pack(pop)
-#endif
-
 /**
  * @brief WorldSocket constructor
  *
@@ -113,9 +92,6 @@ WorldSocket::WorldSocket(void) :
     m_LastPingTime(ACE_Time_Value::zero),
     m_OverSpeedPings(0),
     m_Session(0),
-    m_RecvWPct(0),
-    m_RecvPct(),
-    m_Header(sizeof(ClientPktHeader)),
     m_OutBuffer(0),
     m_OutBufferSize(65536),
     m_OutActive(false),
@@ -137,8 +113,6 @@ WorldSocket::WorldSocket(void) :
  */
 WorldSocket::~WorldSocket(void)
 {
-    delete m_RecvWPct;
-
     if (m_OutBuffer)
     {
         m_OutBuffer->release();
@@ -632,173 +606,93 @@ int WorldSocket::Update(void)
 }
 
 /**
- * @brief Parses and validates an incoming packet header.
+ * @brief Receives socket data and drains as many complete frames as are buffered.
  *
- * @return int Zero on success; otherwise -1.
- */
-int WorldSocket::handle_input_header(void)
-{
-    MANGOS_ASSERT(m_RecvWPct == NULL);
-
-    MANGOS_ASSERT(m_Header.length() == sizeof(ClientPktHeader));
-
-    m_Crypt.DecryptRecv((uint8*) m_Header.rd_ptr(), sizeof(ClientPktHeader));
-
-    ClientPktHeader& header = *((ClientPktHeader*) m_Header.rd_ptr());
-
-    EndianConvertReverse(header.size);
-    EndianConvert(header.cmd);
-
-    if ((header.size < 4) || (header.size > 10240))
-    {
-        sLog.outError("WorldSocket::handle_input_header: client sent malformed packet size = %d , cmd = %d",
-                      header.size, header.cmd);
-
-        errno = EINVAL;
-        return -1;
-    }
-
-    header.size -= 4;
-
-    ACE_NEW_RETURN(m_RecvWPct, WorldPacket(OpcodesList(header.cmd), header.size), -1);
-
-    if (header.size > 0)
-    {
-        m_RecvWPct->resize(header.size);
-        m_RecvPct.base((char*) m_RecvWPct->contents(), m_RecvWPct->size());
-    }
-    else
-    {
-        MANGOS_ASSERT(m_RecvPct.space() == 0);
-    }
-
-    return 0;
-}
-
-/**
- * @brief Finalizes processing of a fully received packet payload.
+ * Delegates two-phase header + payload reassembly to MopFrameReader (consume-one-frame
+ * reader). postCrypt is passed per call as m_Crypt.IsInitialized() - the sole codec
+ * authority - so a crypt Init() mid-stream (Phase 3 auth) is picked up automatically on
+ * the very next TryFrame() with no separate flag to keep in sync.
  *
- * @return int Zero on success; otherwise -1.
- */
-int WorldSocket::handle_input_payload(void)
-{
-    // set errno properly here on error !!!
-    // now have a header and payload
-
-    MANGOS_ASSERT(m_RecvPct.space() == 0);
-    MANGOS_ASSERT(m_Header.space() == 0);
-    MANGOS_ASSERT(m_RecvWPct != NULL);
-
-    const int ret = ProcessIncoming(m_RecvWPct);
-
-    m_RecvPct.base(NULL, 0);
-    m_RecvPct.reset();
-    m_RecvWPct = NULL;
-
-    m_Header.reset();
-
-    if (ret == -1)
-    {
-        errno = EINVAL;
-    }
-
-    return ret;
-}
-
-/**
- * @brief Receives and assembles any missing header or payload data from the socket.
- *
- * @return int A receive state code, or -1 on error.
+ * @return int A receive state code (ACE contract: 0 peer-closed, -1 error, 1 full read,
+ *             2 partial read), or -1 on error.
  */
 int WorldSocket::handle_input_missing_data(void)
 {
-    char buf [4096];
-
-    ACE_Data_Block db(sizeof(buf),
-                      ACE_Message_Block::MB_DATA,
-                      buf,
-                      0,
-                      0,
-                      ACE_Message_Block::DONT_DELETE,
-                      0);
-
-    ACE_Message_Block message_block(&db,
-                                    ACE_Message_Block::DONT_DELETE,
-                                    0);
-
-    const size_t recv_size = message_block.space();
-
-    const ssize_t n = peer().recv(message_block.wr_ptr(),
-                                  recv_size);
-
+    char buf[4096];
+    const ssize_t n = peer().recv(buf, sizeof(buf));
     if (n <= 0)
     {
         return (int)n;
     }
 
-    message_block.wr_ptr(n);
+    m_frameReader.Push((const uint8*)buf, size_t(n));
 
-    while (message_block.length() > 0)
+    for (;;)
     {
-        if (m_Header.space() > 0)
+        MopFrameReader::Frame frame;
+        const MopFrameReader::Status s =
+            m_frameReader.TryFrame(frame, m_Crypt.IsInitialized(), this, &DecryptHeaderHook, &CmdValidHook);
+
+        if (s == MopFrameReader::NEED_MORE)
         {
-            // need to receive the header
-            const size_t to_header = (message_block.length() > m_Header.space() ? m_Header.space() : message_block.length());
-            m_Header.copy(message_block.rd_ptr(), to_header);
-            message_block.rd_ptr(to_header);
-
-            if (m_Header.space() > 0)
-            {
-                // Couldn't receive the whole header this time.
-                MANGOS_ASSERT(message_block.length() == 0);
-                errno = EWOULDBLOCK;
-                return -1;
-            }
-
-            // We just received nice new header
-            if (handle_input_header() == -1)
-            {
-                MANGOS_ASSERT((errno != EWOULDBLOCK) && (errno != EAGAIN));
-                return -1;
-            }
+            break;
         }
 
-        // Its possible on some error situations that this happens
-        // for example on closing when epoll receives more chunked data and stuff
-        // hope this is not hack ,as proper m_RecvWPct is asserted around
-        if (!m_RecvWPct)
+        if (s == MopFrameReader::MALFORMED)
         {
-            sLog.outError("Forcing close on input m_RecvWPct = NULL");
+            const ACE_Time_Value now = ACE_OS::gettimeofday();
+            if (MopHs::RateLimitElapsed(m_lastDecodeLog.sec(), now.sec()))
+            {
+                m_lastDecodeLog = now;
+                size_t hl = 0;
+                bool preCrypt = false;
+                const uint8* hb = m_frameReader.LastHeader(hl, preCrypt);   // <=6 HEADER bytes; never payload
+                char hex[6 * 3 + 1];
+                for (size_t i = 0; i < hl; ++i)
+                {
+                    snprintf(hex + i * 3, 4, "%02X ", hb[i]);
+                }
+                hex[hl ? hl * 3 - 1 : 0] = '\0';
+                sLog.outError("WorldSocket: malformed frame from %s [%s reason=%s header=%s]; closing.",
+                              GetRemoteAddress().c_str(), preCrypt ? "pre-crypt" : "post-crypt",
+                              MalformedReasonName(m_frameReader.LastReason()), hex);
+            }
             errno = EINVAL;
             return -1;
         }
 
-        // We have full read header, now check the data payload
-        if (m_RecvPct.space() > 0)
+        WorldPacket* pct = new WorldPacket(OpcodesList(uint16(frame.cmd)), uint32(frame.payload.size()));
+        if (!frame.payload.empty())
         {
-            // need more data in the payload
-            const size_t to_data = (message_block.length() > m_RecvPct.space() ? m_RecvPct.space() : message_block.length());
-            m_RecvPct.copy(message_block.rd_ptr(), to_data);
-            message_block.rd_ptr(to_data);
-
-            if (m_RecvPct.space() > 0)
-            {
-                // Couldn't receive the whole data this time.
-                MANGOS_ASSERT(message_block.length() == 0);
-                errno = EWOULDBLOCK;
-                return -1;
-            }
+            pct->append(frame.payload.data(), frame.payload.size());
         }
 
-        // just received fresh new payload
-        if (handle_input_payload() == -1)
+        if (ProcessIncoming(pct) == -1)
         {
-            MANGOS_ASSERT((errno != EWOULDBLOCK) && (errno != EAGAIN));
+            errno = EINVAL;
             return -1;
         }
+        // Phase 3: after crypt Init in the auth path, the NEXT TryFrame sees IsInitialized()==true (no manual flag).
     }
 
-    return size_t(n) == recv_size ? 1 : 2;
+    return (size_t(n) == sizeof(buf)) ? 1 : 2;   // preserve ACE contract: full read -> 1, partial -> 2
+}
+
+/// MopFrameReader::DecryptFn hook (Phase 2 wire framing): in-place ARC4 on the header only.
+bool WorldSocket::DecryptHeaderHook(void* ctx, uint8* header, size_t len)
+{
+    static_cast<WorldSocket*>(ctx)->m_Crypt.DecryptRecv(header, len);
+    return true;   // no-op pre-crypt (m_Crypt.DecryptRecv() is itself a no-op before Init())
+}
+
+/// MopFrameReader::CmdValidFn hook (Phase 2 wire framing): game rule; false rejects the frame.
+bool WorldSocket::CmdValidHook(void* ctx, uint32 cmd, bool preCrypt)
+{
+    if (!preCrypt)
+    {
+        return true;
+    }
+    return cmd == MSG_WOW_CONNECTION || cmd < OPCODE_TABLE_SIZE;
 }
 
 int WorldSocket::cancel_wakeup_output(GuardType& g)

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -73,6 +73,7 @@
 #ifdef ENABLE_ELUNA
 #include "LuaEngine.h"
 #endif /* ENABLE_ELUNA */
+#include <openssl/rand.h>
 
 #if defined( __GNUC__ )
 #pragma pack(1)
@@ -118,7 +119,7 @@ WorldSocket::WorldSocket(void) :
     m_OutBuffer(0),
     m_OutBufferSize(65536),
     m_OutActive(false),
-    m_Seed(rand32()),
+    m_Seed(0),
     m_connState(MopHs::CONN_GREETING),
     m_frameReader(),
     m_lastDecodeLog(ACE_Time_Value::zero)
@@ -368,20 +369,23 @@ int WorldSocket::HandleWowConnection(WorldPacket& recvPacket)
     return SendAuthChallenge();
 }
 
+static bool DefaultRandomBytes(uint8_t* out, size_t len) { return RAND_bytes(out, int(len)) == 1; }
+
 int WorldSocket::SendAuthChallenge()
 {
     DEBUG_LOG("Sending SMSG_AUTH_CHALLENGE");
-    WorldPacket packet(SMSG_AUTH_CHALLENGE, 37);
-    packet << uint16(0);
-
-    for (int i = 0; i < 8; i++)
-        packet << uint32(0);
-
-    packet << uint8(1);
-    packet << uint32(m_Seed);
-
-    return SendPacket(packet);
-
+    std::vector<uint8_t> payload; uint32 seed = 0;
+    if (!MopHs::BuildAuthChallengePayload(&DefaultRandomBytes, payload, seed))
+    {
+        sLog.outError("WorldSocket::SendAuthChallenge: CSPRNG failure; closing.");
+        return -1;                                            // nothing sent
+    }
+    m_Seed = seed;
+    WorldPacket packet(SMSG_AUTH_CHALLENGE, uint32(payload.size()));
+    packet.append(payload.data(), payload.size());
+    if (SendPacket(packet) == -1) { return -1; }
+    m_connState = MopHs::CONN_CHALLENGED;                     // member exists since Task 2.1
+    return 0;
 }
 
 void WorldSocket::SendAuthResponseError(uint8 code)

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -380,10 +380,13 @@ int WorldSocket::SendAuthChallenge()
         sLog.outError("WorldSocket::SendAuthChallenge: CSPRNG failure; closing.");
         return -1;                                            // nothing sent
     }
-    m_Seed = seed;
     WorldPacket packet(SMSG_AUTH_CHALLENGE, uint32(payload.size()));
     packet.append(payload.data(), payload.size());
-    if (SendPacket(packet) == -1) { return -1; }
+    if (SendPacket(packet) == -1)
+    {
+        return -1;
+    }
+    m_Seed = seed;                                            // only after the challenge is actually on the wire
     m_connState = MopHs::CONN_CHALLENGED;                     // member exists since Task 2.1
     return 0;
 }

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -157,7 +157,10 @@ WorldSocket::WorldSocket(void) :
     m_OutBuffer(0),
     m_OutBufferSize(65536),
     m_OutActive(false),
-    m_Seed(rand32())
+    m_Seed(rand32()),
+    m_connState(MopHs::CONN_GREETING),
+    m_frameReader(),
+    m_lastDecodeLog(ACE_Time_Value::zero)
 {
     reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
 

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -56,6 +56,7 @@
 
 #include "WorldSocket.h"
 #include "Common.h"
+#include "MopWireCodec.h"
 
 #include "Util.h"
 #include "World.h"
@@ -78,46 +79,6 @@
 #else
 #pragma pack(push,1)
 #endif
-
-/**
- * @brief Server packet header structure
- *
- * Header for packets sent from server to client.
- */
-struct ServerPktHeader
-{
-    /*
-     * size is the length of the payload _plus_ the length of the opcode
-     */
-    ServerPktHeader(uint32 size, uint16 cmd) : size(size)
-    {
-        uint8 headerIndex = 0;
-        if (isLargePacket())
-        {
-            DEBUG_LOG("initializing large server to client packet. Size: %u, cmd: %u", size, cmd);
-            header[headerIndex++] = 0x80 | (0xFF & (size >> 16));
-        }
-        header[headerIndex++] = 0xFF & (size >> 8);
-        header[headerIndex++] = 0xFF & size;
-
-        header[headerIndex++] = 0xFF & cmd;
-        header[headerIndex++] = 0xFF & (cmd >> 8);
-    }
-
-    uint8 getHeaderLength()
-    {
-        // cmd = 2 bytes, size= 2||3bytes
-        return 2 + (isLargePacket() ? 3 : 2);
-    }
-
-    bool isLargePacket()
-    {
-        return size > 0x7FFF;
-    }
-
-    const uint32 size;
-    uint8 header[5];
-};
 
 /**
  * @brief Client packet header structure
@@ -256,13 +217,23 @@ int WorldSocket::SendPacket(const WorldPacket& pct)
     }
 #endif
 
-    ServerPktHeader header(pct.size() + 2, pct.GetOpcode());
-    m_Crypt.EncryptSend((uint8*)header.header, header.getHeaderLength());
+    uint8 header[4];
+    const bool postCrypt = m_Crypt.IsInitialized();
+    if (!MopWire::BuildServerHeader(postCrypt, pct.size(), pct.GetOpcode(), header))
+    {
+        sLog.outError("WorldSocket::SendPacket: frame out of range (size=%zu opcode=0x%.4X postCrypt=%d)",
+                      pct.size(), pct.GetOpcode(), int(postCrypt));
+        return -1;
+    }
+    if (postCrypt)
+    {
+        m_Crypt.EncryptSend(header, sizeof(header));
+    }
 
-    if (m_OutBuffer->space() >= pct.size() + header.getHeaderLength() && msg_queue()->is_empty())
+    if (m_OutBuffer->space() >= pct.size() + sizeof(header) && msg_queue()->is_empty())
     {
         // Put the packet on the buffer.
-        if (m_OutBuffer->copy((char*) header.header, header.getHeaderLength()) == -1)
+        if (m_OutBuffer->copy((char*) header, sizeof(header)) == -1)
         {
             MANGOS_ASSERT(false);
         }
@@ -280,9 +251,9 @@ int WorldSocket::SendPacket(const WorldPacket& pct)
         // Enqueue the packet.
         ACE_Message_Block* mb;
 
-        ACE_NEW_RETURN(mb, ACE_Message_Block(pct.size() + header.getHeaderLength()), -1);
+        ACE_NEW_RETURN(mb, ACE_Message_Block(pct.size() + sizeof(header)), -1);
 
-        mb->copy((char*) header.header, header.getHeaderLength());
+        mb->copy((char*) header, sizeof(header));
 
         if (!pct.empty())
         {

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -177,9 +177,18 @@ int WorldSocket::SendPacket(const WorldPacket& pct)
     }
 
     // Dump outgoing packet (opt-in via PacketLoggingEnabled; off by default).
+    // SMSG_AUTH_RESPONSE is auth-adjacent and must never have its body logged
+    // (defensive for Phase 3, when this response starts carrying auth material).
     if (sLog.IsPacketLoggingEnabled())
     {
-        sLog.outWorldPacketDump(uint32(get_handle()), pct.GetOpcode(), LookupOpcodeName(DIR_SERVER, pct.GetOpcode()), &pct, false);
+        if (pct.GetOpcode() == SMSG_AUTH_RESPONSE)
+        {
+            sLog.outWorldPacketDumpRedacted(uint32(get_handle()), pct.GetOpcode(), LookupOpcodeName(DIR_SERVER, pct.GetOpcode()), pct.size(), false);
+        }
+        else
+        {
+            sLog.outWorldPacketDump(uint32(get_handle()), pct.GetOpcode(), LookupOpcodeName(DIR_SERVER, pct.GetOpcode()), &pct, false);
+        }
     }
 
 #ifdef ENABLE_ELUNA
@@ -759,9 +768,17 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
     }
 
     // Dump received packet (opt-in via PacketLoggingEnabled; off by default).
+    // CMSG_AUTH_SESSION carries the client's auth proof and must never have its body logged.
     if (sLog.IsPacketLoggingEnabled())
     {
-        sLog.outWorldPacketDump(uint32(get_handle()), opcode, LookupOpcodeName(DIR_CLIENT, opcode), new_pct, true);
+        if (opcode == CMSG_AUTH_SESSION)
+        {
+            sLog.outWorldPacketDumpRedacted(uint32(get_handle()), opcode, LookupOpcodeName(DIR_CLIENT, opcode), new_pct->size(), true);
+        }
+        else
+        {
+            sLog.outWorldPacketDump(uint32(get_handle()), opcode, LookupOpcodeName(DIR_CLIENT, opcode), new_pct, true);
+        }
     }
 
     // Handshake state legality allowlist. MUST run before the MSG_WOW_CONNECTION early-return below,
@@ -846,12 +863,29 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
     }
     catch (ByteBufferException&)
     {
-        sLog.outError("WorldSocket::ProcessIncoming ByteBufferException occured while parsing an instant handled packet (opcode: %u) from client %s, accountid=%i.",
-                      opcode, GetRemoteAddress().c_str(), m_Session ? m_Session->GetAccountId() : -1);
-        if (sLog.HasLogLevelOrHigher(LOG_LVL_DEBUG))
+        // Bounded + rate-limited: shares m_lastDecodeLog with the Task-2.5 malformed-frame
+        // path so every decode-failure path is rate-limited together. CMSG_AUTH_SESSION never
+        // has its body logged, even on error; other opcodes log at most the first 64 bytes.
+        const ACE_Time_Value now = ACE_OS::gettimeofday();
+        if (MopHs::RateLimitElapsed(m_lastDecodeLog.sec(), now.sec()))
         {
-            DEBUG_LOG("Dumping error-causing packet:");
-            new_pct->hexlike();
+            m_lastDecodeLog = now;
+            if (opcode == CMSG_AUTH_SESSION)
+            {
+                sLog.outError("WorldSocket: CMSG_AUTH_SESSION decode failed from %s (body redacted).", GetRemoteAddress().c_str());
+            }
+            else
+            {
+                const size_t cap = 64, m = new_pct->size() < cap ? new_pct->size() : cap;
+                char hex[cap * 3 + 1];
+                for (size_t i = 0; i < m; ++i)
+                {
+                    snprintf(hex + i * 3, 4, "%02X ", new_pct->contents()[i]);
+                }
+                hex[m ? m * 3 - 1 : 0] = '\0';
+                sLog.outError("WorldSocket: decode failure opcode 0x%.4X (%s) from %s; first %zu bytes: %s",
+                              opcode, LookupOpcodeName(DIR_CLIENT, opcode), GetRemoteAddress().c_str(), m, hex);
+            }
         }
 
         if (sWorld.getConfig(CONFIG_BOOL_KICK_PLAYER_ON_BAD_PACKET))

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -119,8 +119,10 @@ class WorldSocket : protected WorldHandler
 
         /// Send A packet on the socket, this function is reentrant.
         /// @param pct packet to send
+        /// @param sent optional out-param; set to whether the packet actually reached the
+        ///        buffer/queue, as opposed to being suppressed by an Eluna OnPacketSend veto
         /// @return -1 of failure
-        int SendPacket(const WorldPacket& pct);
+        int SendPacket(const WorldPacket& pct, bool* sent = nullptr);
 
         /// Add reference to this object.
         long AddReference(void);

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -160,8 +160,6 @@ class WorldSocket : protected WorldHandler
 
     private:
         /// Helper functions for processing incoming data.
-        int handle_input_header(void);
-        int handle_input_payload(void);
         int handle_input_missing_data(void);
 
         /// Help functions to mark/unmark the socket for output.
@@ -207,17 +205,6 @@ class WorldSocket : protected WorldHandler
         /// Session to which received packets are routed
         WorldSession* m_Session;
 
-        /// here are stored the fragments of the received data
-        WorldPacket* m_RecvWPct;
-
-        /// This block actually refers to m_RecvWPct contents,
-        /// which allows easy and safe writing to it.
-        /// It wont free memory when its deleted. m_RecvWPct takes care of freeing.
-        ACE_Message_Block m_RecvPct;
-
-        /// Fragment of the received header.
-        ACE_Message_Block m_Header;
-
         /// Mutex for protecting output related data.
         LockType m_OutBufferLock;
 
@@ -237,10 +224,10 @@ class WorldSocket : protected WorldHandler
         /// Phase 2 wire framing: current handshake state (unused until later tasks).
         MopHs::ConnectionState m_connState;
 
-        /// Phase 2 wire framing: consume-one-frame reader (unused until later tasks).
+        /// Phase 2 wire framing: consume-one-frame reader driving the production inbound path.
         MopFrameReader m_frameReader;
 
-        /// Phase 2 wire framing: rate-limits malformed-frame diagnostic logging (unused until later tasks).
+        /// Phase 2 wire framing: rate-limits malformed-frame diagnostic logging.
         ACE_Time_Value m_lastDecodeLog;
 };
 

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -49,6 +49,8 @@
 #include "Common.h"
 #include "Auth/AuthCrypt.h"
 #include "Auth/BigNumber.h"
+#include "MopHandshake.h"
+#include "MopFrameReader.h"
 
 class ACE_Message_Block;
 class WorldPacket;
@@ -180,6 +182,11 @@ class WorldSocket : protected WorldHandler
         /// Called by ProcessIncoming() on CMSG_PING.
         int HandlePing(WorldPacket& recvPacket);
 
+        /// MopFrameReader::DecryptFn hook (Phase 2 wire framing).
+        static bool DecryptHeaderHook(void*, uint8*, size_t);
+        /// MopFrameReader::CmdValidFn hook (Phase 2 wire framing).
+        static bool CmdValidHook(void*, uint32, bool);
+
     private:
         void SendAuthResponseError(uint8);
         /// Time in which the last ping was received
@@ -226,6 +233,15 @@ class WorldSocket : protected WorldHandler
         uint32 m_Seed;
 
         BigNumber m_s;
+
+        /// Phase 2 wire framing: current handshake state (unused until later tasks).
+        MopHs::ConnectionState m_connState;
+
+        /// Phase 2 wire framing: consume-one-frame reader (unused until later tasks).
+        MopFrameReader m_frameReader;
+
+        /// Phase 2 wire framing: rate-limits malformed-frame diagnostic logging (unused until later tasks).
+        ACE_Time_Value m_lastDecodeLog;
 };
 
 #endif  /* _WORLDSOCKET_H */

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(mop_framing_test mop_framing_test.cpp)
+target_include_directories(mop_framing_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
+set_target_properties(mop_framing_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+add_test(NAME mop_framing COMMAND mop_framing_test)

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -1,3 +1,22 @@
+# MaNGOS is a full featured server for World of Warcraft, supporting
+# the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+#
+# Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
 add_executable(mop_framing_test mop_framing_test.cpp)
 target_include_directories(mop_framing_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set_target_properties(mop_framing_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)

--- a/src/game/Server/tests/mop_framing_test.cpp
+++ b/src/game/Server/tests/mop_framing_test.cpp
@@ -69,6 +69,100 @@ static void test_challenge()
     g_rngCall = 0; out.assign(5, 0xFF);                         // fail-closed: SECOND (seed) draw fails
     CHECK(!BuildAuthChallengePayload(&failSecondRng, out, seed) && out.empty());
 }
-// test_framereader() -> Task 2.5
-int main() { test_codec(); test_legality(); test_challenge(); /* test_framereader(); */
+struct HookCtx { int decryptCalls, calls6, calls4; bool sawOther, decryptOk, cmdOk; };
+static bool countingDecrypt(void* ctx, uint8_t*, size_t len)
+{
+    HookCtx* c = static_cast<HookCtx*>(ctx);
+    ++c->decryptCalls;
+    if (len == 6) { ++c->calls6; } else if (len == 4) { ++c->calls4; } else { c->sawOther = true; }
+    return c->decryptOk;
+}
+static bool countingCmdValid(void* ctx, uint32_t cmd, bool)
+{
+    HookCtx* c = static_cast<HookCtx*>(ctx);
+    return c->cmdOk && (cmd == 0x4F57u || cmd < 0x2000u);        // mirrors the production CmdValidHook rule
+}
+static void test_framereader()
+{
+    typedef MopFrameReader R;
+    // 1) pre-crypt frame, fragmented header -> NO decrypt before a full header; then exactly one 6-byte call.
+    {
+        HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
+        uint8_t part[3] = {0x08,0,0xB2}; rd.Push(part, 3);      // size=8 => payload 4, cmd 0xB2
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
+        CHECK(cx.decryptCalls == 0);                            // hook NOT called on a partial header
+        uint8_t rest[3] = {0,0,0}; rd.Push(rest, 3);
+        uint8_t body[4] = {1,2,3,4};  rd.Push(body, 4);
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
+        CHECK(cx.decryptCalls == 1 && cx.calls6 == 1 && cx.calls4 == 0 && !cx.sawOther);
+        CHECK(f.cmd == 0x000000B2u && f.payload.size() == 4);
+    }
+    // 2) post-crypt frame -> exactly one 4-byte decrypt call.
+    {
+        HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
+        uint8_t h[4] = {0x01,0,0,0};  rd.Push(h, 4);            // v=1 => size 0, cmd 1
+        CHECK(rd.TryFrame(f, true, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
+        CHECK(cx.decryptCalls == 1 && cx.calls4 == 1 && cx.calls6 == 0 && !cx.sawOther);
+        CHECK(f.cmd == 1u && f.payload.empty());
+    }
+    // 3) malformed: size < 4 -> MF_BAD_SIZE; header captured (6 bytes, pre-crypt), never payload.
+    {
+        HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
+        uint8_t bad[6] = {0x03,0,0,0,0,0};  rd.Push(bad, 6);
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
+        CHECK(rd.LastReason() == R::MF_BAD_SIZE);
+        size_t hl = 0; bool pc = false; const uint8_t* hb = rd.LastHeader(hl, pc);
+        CHECK(hl == 6 && pc == true && hb[0] == 0x03);
+    }
+    // 4) malformed: high-bit cmd rejected by the validator -> MF_BAD_COMMAND.
+    {
+        HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
+        uint8_t hi[6] = {0x08,0,0x00,0x00,0x01,0x00};  rd.Push(hi, 6);   // cmd = 0x00010000 (>= 0x2000)
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
+        CHECK(rd.LastReason() == R::MF_BAD_COMMAND);
+    }
+    // 5) malformed: decrypt hook returns false -> MF_DECRYPT (exactly one call).
+    {
+        HookCtx cx = {0,0,0,false,false,true}; R rd; R::Frame f;   // decryptOk=false
+        uint8_t any[4] = {0x01,0,0,0};  rd.Push(any, 4);
+        CHECK(rd.TryFrame(f, true, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
+        CHECK(rd.LastReason() == R::MF_DECRYPT && cx.decryptCalls == 1);
+    }
+    // 6) 6->4 transition in ONE buffer, postCrypt passed per call (no stored flag).
+    {
+        HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
+        uint8_t pre[6]  = {0x04,0,0xB2,0,0,0};   // size 4 => payload 0, cmd 0xB2
+        uint8_t post[4] = {0x01,0,0,0};          // size 0, cmd 1
+        rd.Push(pre, 6); rd.Push(post, 4);
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xB2u);
+        CHECK(rd.TryFrame(f, true,  &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 1u);
+        CHECK(cx.calls6 == 1 && cx.calls4 == 1 && !cx.sawOther);   // one call each width, never payload
+    }
+    // 7) complete header + PARTIAL payload -> NEED_MORE; remaining payload -> FRAME_READY;
+    //    decrypt count stays EXACTLY ONE across the whole sequence (header not re-decrypted).
+    {
+        HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
+        uint8_t hdr[6]  = {0x08,0,0xB2,0,0,0};           // size 8 => payload 4, cmd 0xB2
+        uint8_t half[2] = {0xAA,0xBB};                   // only 2 of the 4 payload bytes
+        rd.Push(hdr, 6); rd.Push(half, 2);
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
+        CHECK(cx.decryptCalls == 1);                     // header decrypted once; NOT re-decrypted while waiting
+        uint8_t rest[2] = {0xCC,0xDD}; rd.Push(rest, 2);
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
+        CHECK(cx.decryptCalls == 1 && cx.calls6 == 1 && cx.calls4 == 0);   // still exactly one 6-byte decrypt
+        CHECK(f.cmd == 0xB2u && f.payload.size() == 4 && f.payload[0] == 0xAA && f.payload[3] == 0xDD);
+    }
+    // 8) two ORDINARY pre-crypt frames coalesced in one Push -> READY, READY, then NEED_MORE (drained).
+    {
+        HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
+        uint8_t two[20] = {0x08,0,0xB2,0,0,0, 0xDE,0xAD,0xBE,0xEF,    // frame A: cmd 0xB2, payload 4
+                           0x08,0,0xC3,0,0,0, 0x01,0x02,0x03,0x04};   // frame B: cmd 0xC3, payload 4
+        rd.Push(two, 20);
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xB2u);
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xC3u);
+        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
+        CHECK(cx.decryptCalls == 2 && cx.calls6 == 2 && !cx.sawOther);    // one header decrypt per frame
+    }
+}
+int main() { test_codec(); test_legality(); test_challenge(); test_framereader();
     std::printf(g_fail? "FAILED (%d)\n":"OK\n", g_fail); return g_fail? 1:0; }

--- a/src/game/Server/tests/mop_framing_test.cpp
+++ b/src/game/Server/tests/mop_framing_test.cpp
@@ -1,3 +1,27 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
 #include "MopWireCodec.h"
 #include "MopHandshake.h"
 #include "MopFrameReader.h"

--- a/src/game/Server/tests/mop_framing_test.cpp
+++ b/src/game/Server/tests/mop_framing_test.cpp
@@ -1,0 +1,45 @@
+#include "MopWireCodec.h"
+#include "MopHandshake.h"
+#include "MopFrameReader.h"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+static int g_fail = 0;
+#define CHECK(c) do { if(!(c)) { std::fprintf(stderr,"FAIL %s:%d: %s\n",__FILE__,__LINE__,#c); ++g_fail; } } while(0)
+
+static void test_codec()
+{
+    uint8_t h[4];
+    CHECK(MopWire::BuildServerHeader(false,46,0x4F57,h) && h[0]==0x30&&h[1]==0x00&&h[2]==0x57&&h[3]==0x4F);
+    CHECK(MopWire::BuildServerHeader(false,0,0x0001,h) && h[0]==0x02&&h[1]==0x00);      // pre-crypt payload 0
+    CHECK(MopWire::BuildServerHeader(false,65533,0x0001,h));                            // exact pre-crypt max
+    CHECK(!MopWire::BuildServerHeader(false,65534,0x0001,h));                           // pre-crypt over-max
+    CHECK(!MopWire::BuildServerHeader(false,(size_t)0xFFFFFFFFull+1,0x0001,h));         // huge payload
+    CHECK(!MopWire::BuildServerHeader(false,46,0x10001,h));                             // cmd>0xFFFF (before narrow)
+    CHECK(MopWire::BuildServerHeader(true,0,0x0001,h) && h[0]==0x01);                   // post-crypt zero
+    CHECK(MopWire::BuildServerHeader(true,0x7FFFF,0x1FFF,h));                            // post-crypt max
+    CHECK(!MopWire::BuildServerHeader(true,0x80000,0x0001,h));                          // post-crypt oversize
+    CHECK(!MopWire::BuildServerHeader(true,0,0x2000,h));                                // opcode overflow (no alias)
+    uint16_t sz,c16; uint32_t c32;
+    uint8_t ok[6]={0x08,0,0xB2,0,0,0};    CHECK(MopWire::ReadClientPreCryptHeader(ok,sz,c32)&&sz==4&&c32==0x000000B2u);
+    uint8_t hi[6]={0x08,0,0xB2,0,0x01,0}; CHECK(MopWire::ReadClientPreCryptHeader(hi,sz,c32)&&c32==0x000100B2u);
+    uint8_t sm[6]={0x03,0,0,0,0,0};       CHECK(!MopWire::ReadClientPreCryptHeader(sm,sz,c32));
+    uint8_t lg[6]={0x00,0x30,0,0,0,0};    CHECK(!MopWire::ReadClientPreCryptHeader(lg,sz,c32));
+    uint8_t pc[4]={0xBA,0x2A,0x05,0x00};  CHECK(MopWire::ReadClientPostCryptHeader(pc,sz,c16)&&sz==41&&c16==0x0ABA);
+    uint8_t pb[4]={0xFF,0xFF,0xFF,0xFF};  CHECK(!MopWire::ReadClientPostCryptHeader(pb,sz,c16));   // post-crypt size>10236
+}
+static void test_legality()
+{
+    using namespace MopHs;
+    const ConnectionState S[4]={CONN_GREETING,CONN_CHALLENGED,CONN_AUTHENTICATING,CONN_AUTHED};
+    for (int i=0;i<4;++i)                                  // full 3x4 matrix
+    {
+        CHECK(IsHandshakeOpcodeLegal(S[i],OPC_GREETING)     == (S[i]==CONN_GREETING));
+        CHECK(IsHandshakeOpcodeLegal(S[i],OPC_AUTH_SESSION) == (S[i]==CONN_CHALLENGED));
+        CHECK(IsHandshakeOpcodeLegal(S[i],OPC_NORMAL)       == (S[i]==CONN_AUTHED));
+    }
+    CHECK(RateLimitElapsed(10,11) && !RateLimitElapsed(10,10));
+}
+// test_challenge() -> Task 2.4 ; test_framereader() -> Task 2.5
+int main() { test_codec(); test_legality(); /* test_challenge(); test_framereader(); */
+    std::printf(g_fail? "FAILED (%d)\n":"OK\n", g_fail); return g_fail? 1:0; }

--- a/src/game/Server/tests/mop_framing_test.cpp
+++ b/src/game/Server/tests/mop_framing_test.cpp
@@ -40,6 +40,35 @@ static void test_legality()
     }
     CHECK(RateLimitElapsed(10,11) && !RateLimitElapsed(10,10));
 }
-// test_challenge() -> Task 2.4 ; test_framereader() -> Task 2.5
-int main() { test_codec(); test_legality(); /* test_challenge(); test_framereader(); */
+static bool constRng(uint8_t* out, size_t len)                  // deterministic: field=0xAB..., seed=01 02 03 04
+{
+    if (len == 32) { for (size_t i = 0; i < 32; ++i) { out[i] = 0xAB; } return true; }
+    if (len == 4)  { out[0] = 1; out[1] = 2; out[2] = 3; out[3] = 4; return true; }
+    return false;
+}
+static bool failFirstRng(uint8_t*, size_t) { return false; }
+static int g_rngCall = 0;
+static bool failSecondRng(uint8_t* out, size_t len)             // first draw (32B) ok, second (seed) fails
+{
+    if (++g_rngCall == 1) { for (size_t i = 0; i < len; ++i) { out[i] = 0xCD; } return true; }
+    return false;
+}
+static void test_challenge()
+{
+    using namespace MopHs;
+    std::vector<uint8_t> out; uint32_t seed = 0xDEADBEEFu;
+    CHECK(BuildAuthChallengePayload(&constRng, out, seed));
+    CHECK(out.size() == 39);
+    CHECK(out[0] == 0 && out[1] == 0);                          // two leading zero bytes
+    CHECK(out[2] == 0xAB && out[33] == 0xAB);                   // 32 entropy bytes
+    CHECK(out[34] == 1);                                        // the 0x01 marker
+    CHECK(out[35] == 1 && out[36] == 2 && out[37] == 3 && out[38] == 4);   // seed suffix = LE bytes (identity)
+    CHECK(seed == 0x04030201u);                                 // uint32 LE of 01 02 03 04
+    out.assign(5, 0xFF); seed = 7;                              // fail-closed: first draw fails
+    CHECK(!BuildAuthChallengePayload(&failFirstRng, out, seed) && out.empty());
+    g_rngCall = 0; out.assign(5, 0xFF);                         // fail-closed: SECOND (seed) draw fails
+    CHECK(!BuildAuthChallengePayload(&failSecondRng, out, seed) && out.empty());
+}
+// test_framereader() -> Task 2.5
+int main() { test_codec(); test_legality(); test_challenge(); /* test_framereader(); */
     std::printf(g_fail? "FAILED (%d)\n":"OK\n", g_fail); return g_fail? 1:0; }

--- a/src/game/Server/tests/mop_framing_test.cpp
+++ b/src/game/Server/tests/mop_framing_test.cpp
@@ -91,11 +91,11 @@ static void test_framereader()
     {
         HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
         uint8_t part[3] = {0x08,0,0xB2}; rd.Push(part, 3);      // size=8 => payload 4, cmd 0xB2
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
         CHECK(cx.decryptCalls == 0);                            // hook NOT called on a partial header
         uint8_t rest[3] = {0,0,0}; rd.Push(rest, 3);
         uint8_t body[4] = {1,2,3,4};  rd.Push(body, 4);
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
         CHECK(cx.decryptCalls == 1 && cx.calls6 == 1 && cx.calls4 == 0 && !cx.sawOther);
         CHECK(f.cmd == 0x000000B2u && f.payload.size() == 4);
     }
@@ -103,7 +103,7 @@ static void test_framereader()
     {
         HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
         uint8_t h[4] = {0x01,0,0,0};  rd.Push(h, 4);            // v=1 => size 0, cmd 1
-        CHECK(rd.TryFrame(f, true, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
+        CHECK(rd.TryFrame(f, R::HDR_POSTCRYPT, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
         CHECK(cx.decryptCalls == 1 && cx.calls4 == 1 && cx.calls6 == 0 && !cx.sawOther);
         CHECK(f.cmd == 1u && f.payload.empty());
     }
@@ -111,7 +111,7 @@ static void test_framereader()
     {
         HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
         uint8_t bad[6] = {0x03,0,0,0,0,0};  rd.Push(bad, 6);
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
         CHECK(rd.LastReason() == R::MF_BAD_SIZE);
         size_t hl = 0; bool pc = false; const uint8_t* hb = rd.LastHeader(hl, pc);
         CHECK(hl == 6 && pc == true && hb[0] == 0x03);
@@ -120,14 +120,14 @@ static void test_framereader()
     {
         HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
         uint8_t hi[6] = {0x08,0,0x00,0x00,0x01,0x00};  rd.Push(hi, 6);   // cmd = 0x00010000 (>= 0x2000)
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
         CHECK(rd.LastReason() == R::MF_BAD_COMMAND);
     }
     // 5) malformed: decrypt hook returns false -> MF_DECRYPT (exactly one call).
     {
         HookCtx cx = {0,0,0,false,false,true}; R rd; R::Frame f;   // decryptOk=false
         uint8_t any[4] = {0x01,0,0,0};  rd.Push(any, 4);
-        CHECK(rd.TryFrame(f, true, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
+        CHECK(rd.TryFrame(f, R::HDR_POSTCRYPT, &cx, countingDecrypt, countingCmdValid) == R::MALFORMED);
         CHECK(rd.LastReason() == R::MF_DECRYPT && cx.decryptCalls == 1);
     }
     // 6) 6->4 transition in ONE buffer, postCrypt passed per call (no stored flag).
@@ -136,9 +136,33 @@ static void test_framereader()
         uint8_t pre[6]  = {0x04,0,0xB2,0,0,0};   // size 4 => payload 0, cmd 0xB2
         uint8_t post[4] = {0x01,0,0,0};          // size 0, cmd 1
         rd.Push(pre, 6); rd.Push(post, 4);
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xB2u);
-        CHECK(rd.TryFrame(f, true,  &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 1u);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xB2u);
+        CHECK(rd.TryFrame(f, R::HDR_POSTCRYPT, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 1u);
         CHECK(cx.calls6 == 1 && cx.calls4 == 1 && !cx.sawOther);   // one call each width, never payload
+    }
+    // 6b) REGRESSION, captured from the live gate 2a: the client's MSG_WOW_CONNECTION reply is framed
+    //     with the 4-byte GREETING header, NOT the 6-byte auth header. Reading it as 6-byte swallows
+    //     "RL" into cmd -> 0x4C524F57 -> BAD_COMMAND -> socket closed (the original gate-2a failure).
+    //     These are the exact bytes the real 5.4.8 client sent: 30 00 57 4F 52 4C ...
+    {
+        HookCtx cx = {0,0,0,false,true,true}; R rd; R::Frame f;
+        const char* s = "RLD OF WARCRAFT CONNECTION - CLIENT TO SERVER";   // 45 chars
+        uint8_t greet[50];
+        greet[0] = 0x30; greet[1] = 0x00;                      // size = 48 = payload(46) + 2
+        greet[2] = 0x57; greet[3] = 0x4F;                      // cmd  = 0x4F57 (MSG_WOW_CONNECTION, "WO" LE)
+        for (size_t i = 0; i < 45; ++i) { greet[4 + i] = uint8_t(s[i]); }
+        greet[49] = 0x00;                                      // NUL -> payload is 46 bytes
+        rd.Push(greet, 50);
+        CHECK(rd.TryFrame(f, R::HDR_GREETING, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
+        CHECK(f.cmd == 0x4F57u);                               // greeting opcode survives (unmasked)
+        CHECK(f.payload.size() == 46);                         // size - 2, not size - 4
+        CHECK(f.payload[0] == 'R' && f.payload[45] == 0x00);
+        CHECK(cx.calls4 == 1 && cx.calls6 == 0 && !cx.sawOther);   // greeting uses the 4-byte width
+        // and prove the OLD behaviour was genuinely wrong: same bytes read as the 6-byte auth header
+        HookCtx cx2 = {0,0,0,false,true,true}; R rd2; R::Frame f2;
+        rd2.Push(greet, 50);
+        CHECK(rd2.TryFrame(f2, R::HDR_PRECRYPT, &cx2, countingDecrypt, countingCmdValid) == R::MALFORMED);
+        CHECK(rd2.LastReason() == R::MF_BAD_COMMAND);          // exactly what the live gate logged
     }
     // 7) complete header + PARTIAL payload -> NEED_MORE; remaining payload -> FRAME_READY;
     //    decrypt count stays EXACTLY ONE across the whole sequence (header not re-decrypted).
@@ -147,10 +171,10 @@ static void test_framereader()
         uint8_t hdr[6]  = {0x08,0,0xB2,0,0,0};           // size 8 => payload 4, cmd 0xB2
         uint8_t half[2] = {0xAA,0xBB};                   // only 2 of the 4 payload bytes
         rd.Push(hdr, 6); rd.Push(half, 2);
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
         CHECK(cx.decryptCalls == 1);                     // header decrypted once; NOT re-decrypted while waiting
         uint8_t rest[2] = {0xCC,0xDD}; rd.Push(rest, 2);
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY);
         CHECK(cx.decryptCalls == 1 && cx.calls6 == 1 && cx.calls4 == 0);   // still exactly one 6-byte decrypt
         CHECK(f.cmd == 0xB2u && f.payload.size() == 4 && f.payload[0] == 0xAA && f.payload[3] == 0xDD);
     }
@@ -160,9 +184,9 @@ static void test_framereader()
         uint8_t two[20] = {0x08,0,0xB2,0,0,0, 0xDE,0xAD,0xBE,0xEF,    // frame A: cmd 0xB2, payload 4
                            0x08,0,0xC3,0,0,0, 0x01,0x02,0x03,0x04};   // frame B: cmd 0xC3, payload 4
         rd.Push(two, 20);
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xB2u);
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xC3u);
-        CHECK(rd.TryFrame(f, false, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xB2u);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::FRAME_READY && f.cmd == 0xC3u);
+        CHECK(rd.TryFrame(f, R::HDR_PRECRYPT, &cx, countingDecrypt, countingCmdValid) == R::NEED_MORE);
         CHECK(cx.decryptCalls == 2 && cx.calls6 == 2 && !cx.sawOther);    // one header decrypt per frame
     }
 }

--- a/src/game/Server/tests/mop_framing_test.cpp
+++ b/src/game/Server/tests/mop_framing_test.cpp
@@ -80,7 +80,9 @@ static bool countingDecrypt(void* ctx, uint8_t*, size_t len)
 static bool countingCmdValid(void* ctx, uint32_t cmd, bool)
 {
     HookCtx* c = static_cast<HookCtx*>(ctx);
-    return c->cmdOk && (cmd == 0x4F57u || cmd < 0x2000u);        // mirrors the production CmdValidHook rule
+    return c->cmdOk && (cmd == 0x4F57u || cmd < 0x2000u);        // bound duplicated deliberately (no Opcodes.h
+                                                                  // include here, to keep this test dependency-free);
+                                                                  // MUST be kept in sync with OPCODE_TABLE_SIZE
 }
 static void test_framereader()
 {

--- a/src/shared/Log/Log.cpp
+++ b/src/shared/Log/Log.cpp
@@ -1261,6 +1261,28 @@ void Log::outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeNam
     fwrite(out.c_str(), 1, out.size(), worldLogfile);
 }
 
+void Log::outWorldPacketDumpRedacted(uint32 socket, uint32 opcode, char const* opcodeName, size_t length, bool incoming)
+{
+    if (!worldLogfile)
+    {
+        return;
+    }
+
+    ACE_GUARD(ACE_Thread_Mutex, GuardObj, m_worldLogMtx);
+
+    outTimestamp(worldLogfile);
+
+    // Header line ONLY -- mirrors outWorldPacketDump's CLIENT/SERVER + SOCKET/LENGTH/OPCODE
+    // shape exactly (so a CLIENT.*CMSG_AUTH_SESSION style grep still matches), but the DATA
+    // line carries a redaction marker instead of hex body bytes. Auth material must never
+    // reach worldLogfile.
+    char header[512];
+    snprintf(header, sizeof(header), "\n%s:\nSOCKET: %u\nLENGTH: %zu\nOPCODE: %s (0x%.4X)\nDATA: [BODY REDACTED - auth material]\n\n\n",
+        incoming ? "CLIENT" : "SERVER",
+        socket, length, opcodeName, opcode);
+    fwrite(header, 1, strlen(header), worldLogfile);
+}
+
 void Log::outCharDump(const char* str, uint32 account_id, uint32 guid, const char* name)
 {
     if (charLogfile)

--- a/src/shared/Log/Log.h
+++ b/src/shared/Log/Log.h
@@ -299,6 +299,17 @@ class Log : public MaNGOS::Singleton<Log, MaNGOS::ClassLevelLockable<Log, ACE_Th
          */
         void outWorldPacketDump(uint32 socket, uint32 opcode, char const* opcodeName, ByteBuffer const* packet, bool incoming);
         /**
+         * @brief any log level; writes only a redacted header line (never the body) for
+         * auth-adjacent opcodes so auth material never reaches worldLogfile
+         *
+         * @param socket
+         * @param opcode
+         * @param opcodeName
+         * @param length
+         * @param incoming
+         */
+        void outWorldPacketDumpRedacted(uint32 socket, uint32 opcode, char const* opcodeName, size_t length, bool incoming);
+        /**
          * @brief any log level
          *
          * @param str


### PR DESCRIPTION
## What & why

Part of the MoP 5.4.8.18414 **login-protocol** campaign, building directly on Phase 1a (#11).

**This PR fixes the "Connected." stall.** Selecting the world server used to hang ~19s and drop.
Root cause: `WorldSocket`'s wire framing and handshake were still Cata-era and had never been
ported to MoP — the outbound header was big-endian and variable-length (`isLargePacket`), so the
5.4.8 client misframed the very first packet and could never reply.

**Verified against a real 5.4.8.18414 client with a live wire capture** (gates below), not just
unit tests.

## Scope

- **This PR does NOT authenticate.** `CMSG_AUTH_SESSION` is recognized, redacted, and the socket
  closes cleanly. SRP6 / crypt init / `SMSG_AUTH_RESPONSE` are **Phase 3**.
- **The client will still not log in** — reaching `CMSG_AUTH_SESSION` and closing *is* the goal.
- Invariant held throughout: `AUTHED <=> m_Crypt.IsInitialized()`, both false for all of Phase 2.

## What changed

- **Outbound framing** — deleted the Cata `ServerPktHeader`/`isLargePacket`. Now a fixed 4-byte
  pre-crypt header `{uint16 size LE; uint16 cmd LE}` with `size = payload + 2`, sent unencrypted;
  post-crypt packs `(size<<13)|(cmd&0x1FFF)` then `EncryptSend`. Bounds validated **before**
  narrowing — out-of-range frames are rejected, never silently aliased.
- **Connection sequence** — `open()` now sends the greeting **only**; the challenge follows the
  client's reply via `HandleWowConnection` -> `SendAuthChallenge()`.
- **MoP `SMSG_AUTH_CHALLENGE`** — 39-byte payload (`00 00` | 32 CSPRNG bytes | `01` | 4-byte seed),
  built by a pure **fail-closed** builder with the RNG injected as a parameter; on CSPRNG failure
  nothing is sent. Seed state is only committed after the send succeeds.
- **Inbound path** — a consume-one-frame reader replaces the old header/payload machinery. Header
  width is **state-driven** and derived fresh per frame (no stored codec flag):
  greeting 4B / pre-crypt 6B / post-crypt 4B packed. Native little-endian (the old
  `EndianConvertReverse` is gone); the pre-crypt command is range-checked as a **full uint32**, never
  mask-aliased.
- **State legality allowlist** runs *before* any packet-specific early return, so handshake opcodes
  are only accepted in their own state.
- **Auth redaction** — direction-aware: inbound redacts `CMSG_AUTH_SESSION`, outbound redacts
  `SMSG_AUTH_RESPONSE`. Every failure path emits a bounded, rate-limited summary carrying a reason
  (`BAD_SIZE`/`BAD_COMMAND`/`DECRYPT_FAILURE`) + direction + at most the 6 header bytes — **never
  payload**.

## Testing

**Unit** — three pure, dependency-free headers (`MopWireCodec.h`, `MopHandshake.h`,
`MopFrameReader.h`) that production actually calls, exercised by a new **CTest** target
(`ctest -R '^mop_framing$' --no-tests=error`, **1/1**). Uses a non-elidable `CHECK` macro —
`RelWithDebInfo` defines `NDEBUG`, so `assert` would have been silently elided. Covers the bit math,
bounds (validated pre-narrowing), the full state×class legality matrix, fail-closed CSPRNG paths,
reader buffering/fragmentation, decrypt-hook invocation semantics, and a regression test locking the
real client's greeting bytes.

**Live gate (the real proof)** — a genuine 5.4.8.18414 client + Wireshark capture:

| Step | Result |
|---|---|
| `SERVER: MSG_WOW_CONNECTION` (46) | greeting sent |
| `CLIENT: MSG_WOW_CONNECTION` (46) | **client decoded it and replied** ✅ |
| `SERVER: SMSG_AUTH_CHALLENGE` (39) | challenge accepted by the client |
| `CLIENT: CMSG_AUTH_SESSION` (435) | `[BODY REDACTED]` ✅ |

Plus the post-allowlist marker `CONN_CHALLENGED -> CONN_AUTHENTICATING; auth deferred to Phase 3`,
then a clean close. **0 malformed, 0 illegal-in-state.** Raw capture confirms every framing rule
(`50 = 4+46`, `43 = 4+39`, `size = payload+2`, little-endian, plaintext pre-crypt). Redaction was
proven under fire: a real 435-byte auth body was logged as `[BODY REDACTED]`.

## Two protocol corrections the live gate exposed

Neither was reachable by code review — every reviewer was checking the code against the same
incorrect assumption. Only real client bytes could surface them.

1. **The greeting reply is 4-byte framed, not 6-byte.** The 6-byte `{uint16 size; uint32 cmd}` header
   is correct for `CMSG_AUTH_SESSION` (confirmed: 435-byte body parses cleanly) but wrong for the
   greeting, whose exchange is symmetric with ours. Reading it as 6-byte swallowed `"WORL"` into
   `cmd` -> `0x4C524F57` -> rejected.
2. **`HandleWowConnection` expected `"D OF WARCRAFT ..."`** — missing `"RL"`. That constant was
   *bug-compatible with the old misparse*: the garbage `cmd` truncated to `uint16` = `0x4F57` and
   dispatched **by accident**, so the old path "worked" while misframing. Now expects the true
   payload, with the history documented in-code so it isn't "restored".

## Reviewer notes

- The three new headers are **pure** (`<cstdint>/<cstddef>/<vector>` only) so the standalone test
  binary links without the game — that purity is why the challenge builder takes its RNG as a
  parameter. OpenSSL stays in `WorldSocket.cpp`.
- `Log.cpp` lives in `src/shared`, which `realmd` also links; the change is purely additive (a new
  redacted-dump method `realmd` never calls). `realmd` and its DB are untouched.
- `enable_testing()` is added at the root so the nested `add_test` registers; the game lib globs
  `Server/*.cpp` non-recursively, so `Server/tests/*.cpp` is not swept in.

## Not in this PR

- **Phase 3** — authentication (`CMSG_AUTH_SESSION` body parse, SHA de-interleave, SRP6 session key,
  HMAC-SHA1 -> ARC4 crypt init, `SMSG_AUTH_RESPONSE`), replacing the Phase-2 intercept atomically.
- **Phase 4** — character screen (realm split, bit-packed `SMSG_CHAR_ENUM`).
- **Phase 1b** — full opcode-table migration.

## Acknowledgements

Project SkyFire was used in the research of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/12)
<!-- Reviewable:end -->
