### PR TITLE
MoP 5.4.8 login (Phase 3 Stage 1): restructure the dormant auth path — activates nothing

### DIFF
--- a/src/game/Server/MopAuthSession.cpp
+++ b/src/game/Server/MopAuthSession.cpp
@@ -1,0 +1,136 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "MopAuthSession.h"
+#include "Utilities/ByteBuffer.h"
+#include <utility>
+
+namespace MopAuth
+{
+    DecodeResult DecodeAuthSession(ByteBuffer& in, AuthSessionFields& out)
+    {
+        // Parse into a local and publish it only on success, so a rejected body can never leave
+        // 'out' half-populated.
+        AuthSessionFields parsed{};
+
+        try
+        {
+            if (in.size() - in.rpos() < LegacyFixedPrefixBytes)
+            {
+                return DecodeResult::ShortBody;
+            }
+
+            // Legacy fixed prefix, reproduced verbatim from the pre-extraction inline reads.
+            // The skips and the scattered digest[] indices are intentionally NOT reinterpreted:
+            // this extraction is behaviour-preserving for valid input.
+            in.read_skip<uint32_t>();
+            in.read_skip<uint32_t>();
+            in >> parsed.digest[18];
+            in >> parsed.digest[14];
+            in >> parsed.digest[3];
+            in >> parsed.digest[4];
+            in >> parsed.digest[0];
+            in.read_skip<uint32_t>();
+            in >> parsed.digest[11];
+            in >> parsed.clientSeed;
+            in >> parsed.digest[19];
+            in.read_skip<uint8_t>();
+            in.read_skip<uint8_t>();
+            in >> parsed.digest[2];
+            in >> parsed.digest[9];
+            in >> parsed.digest[12];
+            in.read_skip<uint64_t>();
+            in.read_skip<uint32_t>();
+            in >> parsed.digest[16];
+            in >> parsed.digest[5];
+            in >> parsed.digest[6];
+            in >> parsed.digest[8];
+            in >> parsed.builtNumberClient;                  // two bytes on the wire; never widen
+            in >> parsed.digest[17];
+            in >> parsed.digest[7];
+            in >> parsed.digest[13];
+            in >> parsed.digest[15];
+            in >> parsed.digest[1];
+            in >> parsed.digest[10];
+
+            in >> parsed.addonSize;                          // addon data size
+
+            // Bound the addon blob against the real remainder before allocating anything.
+            if (parsed.addonSize < 4 || parsed.addonSize > in.size() - in.rpos())
+            {
+                return DecodeResult::BadAddonSize;
+            }
+
+            parsed.addonData.resize(parsed.addonSize);
+            in.read(parsed.addonData.data(), parsed.addonSize);
+
+            // The blob's first four little-endian bytes are its self-described inflated size.
+            // Sanity-bound it here; actual inflation stays out of this decoder.
+            uint32_t const inflatedSize =
+                static_cast<uint32_t>(parsed.addonData[0])
+                | (static_cast<uint32_t>(parsed.addonData[1]) << 8)
+                | (static_cast<uint32_t>(parsed.addonData[2]) << 16)
+                | (static_cast<uint32_t>(parsed.addonData[3]) << 24);
+
+            if (inflatedSize == 0 || inflatedSize > MaxInflatedAddonBytes)
+            {
+                return DecodeResult::BadInflatedAddonSize;
+            }
+
+            // ReadBits(11) consumes two bytes; require them explicitly rather than via a throw.
+            if (in.size() - in.rpos() < 2)
+            {
+                return DecodeResult::ShortBody;
+            }
+
+            // BUG-FOR-BUG: the legacy path issued ReadBits(11) with NO preceding ReadBit().
+            // That is wrong for a real 5.4.8 client, but correcting it is out of scope here;
+            // this extraction must not change behaviour for input the legacy code accepted.
+            uint32_t const nameLength = in.ReadBits(11);
+
+            if (nameLength == 0 || nameLength > MaxAccountNameBytes)
+            {
+                return DecodeResult::BadNameLength;
+            }
+
+            // ReadString() silently truncates at end-of-buffer, so reject the short case up front
+            // instead of accepting a quietly shortened account name.
+            if (nameLength > in.size() - in.rpos())
+            {
+                return DecodeResult::TruncatedName;
+            }
+
+            parsed.account = in.ReadString(nameLength);
+        }
+        catch (ByteBufferException const&)
+        {
+            // Final safety net only; the explicit bounds above should make this unreachable.
+            // Deliberately logs nothing: this runs on unauthenticated, attacker-controlled input.
+            return DecodeResult::ShortBody;
+        }
+
+        out = std::move(parsed);
+        return DecodeResult::Ok;
+    }
+}

--- a/src/game/Server/MopAuthSession.h
+++ b/src/game/Server/MopAuthSession.h
@@ -1,0 +1,95 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_MOPAUTHSESSION
+#define MANGOS_H_MOPAUTHSESSION
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class ByteBuffer;
+
+/**
+ * @brief Bounded decoder for the legacy CMSG_AUTH_SESSION body.
+ *
+ * This is a behaviour-preserving extraction of the inline reads that used to live in
+ * WorldSocket::HandleAuthSession. The read/skip order and the digest[] scatter are
+ * reproduced bug-for-bug on purpose: notably ReadBits(11) is issued with NO preceding
+ * ReadBit(), which is wrong for a real 5.4.8 client but is what the legacy path did.
+ * Correcting the wire semantics is deliberately out of scope here.
+ *
+ * The added value over the inline version is malformed-input safety: every read is
+ * bounds-checked up front and the output is written atomically (only on Ok), so a
+ * truncated or hostile body can no longer leave a half-populated result behind.
+ */
+namespace MopAuth
+{
+    /** Bytes consumed by the fixed legacy prefix, up to and including the addon size field. */
+    static constexpr size_t LegacyFixedPrefixBytes = 56;
+
+    /** Upper bound on a decoded account name, in bytes. */
+    static constexpr size_t MaxAccountNameBytes = 16;
+
+    /** Upper bound on the self-described inflated addon payload, in bytes. */
+    static constexpr uint32_t MaxInflatedAddonBytes = 0xFFFFF;
+
+    /**
+     * @brief Outcome of DecodeAuthSession. Anything other than Ok means 'out' is untouched.
+     */
+    enum class DecodeResult : uint8_t
+    {
+        Ok = 0,
+        ShortBody,
+        BadAddonSize,
+        BadInflatedAddonSize,
+        BadNameLength,
+        TruncatedName
+    };
+
+    /**
+     * @brief Fields carried by the legacy CMSG_AUTH_SESSION body.
+     */
+    struct AuthSessionFields
+    {
+        uint8_t digest[20];
+        uint32_t clientSeed;
+        uint16_t builtNumberClient; // binding: the wire field is two bytes
+        uint32_t addonSize;
+        std::vector<uint8_t> addonData;
+        std::string account;
+    };
+
+    /**
+     * @brief Decodes the legacy auth session body.
+     *
+     * @param in  Buffer positioned at the start of the body.
+     * @param out Receives the decoded fields, and is written ONLY when the result is Ok.
+     * @return DecodeResult::Ok on success, otherwise the specific rejection reason.
+     */
+    DecodeResult DecodeAuthSession(ByteBuffer& in, AuthSessionFields& out);
+}
+
+#endif

--- a/src/game/Server/MopSocketDrain.h
+++ b/src/game/Server/MopSocketDrain.h
@@ -1,0 +1,64 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_MOP_SOCKET_DRAIN_H
+#define MANGOS_MOP_SOCKET_DRAIN_H
+
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * Pure decisions for the auth-error drain state machine.
+ *
+ * An auth rejection cannot simply close the socket: SendPacket() only appends to the
+ * outbound buffer, so closing straight away discards the error response and the peer sees
+ * a bare TCP close. The socket must instead stay open until the response has actually been
+ * written, while refusing to act on any further input from a peer we have already rejected.
+ *
+ * Header-only and free of ACE/WorldSocket so both decisions are unit-testable.
+ */
+namespace MopSock
+{
+    /// Open   -> normal traffic.
+    /// Flushing -> an auth error is queued; accept no further input, close once fully written.
+    enum class DrainState : uint8_t { Open, Flushing };
+
+    /// Whether an inbound frame may still be acted upon.
+    /// False once Flushing, so a frame already coalesced into the read buffer before the
+    /// rejection is never dispatched from a socket we have decided to reject.
+    inline bool MayProcessInput(DrainState state)
+    {
+        return state == DrainState::Open;
+    }
+
+    /// Whether the socket has finished draining and may now be closed.
+    /// Both the buffer and the queue must be empty: closing earlier is exactly the bug this
+    /// state exists to prevent, since the queued error response would be discarded unsent.
+    inline bool ShouldCloseNow(DrainState state, size_t outBufferLen, bool queueEmpty)
+    {
+        return state == DrainState::Flushing && outBufferLen == 0 && queueEmpty;
+    }
+}
+
+#endif

--- a/src/game/Server/MopSocketDrain.h
+++ b/src/game/Server/MopSocketDrain.h
@@ -36,7 +36,7 @@
  * a bare TCP close. The socket must instead stay open until the response has actually been
  * written, while refusing to act on any further input from a peer we have already rejected.
  *
- * Header-only and free of ACE/WorldSocket so both decisions are unit-testable.
+ * Header-only and free of ACE/WorldSocket so the decisions are unit-testable.
  */
 namespace MopSock
 {
@@ -58,6 +58,26 @@ namespace MopSock
     inline bool ShouldCloseNow(DrainState state, size_t outBufferLen, bool queueEmpty)
     {
         return state == DrainState::Flushing && outBufferLen == 0 && queueEmpty;
+    }
+
+    /// The receive-status a handle_input() implementation must report (ACE contract: 1 = full
+    /// read, 2 = partial read). Normally a full read reports 1 so the reactor keeps draining the
+    /// socket. While Flushing it must report 2 instead: ACE_TP_Reactor::dispatch_socket_event
+    /// re-invokes the callback DIRECTLY on a positive status
+    /// ("while (status > 0) status = (event_handler->*callback)(handle);", TP_Reactor.cpp:541-543)
+    /// consulting neither the wait set nor the dispatch mask, so dropping READ interest cannot
+    /// stop that loop -- only a non-positive... specifically a non-1 ... status ends it. A peer
+    /// can otherwise force continued service simply by sending >= 4096 bytes at once.
+    ///
+    /// This is the drain's third leg and is called from WorldSocket::handle_input_missing_data();
+    /// it lives here, not open-coded at the call site, so the rule is pinned by unit tests.
+    inline int InputStatus(DrainState state, bool fullRead)
+    {
+        if (!MayProcessInput(state))
+        {
+            return 2;
+        }
+        return fullRead ? 1 : 2;
     }
 }
 

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -969,9 +969,6 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     std::string account;
     Sha1Hash sha1;
     BigNumber v, s, g, N, K;
-    std::string os;
-    WorldPacket packet;
-    bool wardenActive = (sWorld.getConfig(CONFIG_BOOL_WARDEN_WIN_ENABLED) || sWorld.getConfig(CONFIG_BOOL_WARDEN_OSX_ENABLED));
 
     // Read the content of the packet.
     // The read order, the scattered digest[] indices and the missing leading ReadBit() before
@@ -1029,8 +1026,7 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
                              "`s`, "                       // 6
                              "`expansion`, "               // 7
                              "`mutetime`, "                // 8
-                             "`locale`, "                  // 9
-                             "`os` "                       // 10
+                             "`locale` "                   // 9
                              "FROM `account` "
                              "WHERE `username` = '%s'",
                              safe_account.c_str());
@@ -1095,8 +1091,6 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
         locale = LOCALE_enUS;
     }
 
-    os = fields[10].GetString();
-
     delete result;
 
     // Re-check account ban (same check as in realmd)
@@ -1127,17 +1121,7 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
         return -1;
     }
 
-    // Warden: Must be done before WorldSession is created
-    if (wardenActive && os != "Win" && os != "OSX")
-    {
-        WorldPacket Packet(SMSG_AUTH_RESPONSE, 1);
-        Packet << uint8(AUTH_REJECT);
-
-        SendPacket(packet);
-
-        BASIC_LOG("WorldSocket::HandleAuthSession: Client %s attempted to log in using invalid client OS (%s).", GetRemoteAddress().c_str(), os.c_str());
-        return -1;
-    }
+    // Phase 3 defers Warden structurally; see auth design §6.11 before re-enabling.
 
     // Check that Key and account name are the same on client and server
     Sha1Hash sha;
@@ -1184,12 +1168,6 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
 
     // In case needed sometime the second arg is in microseconds 1 000 000 = 1 sec
     ACE_OS::sleep(ACE_Time_Value(0, 10000));
-
-    // Warden: Initialize Warden system only if it is enabled by config
-    if (wardenActive)
-    {
-        m_Session->InitWarden(uint16(BuiltNumberClient), &K, os);
-    }
 
     sWorld.AddSession(m_Session);
 

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -55,6 +55,7 @@
 #include <ace/Auto_Ptr.h>
 
 #include <cstdio>
+#include <cstring>
 
 #include "WorldSocket.h"
 #include "Common.h"
@@ -96,6 +97,7 @@ WorldSocket::WorldSocket(void) :
     m_OutBuffer(0),
     m_OutBufferSize(65536),
     m_OutActive(false),
+    m_drainState(MopSock::DrainState::Open),
     m_Seed(0),
     m_connState(MopHs::CONN_GREETING),
     m_frameReader(),
@@ -401,13 +403,74 @@ int WorldSocket::SendAuthChallenge()
     return 0;
 }
 
-void WorldSocket::SendAuthResponseError(uint8 code)
+/**
+ * @brief Queues the auth error response and enters the drain state.
+ *
+ * The sole SMSG_AUTH_RESPONSE construction site on the rejection path: every auth rejection
+ * routes through here, so the response body and the drain bookkeeping cannot drift apart.
+ *
+ * Ordering matters. READ interest is dropped BEFORE the response is queued, so a failure to
+ * quiesce input is reported while nothing has been committed to the wire.
+ *
+ * @param code the AUTH_* result to report.
+ * @return int 0 with the response queued and the drain armed; -1 if nothing was queued.
+ */
+int WorldSocket::BeginAuthErrorDrain(uint8 code)
 {
+    // 1. Idempotent: a second rejection must not re-arm the drain or re-queue a response.
+    if (m_drainState.load() == MopSock::DrainState::Flushing)
+    {
+        return 0;
+    }
+
+    // 2. Drop reactor READ interest only; the socket must stay writable to drain.
+    //
+    // NOTE: cancel_wakeup(), NOT remove_handler(READ_MASK | DONT_CALL). Verified against the
+    // vendored ACE (dep/acelite): remove_handler() -> handler_rep_.unbind(), which sets
+    // complete_removal when the cleared mask leaves the handle with no wait/suspend mask left,
+    // and then calls remove_reference() (Select_Reactor_Base.cpp:395). open() registers
+    // READ|WRITE, but cancel_wakeup_output() clears WRITE as soon as the auth challenge has
+    // flushed, so by the time a rejection runs READ is the ONLY mask: removing it would fully
+    // unbind the handler and drop the reactor's reference, not merely stop reads. The socket
+    // would survive (WorldSocketMgr::OnSocketOpen holds a second reference) but the handler
+    // would be gone from the reactor, so a later schedule_wakeup_output() on a short write
+    // could never be serviced -- m_OutActive would stay true, Update() would early-return 0
+    // forever, and the socket would leak, never draining and never closing.
+    //
+    // cancel_wakeup() -> mask_ops(CLR_MASK) clears the read bit without unbinding, without
+    // touching the reference count, and without invoking handle_close() (which would set
+    // closing_ and defeat the drain outright, making DONT_CALL moot here). It also calls
+    // clear_dispatch_mask(), dropping a read event already selected for this dispatch. This is
+    // the same idiom cancel_wakeup_output() uses for WRITE_MASK a few lines below.
+    if (reactor()->cancel_wakeup(this, ACE_Event_Handler::READ_MASK) == -1)
+    {
+        sLog.outError("WorldSocket::BeginAuthErrorDrain: could not cancel read interest for %s; closing.",
+                      GetRemoteAddress().c_str());
+        return -1;                                            // nothing queued yet
+    }
+
+    // 3. Construct the legacy error response (unchanged wire shape).
     WorldPacket packet(SMSG_AUTH_RESPONSE, 1);
     packet.WriteBit(0); // has account info
     packet.WriteBit(0); // has queue info
     packet << uint8(code);
-    SendPacket(packet);
+
+    // 4. Queue it. If it never reached the buffer there is nothing to drain, so close now.
+    bool sent = false;
+    if (SendPacket(packet, &sent) == -1)
+    {
+        return -1;
+    }
+    if (!sent)
+    {
+        // Eluna's OnPacketSend vetoed the response; draining for it would hang the socket open.
+        DEBUG_LOG("WorldSocket::BeginAuthErrorDrain: auth error response suppressed; closing.");
+        return -1;
+    }
+
+    // 5. Arm the drain only once the bytes are genuinely pending.
+    m_drainState.store(MopSock::DrainState::Flushing);
+    return 0;
 }
 
 /**
@@ -628,6 +691,17 @@ int WorldSocket::Update(void)
         return -1;
     }
 
+    // The auth error response has now been written: close for real.
+    // This MUST sit above the drained early-return below, and NOT in handle_output(): once the
+    // buffers are empty Update() returns 0 without ever calling handle_output(), and the full
+    // drain already called cancel_wakeup_output(), so the reactor raises no further write event
+    // either. A check inside handle_output() would never run and the socket would leak.
+    // Returning -1 makes WorldSocketMgr::svc() do the orderly CloseSocket()/RemoveReference().
+    if (MopSock::ShouldCloseNow(m_drainState.load(), m_OutBuffer->length(), msg_queue()->is_empty()))
+    {
+        return -1;
+    }
+
     if (m_OutActive || (m_OutBuffer->length() == 0 && msg_queue()->is_empty()))
     {
         return 0;
@@ -713,12 +787,36 @@ int WorldSocket::handle_input_missing_data(void)
             pct->append(frame.payload.data(), frame.payload.size());
         }
 
-        if (ProcessIncoming(pct) == -1)
+        const int processed = ProcessIncoming(pct);
+        if (processed == -1)
         {
             errno = EINVAL;
             return -1;
         }
+
+        // An auth rejection is now draining. Stop dispatching immediately: MopFrameReader may
+        // already have coalesced a further frame into the buffer, and a peer we have decided to
+        // reject must not have it acted upon. Removing reactor READ interest stops FUTURE
+        // callbacks; only this break stops the frame that is already buffered -- both are needed.
+        // Nothing is discarded here: the buffered frames die with the socket once output drains.
+        if (!MopSock::MayProcessInput(m_drainState.load()))
+        {
+            break;
+        }
         // Phase 3: after crypt Init in the auth path, the NEXT TryFrame sees IsInitialized()==true (no manual flag).
+    }
+
+    // Third leg of the quiesce, and NOT redundant with the break above or the READ-interest
+    // removal. A full read reports 1, which handle_input() passes straight to the reactor, and
+    // ACE_TP_Reactor::dispatch_socket_event re-invokes the callback DIRECTLY on a positive status
+    // ("int status = 1; while (status > 0) status = (event_handler->*callback)(handle);",
+    // TP_Reactor.cpp). That loop consults neither the wait set nor the dispatch mask, so
+    // cancel_wakeup() cannot stop it: we would recv() and dispatch further frames from a peer we
+    // have already rejected, which a peer can force simply by sending >= 4096 bytes at once.
+    // Reporting a partial read instead ends the re-entry; the drain then proceeds via Update().
+    if (!MopSock::MayProcessInput(m_drainState.load()))
+    {
+        return 2;
     }
 
     return (size_t(n) == sizeof(buf)) ? 1 : 2;   // preserve ACE contract: full read -> 1, partial -> 2
@@ -979,13 +1077,20 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     MopAuth::DecodeResult const decodeResult = MopAuth::DecodeAuthSession(recvPacket, authFields);
     if (decodeResult != MopAuth::DecodeResult::Ok)
     {
-        // TODO(Task 3): replace with the drain helper + AUTH_FAILED response.
-        sLog.outError("WorldSocket::HandleAuthSession: malformed auth session body (result %u).",
-                      static_cast<uint32>(decodeResult));
-        return -1;
+        // DEBUG_LOG, not sLog.outError: this fires on every malformed body on an UNAUTHENTICATED
+        // path, so at error level an attacker spraying junk auth bodies would drive unbounded
+        // error-level log writes (disk/IO amplification). Deliberately NOT rate-limited via
+        // m_lastDecodeLog like the sibling decode paths: a rejection now drains and closes the
+        // socket, so this path logs at most ONCE per connection and a PER-SOCKET limiter cannot
+        // bound it -- volume tracks connection rate, which the limiter never sees. Demoting is
+        // what actually removes the amplification at default log levels.
+        // Payload-free: the decode result enum only, never the body.
+        DEBUG_LOG("WorldSocket::HandleAuthSession: malformed auth session body (result %u).",
+                  static_cast<uint32>(decodeResult));
+        return BeginAuthErrorDrain(AUTH_FAILED);
     }
 
-    memcpy(digest, authFields.digest, sizeof(digest));
+    std::memcpy(digest, authFields.digest, sizeof(digest));
     clientSeed = authFields.clientSeed;
     BuiltNumberClient = authFields.builtNumberClient;
     account = authFields.account;
@@ -1004,10 +1109,8 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // Check the version of client trying to connect
     if (!IsAcceptableClientBuild(BuiltNumberClient))
     {
-        SendAuthResponseError(AUTH_VERSION_MISMATCH);
-
         sLog.outError("WorldSocket::HandleAuthSession: Sent Auth Response (version mismatch).");
-        return -1;
+        return BeginAuthErrorDrain(AUTH_VERSION_MISMATCH);
     }
 
     // Get the account information from the realmd database
@@ -1034,10 +1137,8 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // Stop if the account is not found
     if (!result)
     {
-        SendAuthResponseError(AUTH_UNKNOWN_ACCOUNT);
-
         sLog.outError("WorldSocket::HandleAuthSession: Sent Auth Response (unknown account).");
-        return -1;
+        return BeginAuthErrorDrain(AUTH_UNKNOWN_ACCOUNT);
     }
 
     Field* fields = result->Fetch();
@@ -1066,11 +1167,9 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     {
         if (strcmp(fields[3].GetString(), GetRemoteAddress().c_str()))
         {
-            SendAuthResponseError(AUTH_FAILED);
-
-            delete result;
+            delete result;                                    // 'fields' dies with it; not used below
             BASIC_LOG("WorldSocket::HandleAuthSession: Sent Auth Response (Account IP differs).");
-            return -1;
+            return BeginAuthErrorDrain(AUTH_FAILED);
         }
     }
 
@@ -1102,12 +1201,10 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
 
     if (banresult) // if account banned
     {
-        SendAuthResponseError(AUTH_BANNED);
-
         delete banresult;
 
         sLog.outError("WorldSocket::HandleAuthSession: Sent Auth Response (Account banned).");
-        return -1;
+        return BeginAuthErrorDrain(AUTH_BANNED);
     }
 
     // Check locked state for server
@@ -1115,10 +1212,8 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
 
     if (allowedAccountType > SEC_PLAYER && AccountTypes(security) < allowedAccountType)
     {
-        SendAuthResponseError(AUTH_UNAVAILABLE);
-
         BASIC_LOG("WorldSocket::HandleAuthSession: User tries to login but his security level is not enough");
-        return -1;
+        return BeginAuthErrorDrain(AUTH_UNAVAILABLE);
     }
 
     // Phase 3 defers Warden structurally; see auth design §6.11 before re-enabling.
@@ -1138,10 +1233,8 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
 
     if (memcmp(sha.GetDigest(), digest, 20))
     {
-        SendAuthResponseError(AUTH_FAILED);
-
         sLog.outError("WorldSocket::HandleAuthSession: Sent Auth Response (authentification failed).");
-        return -1;
+        return BeginAuthErrorDrain(AUTH_FAILED);
     }
 
     std::string address = GetRemoteAddress();

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -1277,17 +1277,36 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     stmt.PExecute(address.c_str(), account.c_str());
 
     // NOTE ATM the socket is single-threaded, have this in mind ...
+    // Allocation stays ahead of its own load calls below; ACE_NEW_RETURN is an explicit early
+    // return, so it must remain pre-commit.
     ACE_NEW_RETURN(m_Session, WorldSession(id, this, AccountTypes(security), expansion, mutetime, locale), -1);
 
-    m_Crypt.Init(&K);
-
+    // Every fallible step -- DB loads, addon inflate -- runs BEFORE the commit region. Their
+    // internal semantics are unchanged from the pre-Task-4 code; only their position moved above
+    // m_Crypt.Init. This is what makes the region atomic BY ORDERING: once the commit region is
+    // entered nothing below it can fail, so no failure path can observe an initialised crypt on an
+    // unauthenticated session. AuthCrypt has no rollback and deliberately does not gain one --
+    // rollback would exist only to paper over the ordering defect this reorder removes.
     m_Session->LoadGlobalAccountData();
     m_Session->LoadTutorialsData();
     m_Session->ReadAddonsInfo(addonsData);
 
     // In case needed sometime the second arg is in microseconds 1 000 000 = 1 sec
+    // Legacy delay, semantics unchanged; hoisted above the commit region because a delay may not
+    // appear between the three commit statements.
     ACE_OS::sleep(ACE_Time_Value(0, 10000));
 
+    // ===================== COMMIT REGION -- no failure is possible below =====================
+    // Exactly three statements, in this order, with nothing between them: no log, no packet send,
+    // no validation, no branch, no delay, no allocation, no early return. Publication ends the
+    // region.
+    //
+    // LIMITATION (Stage 1 scope): AuthCrypt::Init is void and does NOT report OpenSSL failure, so
+    // this proves SOURCE ORDERING only -- it cannot prove initialisation SUCCEEDED. Stage 2 owns
+    // making init success observable during its atomic raw-40 K migration, before activation.
+    // Do not read this region as a proof of cryptographic atomicity.
+    m_Crypt.Init(&K);
+    m_connState = MopHs::CONN_AUTHED;
     sWorld.AddSession(m_Session);
 
     return 0;

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -439,9 +439,24 @@ int WorldSocket::BeginAuthErrorDrain(uint8 code)
     //
     // cancel_wakeup() -> mask_ops(CLR_MASK) clears the read bit without unbinding, without
     // touching the reference count, and without invoking handle_close() (which would set
-    // closing_ and defeat the drain outright, making DONT_CALL moot here). It also calls
-    // clear_dispatch_mask(), dropping a read event already selected for this dispatch. This is
-    // the same idiom cancel_wakeup_output() uses for WRITE_MASK a few lines below.
+    // closing_ and defeat the drain outright, making DONT_CALL moot here). This is the same
+    // idiom cancel_wakeup_output() uses for WRITE_MASK a few lines below.
+    //
+    // What actually stops the reads is a SUSPEND-set operation, not a wait-set one, and that
+    // depends on running inside the suspended dispatch window: ACE_TP_Reactor::dispatch_socket_event
+    // calls suspend_i() BEFORE dispatching us (TP_Reactor.cpp:395-397), and suspend_i() moves READ
+    // out of wait_set_ into suspend_set_ and clears the dispatch mask, dropping a read event
+    // already selected for this dispatch (Select_Reactor_T.cpp:949-975). mask_ops() is
+    // suspend-aware -- "if (is_suspended_i(handle)) bit_ops(..., suspend_set_, ops)"
+    // (Select_Reactor_T.cpp:851-866) -- so our CLR_MASK clears READ from suspend_set_. Afterwards
+    // post_process_socket_event() calls resume_i() (TP_Reactor.cpp:596), and resume_i() restores
+    // to wait_set_ only bits STILL present in suspend_set_ (Select_Reactor_T.cpp:929-933). READ is
+    // gone by then, so it is never restored and no further read event is raised.
+    //
+    // Therefore this must stay INSIDE the suspended dispatch window (i.e. on the handler's own
+    // upcall path, as HandleAuthSession is). Arming the drain from outside it would route the
+    // CLR_MASK to wait_set_ instead, where a subsequent resume_i() has nothing to do with it --
+    // the reasoning above simply would not apply and reads would continue.
     if (reactor()->cancel_wakeup(this, ACE_Event_Handler::READ_MASK) == -1)
     {
         sLog.outError("WorldSocket::BeginAuthErrorDrain: could not cancel read interest for %s; closing.",
@@ -697,6 +712,15 @@ int WorldSocket::Update(void)
     // drain already called cancel_wakeup_output(), so the reactor raises no further write event
     // either. A check inside handle_output() would never run and the socket would leak.
     // Returning -1 makes WorldSocketMgr::svc() do the orderly CloseSocket()/RemoveReference().
+    //
+    // KNOWN, ACCEPTED RISK: length()/is_empty() are read WITHOUT m_OutBufferLock, matching the
+    // pre-existing convention below -- but the consequence is NOT the same and this is not a plain
+    // convention match. A spurious length()==0 below merely returns 0 and is retried in ~10ms; here
+    // it returns -1 -> CloseSocket() and DISCARDS the auth response, i.e. reintroduces the exact bug
+    // this drain exists to prevent. Accepted because it requires a torn read of ACE_Message_Block's
+    // pointers mid-reset/crunch, which is very unlikely. Do NOT "fix" this by taking the lock:
+    // handle_output() acquires m_OutBufferLock and Update() calls handle_output() a few lines below,
+    // so holding it here is the documented self-deadlock.
     if (MopSock::ShouldCloseNow(m_drainState.load(), m_OutBuffer->length(), msg_queue()->is_empty()))
     {
         return -1;
@@ -740,6 +764,16 @@ int WorldSocket::handle_input_missing_data(void)
     MopFrameReader::Frame frame;
     for (;;)
     {
+        // Structural guard: never dispatch a frame while an auth error is draining, INCLUDING the
+        // first frame of a re-entered call. The post-ProcessIncoming check below only suppresses
+        // the next iteration of this loop, so on its own it would let any re-entry dispatch one
+        // frame from a rejected peer. Unreachable today (legs 1 and 3 stop re-entry happening at
+        // all), so this makes the property structural rather than contingent on those two legs.
+        if (!MopSock::MayProcessInput(m_drainState.load()))
+        {
+            break;
+        }
+
         // Header width is state-driven, derived fresh every frame (no stored codec flag):
         //   crypt live            -> 4-byte packed
         //   still awaiting greet  -> 4-byte {size, cmd16}; the client's MSG_WOW_CONNECTION reply is
@@ -807,19 +841,11 @@ int WorldSocket::handle_input_missing_data(void)
     }
 
     // Third leg of the quiesce, and NOT redundant with the break above or the READ-interest
-    // removal. A full read reports 1, which handle_input() passes straight to the reactor, and
-    // ACE_TP_Reactor::dispatch_socket_event re-invokes the callback DIRECTLY on a positive status
-    // ("int status = 1; while (status > 0) status = (event_handler->*callback)(handle);",
-    // TP_Reactor.cpp). That loop consults neither the wait set nor the dispatch mask, so
-    // cancel_wakeup() cannot stop it: we would recv() and dispatch further frames from a peer we
-    // have already rejected, which a peer can force simply by sending >= 4096 bytes at once.
-    // Reporting a partial read instead ends the re-entry; the drain then proceeds via Update().
-    if (!MopSock::MayProcessInput(m_drainState.load()))
-    {
-        return 2;
-    }
-
-    return (size_t(n) == sizeof(buf)) ? 1 : 2;   // preserve ACE contract: full read -> 1, partial -> 2
+    // removal: while Flushing this reports a partial read so ACE_TP_Reactor cannot re-invoke
+    // handle_input() directly off a positive status. The rule itself lives in MopSocketDrain.h
+    // (see MopSock::InputStatus) where it is unit-tested; do not re-open-code it here.
+    // Otherwise the plain ACE contract applies: full read -> 1, partial -> 2.
+    return MopSock::InputStatus(m_drainState.load(), size_t(n) == sizeof(buf));
 }
 
 /// MopFrameReader::DecryptFn hook (Phase 2 wire framing): in-place ARC4 on the header only.

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -59,6 +59,7 @@
 #include "WorldSocket.h"
 #include "Common.h"
 #include "MopWireCodec.h"
+#include "MopAuthSession.h"
 
 #include "Util.h"
 #include "World.h"
@@ -962,7 +963,6 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // NOTE: ATM the socket is singlethread, have this in mind ...
     uint8 digest[20];
     uint32 clientSeed, id, security;
-    uint32 m_addonSize;
     uint16 BuiltNumberClient;
     uint8 expansion = 0;
     LocaleConstant locale;
@@ -973,44 +973,31 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     WorldPacket packet;
     bool wardenActive = (sWorld.getConfig(CONFIG_BOOL_WARDEN_WIN_ENABLED) || sWorld.getConfig(CONFIG_BOOL_WARDEN_OSX_ENABLED));
 
-    // Read the content of the packet
-    recvPacket.read_skip<uint32>();
-    recvPacket.read_skip<uint32>();
-    recvPacket >> digest[18];
-    recvPacket >> digest[14];
-    recvPacket >> digest[3];
-    recvPacket >> digest[4];
-    recvPacket >> digest[0];
-    recvPacket.read_skip<uint32>();
-    recvPacket >> digest[11];
-    recvPacket >> clientSeed;
-    recvPacket >> digest[19];
-    recvPacket.read_skip<uint8>();
-    recvPacket.read_skip<uint8>();
-    recvPacket >> digest[2];
-    recvPacket >> digest[9];
-    recvPacket >> digest[12];
-    recvPacket.read_skip<uint64>();
-    recvPacket.read_skip<uint32>();
-    recvPacket >> digest[16];
-    recvPacket >> digest[5];
-    recvPacket >> digest[6];
-    recvPacket >> digest[8];
-    recvPacket >> BuiltNumberClient;
-    recvPacket >> digest[17];
-    recvPacket >> digest[7];
-    recvPacket >> digest[13];
-    recvPacket >> digest[15];
-    recvPacket >> digest[1];
-    recvPacket >> digest[10];
+    // Read the content of the packet.
+    // The read order, the scattered digest[] indices and the missing leading ReadBit() before
+    // ReadBits(11) all now live in MopAuth::DecodeAuthSession, which reproduces them bug-for-bug
+    // while bounding every read. See MopAuthSession.h.
+    // NOTE: named authFields, not fields: a 'Field* fields' DB row local already exists below.
+    MopAuth::AuthSessionFields authFields{};
+    MopAuth::DecodeResult const decodeResult = MopAuth::DecodeAuthSession(recvPacket, authFields);
+    if (decodeResult != MopAuth::DecodeResult::Ok)
+    {
+        // TODO(Task 3): replace with the drain helper + AUTH_FAILED response.
+        sLog.outError("WorldSocket::HandleAuthSession: malformed auth session body (result %u).",
+                      static_cast<uint32>(decodeResult));
+        return -1;
+    }
 
-    recvPacket >> m_addonSize;                            // addon data size
+    memcpy(digest, authFields.digest, sizeof(digest));
+    clientSeed = authFields.clientSeed;
+    BuiltNumberClient = authFields.builtNumberClient;
+    account = authFields.account;
 
     ByteBuffer addonsData;
-    addonsData.resize(m_addonSize);
-    recvPacket.read((uint8*)addonsData.contents(), m_addonSize);
-
-    account = recvPacket.ReadString(recvPacket.ReadBits(11));
+    if (!authFields.addonData.empty())
+    {
+        addonsData.append(authFields.addonData.data(), authFields.addonData.size());
+    }
 
     DEBUG_LOG("WorldSocket::HandleAuthSession: client build %u, account %s, clientseed %X",
               BuiltNumberClient,

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -721,7 +721,19 @@ int WorldSocket::Update(void)
     // pointers mid-reset/crunch, which is very unlikely. Do NOT "fix" this by taking the lock:
     // handle_output() acquires m_OutBufferLock and Update() calls handle_output() a few lines below,
     // so holding it here is the documented self-deadlock.
-    if (MopSock::ShouldCloseNow(m_drainState.load(), m_OutBuffer->length(), msg_queue()->is_empty()))
+    //
+    // The state is tested FIRST, before ShouldCloseNow, so m_OutBuffer is not dereferenced unless a
+    // drain is actually armed. ShouldCloseNow takes size_t by value, so an unguarded call would
+    // evaluate m_OutBuffer->length() unconditionally -- above the m_OutActive short-circuit below
+    // that otherwise covers it. open() sets m_OutActive = true at :312 specifically to keep Update()
+    // out while initialising, but m_OutBuffer stays NULL from :312 until :321, a window spanning
+    // OnSocketOpen() at :315 which inserts this socket into the set svc() sweeps. Not reachable
+    // today (sockets_ is ACE_TSS, so only the opening thread sweeps it, and that thread is inside
+    // run_reactor_event_loop() for all of open()) -- but this keeps the safety local and obvious
+    // instead of resting on an invariant stated nowhere near here. Drain state is only ever armed
+    // long after open() completes, so the added test costs nothing.
+    if (m_drainState.load() == MopSock::DrainState::Flushing &&
+        MopSock::ShouldCloseNow(m_drainState.load(), m_OutBuffer->length(), msg_queue()->is_empty()))
     {
         return -1;
     }
@@ -1135,7 +1147,9 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // Check the version of client trying to connect
     if (!IsAcceptableClientBuild(BuiltNumberClient))
     {
-        sLog.outError("WorldSocket::HandleAuthSession: Sent Auth Response (version mismatch).");
+        // Claims only the decision, not the delivery: BeginAuthErrorDrain can return -1 having sent
+        // nothing, and it reports the actual send outcome itself. Keep payload-free.
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (version mismatch).");
         return BeginAuthErrorDrain(AUTH_VERSION_MISMATCH);
     }
 
@@ -1163,7 +1177,7 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // Stop if the account is not found
     if (!result)
     {
-        sLog.outError("WorldSocket::HandleAuthSession: Sent Auth Response (unknown account).");
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (unknown account).");
         return BeginAuthErrorDrain(AUTH_UNKNOWN_ACCOUNT);
     }
 
@@ -1194,7 +1208,7 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
         if (strcmp(fields[3].GetString(), GetRemoteAddress().c_str()))
         {
             delete result;                                    // 'fields' dies with it; not used below
-            BASIC_LOG("WorldSocket::HandleAuthSession: Sent Auth Response (Account IP differs).");
+            BASIC_LOG("WorldSocket::HandleAuthSession: rejecting auth session (account IP differs).");
             return BeginAuthErrorDrain(AUTH_FAILED);
         }
     }
@@ -1229,7 +1243,7 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     {
         delete banresult;
 
-        sLog.outError("WorldSocket::HandleAuthSession: Sent Auth Response (Account banned).");
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (account banned).");
         return BeginAuthErrorDrain(AUTH_BANNED);
     }
 
@@ -1242,7 +1256,23 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
         return BeginAuthErrorDrain(AUTH_UNAVAILABLE);
     }
 
-    // Phase 3 defers Warden structurally; see auth design §6.11 before re-enabling.
+    // Phase 3 defers Warden structurally. Everything needed to re-enable it correctly is stated
+    // here; do not re-add the code without addressing all four points:
+    //
+    // 1. K CONSUMER. Warden is the fourth consumer of the session key K (after the digest check,
+    //    m_Crypt.Init and the DB). Any migration to a canonical raw-40 K must account for it.
+    //    WorldSession::InitWarden still takes BigNumber* k and currently has ZERO callers, so the
+    //    compiler will NOT flag it when the key representation changes. This comment is the only
+    //    barrier -- treat it as a live TODO, not history.
+    // 2. SHORT-K BUG. WardenWin.cpp / WardenMac.cpp reseed from k->AsByteArray(), k->GetNumBytes().
+    //    BigNumber drops leading zero bytes, so whenever K's most-significant byte is zero (~1/256
+    //    of logins) that yields 39 bytes, not 40, and Warden desyncs. A raw-40 K fixes this by
+    //    construction; a BigNumber-shaped K does not.
+    // 3. NO KEY LOGGING. Warden logged its derived encryption keys. That logging was removed in
+    //    Stage 1 and must not be reintroduced.
+    // 4. ORDERING. InitWarden previously ran BEFORE AddSession, which made SMSG_WARDEN_DATA the
+    //    first encrypted server packet -- ahead of SMSG_AUTH_RESPONSE. Re-enabling must decide
+    //    that ordering deliberately rather than inherit it.
 
     // Check that Key and account name are the same on client and server
     Sha1Hash sha;
@@ -1259,7 +1289,7 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
 
     if (memcmp(sha.GetDigest(), digest, 20))
     {
-        sLog.outError("WorldSocket::HandleAuthSession: Sent Auth Response (authentification failed).");
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (authentication failed).");
         return BeginAuthErrorDrain(AUTH_FAILED);
     }
 
@@ -1296,10 +1326,28 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // appear between the three commit statements.
     ACE_OS::sleep(ACE_Time_Value(0, 10000));
 
-    // ===================== COMMIT REGION -- no failure is possible below =====================
+    // ================ COMMIT REGION -- no program failure path exists below ================
     // Exactly three statements, in this order, with nothing between them: no log, no packet send,
     // no validation, no branch, no delay, no allocation, no early return. Publication ends the
-    // region.
+    // region. The claim is precise: no early return, no explicit failure and no fallible call
+    // appears below the commit point -- NOT that no exception can be thrown here.
+    //
+    // A throw IS possible: m_Crypt.Init(&K) -> HMACSHA1::ComputeHash -> BigNumber::AsByteArray
+    // does new uint8[length] and can throw std::bad_alloc inside this region's FIRST statement.
+    // The invariant survives it for two reasons, both of which live in AuthCrypt::Init:
+    //   (a) _initialized = true is the LAST statement of AuthCrypt::Init (AuthCrypt.cpp:71), and
+    //       DecryptRecv/EncryptSend early-return on !_initialized -- so a mid-Init throw leaves
+    //       the crypt inert, not half-keyed.
+    //   (b) both throw sites precede _clientDecrypt.Init/_serverEncrypt.Init (AuthCrypt.cpp:55-56),
+    //       so a throw also leaves the ARC4 contexts un-keyed.
+    // A bad_alloc therefore unwinds past an unauthenticated, non-crypting session -- the same
+    // outcome as an ordinary early return.
+    //
+    // WARNING TO STAGE 2: that guarantee is SILENT and structural. Stage 2 reworks AuthCrypt::Init
+    // for the raw-40 K migration; this region's correctness depends on _initialized = true staying
+    // the last statement of Init. It must not be hoisted above the ARC4 setup, and no early return
+    // may be added on a partial-init path -- either change turns a throw here into a half-keyed
+    // crypt on an unauthenticated session, silently. NO TEST COVERS THIS.
     //
     // LIMITATION (Stage 1 scope): AuthCrypt::Init is void and does NOT report OpenSSL failure, so
     // this proves SOURCE ORDERING only -- it cannot prove initialisation SUCCEEDED. Stage 2 owns

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -51,6 +51,9 @@
 #include "Auth/BigNumber.h"
 #include "MopHandshake.h"
 #include "MopFrameReader.h"
+#include "MopSocketDrain.h"
+
+#include <atomic>
 
 class ACE_Message_Block;
 class WorldPacket;
@@ -188,7 +191,19 @@ class WorldSocket : protected WorldHandler
         static bool CmdValidHook(void*, uint32, bool);
 
     private:
-        void SendAuthResponseError(uint8);
+        /// Queue the legacy auth error response and enter the drain state.
+        ///
+        /// Replaces the former SendAuthResponseError(): that helper only appended to
+        /// m_OutBuffer, so every caller's follow-up `return -1` closed the socket before the
+        /// bytes were ever written and the peer saw a bare TCP close. This instead removes
+        /// reactor READ interest, queues the response, and leaves the socket open until
+        /// Update() observes the output fully drained.
+        ///
+        /// @param code the AUTH_* result to report
+        /// @return 0 once the response is queued (caller must return this, not -1);
+        ///         -1 if nothing was queued and the socket should close immediately
+        int BeginAuthErrorDrain(uint8 code);
+
         /// Time in which the last ping was received
         ACE_Time_Value m_LastPingTime;
 
@@ -218,6 +233,11 @@ class WorldSocket : protected WorldHandler
 
         /// True if the socket is registered with the reactor for output
         bool m_OutActive;
+
+        /// Auth-error drain state; see MopSocketDrain.h.
+        /// Atomic because reactor input dispatch (which sets it) and WorldSocketMgr::Update()
+        /// (which reads it) can run on different threads once Network.Threads > 1.
+        std::atomic<MopSock::DrainState> m_drainState;
 
         uint32 m_Seed;
 

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -21,3 +21,13 @@ add_executable(mop_framing_test mop_framing_test.cpp)
 target_include_directories(mop_framing_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/..)
 set_target_properties(mop_framing_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 add_test(NAME mop_framing COMMAND mop_framing_test)
+
+add_executable(mop_auth_test
+    mop_auth_test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../MopAuthSession.cpp)
+target_include_directories(mop_auth_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src/shared)
+set_target_properties(mop_auth_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+target_link_libraries(mop_auth_test PRIVATE shared)
+add_test(NAME mop_auth COMMAND mop_auth_test)

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "MopAuthSession.h"
+#include "MopSocketDrain.h"
 #include "Utilities/ByteBuffer.h"
 #include <cstdio>
 #include <type_traits>
@@ -174,6 +175,77 @@ static void test_name_truncated_rejected()
     CHECK(decode(in) == MopAuth::DecodeResult::TruncatedName);
 }
 
+// ---------------------------------------------------------------------------------------------
+// Auth-error drain decisions (MopSocketDrain.h)
+//
+// These cover the two pure decisions only. They are NOT a test of the ACE peer/reactor lifecycle:
+// that the production socket calls them in the right places is established by inspection, not here.
+// ---------------------------------------------------------------------------------------------
+
+// While Open, traffic is ordinary and must keep flowing.
+static void test_open_state_processes_input()
+{
+    CHECK(MopSock::MayProcessInput(MopSock::DrainState::Open) == true);
+}
+
+// The core of the quiesce: MopFrameReader may have already coalesced a further frame into the
+// buffer before we decided to reject. Once Flushing, that frame must never be acted upon.
+static void test_flushing_state_rejects_coalesced_next_frame()
+{
+    CHECK(MopSock::MayProcessInput(MopSock::DrainState::Flushing) == false);
+}
+
+// The bug this whole task exists to fix: closing while bytes are still buffered discards the
+// auth error response, leaving the peer with a bare TCP close and no reason for the rejection.
+static void test_buffered_output_prevents_close()
+{
+    CHECK(MopSock::ShouldCloseNow(MopSock::DrainState::Flushing, 7, true) == false);
+}
+
+// Same, for output that overflowed the buffer and went to the message queue instead.
+static void test_queued_output_prevents_close()
+{
+    CHECK(MopSock::ShouldCloseNow(MopSock::DrainState::Flushing, 0, false) == false);
+}
+
+// Neither buffer nor queue holds anything: the response is on the wire, so the socket may go.
+static void test_fully_drained_flushing_closes()
+{
+    CHECK(MopSock::ShouldCloseNow(MopSock::DrainState::Flushing, 0, true) == true);
+}
+
+// A healthy idle socket is drained by definition; it must never be closed on that basis alone.
+static void test_open_state_never_closes()
+{
+    CHECK(MopSock::ShouldCloseNow(MopSock::DrainState::Open, 0, true) == false);
+    CHECK(MopSock::ShouldCloseNow(MopSock::DrainState::Open, 7, false) == false);
+}
+
+// Mirrors handle_input_missing_data()'s return rule. A full read normally reports 1, which
+// ACE_TP_Reactor::dispatch_socket_event turns into an immediate re-invocation of handle_input
+// ("while (status > 0) status = (event_handler->*callback)(handle)") without consulting the wait
+// set -- so while draining, a full read must NOT report 1 or a rejected peer keeps being served.
+static int input_status(MopSock::DrainState state, bool fullRead)
+{
+    if (!MopSock::MayProcessInput(state))
+    {
+        return 2;
+    }
+    return fullRead ? 1 : 2;
+}
+
+static void test_drain_never_requests_reactor_reentry()
+{
+    CHECK(input_status(MopSock::DrainState::Open, true) == 1);      // healthy full read: keep reading
+    CHECK(input_status(MopSock::DrainState::Open, false) == 2);
+    CHECK(input_status(MopSock::DrainState::Flushing, true) != 1);  // draining: never ask to be re-called
+    CHECK(input_status(MopSock::DrainState::Flushing, false) != 1);
+}
+
+// A fresh socket must start Open, or the first Update() would tear down a healthy connection.
+static_assert(MopSock::DrainState{} == MopSock::DrainState::Open,
+              "value-initialized DrainState must be Open");
+
 static_assert(std::is_same<decltype(MopAuth::AuthSessionFields{}.builtNumberClient), uint16_t>::value,
               "auth build field must stay 16-bit");
 
@@ -200,6 +272,13 @@ int main(int /*argc*/, char** /*argv*/)
     test_name_length_at_maximum_accepted();
     test_name_truncated_rejected();
     test_wire_field_widths();
+    test_open_state_processes_input();
+    test_flushing_state_rejects_coalesced_next_frame();
+    test_buffered_output_prevents_close();
+    test_queued_output_prevents_close();
+    test_fully_drained_flushing_closes();
+    test_open_state_never_closes();
+    test_drain_never_requests_reactor_reentry();
     std::printf(g_fail ? "FAILED (%d)\n" : "OK\n", g_fail);
     return g_fail ? 1 : 0;
 }

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -221,25 +221,18 @@ static void test_open_state_never_closes()
     CHECK(MopSock::ShouldCloseNow(MopSock::DrainState::Open, 7, false) == false);
 }
 
-// Mirrors handle_input_missing_data()'s return rule. A full read normally reports 1, which
-// ACE_TP_Reactor::dispatch_socket_event turns into an immediate re-invocation of handle_input
-// ("while (status > 0) status = (event_handler->*callback)(handle)") without consulting the wait
-// set -- so while draining, a full read must NOT report 1 or a rejected peer keeps being served.
-static int input_status(MopSock::DrainState state, bool fullRead)
-{
-    if (!MopSock::MayProcessInput(state))
-    {
-        return 2;
-    }
-    return fullRead ? 1 : 2;
-}
-
+// Pins the rule handle_input_missing_data() RETURNS -- WorldSocket.cpp calls MopSock::InputStatus
+// directly and open-codes nothing, so this test covers production rather than a copy of it.
+// A full read normally reports 1, which ACE_TP_Reactor::dispatch_socket_event turns into an
+// immediate re-invocation of handle_input ("while (status > 0) status = (event_handler->*callback)
+// (handle)") without consulting the wait set -- so while draining, a full read must NOT report 1
+// or a rejected peer keeps being served.
 static void test_drain_never_requests_reactor_reentry()
 {
-    CHECK(input_status(MopSock::DrainState::Open, true) == 1);      // healthy full read: keep reading
-    CHECK(input_status(MopSock::DrainState::Open, false) == 2);
-    CHECK(input_status(MopSock::DrainState::Flushing, true) != 1);  // draining: never ask to be re-called
-    CHECK(input_status(MopSock::DrainState::Flushing, false) != 1);
+    CHECK(MopSock::InputStatus(MopSock::DrainState::Open, true) == 1);      // healthy full read: keep reading
+    CHECK(MopSock::InputStatus(MopSock::DrainState::Open, false) == 2);     // healthy partial read: stop
+    CHECK(MopSock::InputStatus(MopSock::DrainState::Flushing, true) != 1);  // draining: never ask to be re-called
+    CHECK(MopSock::InputStatus(MopSock::DrainState::Flushing, false) != 1);
 }
 
 // A fresh socket must start Open, or the first Update() would tear down a healthy connection.

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -1,0 +1,205 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "MopAuthSession.h"
+#include "Utilities/ByteBuffer.h"
+#include <cstdio>
+#include <type_traits>
+
+static int g_fail = 0;
+#define CHECK(c) do { if (!(c)) { std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #c); ++g_fail; } } while (0)
+
+// The legacy 11-bit name length is read MSB-first across two bytes with no leading ReadBit(),
+// so the encoded value is (bits0 << 3) | (bits1 >> 5). Vectors below are hand-encoded to that.
+static ByteBuffer make_legacy_body(uint32_t addonSize, uint32_t inflatedSize,
+                                   uint8_t nameBits0, uint8_t nameBits1,
+                                   char const* name, size_t nameBytes)
+{
+    ByteBuffer in;
+    for (size_t i = 0; i < 52; ++i)
+    {
+        in << uint8_t(0);
+    }
+    in << addonSize;
+    if (addonSize >= 4)
+    {
+        in << inflatedSize;
+    }
+    for (uint32_t i = 4; i < addonSize; ++i)
+    {
+        in << uint8_t(0);
+    }
+    in << nameBits0 << nameBits1;
+    if (nameBytes)
+    {
+        in.append(reinterpret_cast<uint8_t const*>(name), nameBytes);
+    }
+    return in;
+}
+
+static MopAuth::DecodeResult decode(ByteBuffer& in)
+{
+    MopAuth::AuthSessionFields out{};
+    return MopAuth::DecodeAuthSession(in, out);
+}
+
+static void test_short_body_rejected()
+{
+    ByteBuffer in;
+    in << uint32_t(0);
+    MopAuth::AuthSessionFields out{};
+    CHECK(MopAuth::DecodeAuthSession(in, out) == MopAuth::DecodeResult::ShortBody);
+}
+
+// Structure only: the legacy decode is bug-compatible, so field values are deliberately not asserted.
+static void test_exact_valid_structure_accepted()
+{
+    ByteBuffer in = make_legacy_body(4, 1, 0x00, 0x20, "A", 1);   // 11-bit name length 1
+    CHECK(decode(in) == MopAuth::DecodeResult::Ok);
+}
+
+static void test_prefix_one_byte_short_rejected()
+{
+    ByteBuffer in;
+    for (size_t i = 0; i < 55; ++i)                               // 55 < LegacyFixedPrefixBytes (56)
+    {
+        in << uint8_t(0);
+    }
+    CHECK(decode(in) == MopAuth::DecodeResult::ShortBody);
+}
+
+static void test_addon_size_below_minimum_rejected()
+{
+    ByteBuffer in = make_legacy_body(0, 0, 0x00, 0x20, "A", 1);   // addon size 0 cannot hold its own header
+    CHECK(decode(in) == MopAuth::DecodeResult::BadAddonSize);
+}
+
+// Built by hand so the helper cannot accidentally supply the bytes this bound is meant to reject.
+static void test_addon_size_beyond_remaining_rejected()
+{
+    ByteBuffer in;
+    for (size_t i = 0; i < 52; ++i)
+    {
+        in << uint8_t(0);
+    }
+    in << uint32_t(1000);                                         // claims 1000 bytes ...
+    in << uint32_t(1);                                            // ... but only 4 follow
+    CHECK(decode(in) == MopAuth::DecodeResult::BadAddonSize);
+}
+
+static void test_inflated_size_zero_rejected()
+{
+    ByteBuffer in = make_legacy_body(4, 0, 0x00, 0x20, "A", 1);
+    CHECK(decode(in) == MopAuth::DecodeResult::BadInflatedAddonSize);
+}
+
+static void test_inflated_size_over_maximum_rejected()
+{
+    ByteBuffer in = make_legacy_body(4, 0x100000, 0x00, 0x20, "A", 1);  // one over MaxInflatedAddonBytes
+    CHECK(decode(in) == MopAuth::DecodeResult::BadInflatedAddonSize);
+}
+
+static void test_inflated_size_at_maximum_accepted()
+{
+    ByteBuffer in = make_legacy_body(4, MopAuth::MaxInflatedAddonBytes, 0x00, 0x20, "A", 1);
+    CHECK(decode(in) == MopAuth::DecodeResult::Ok);
+}
+
+// Built by hand: the helper always emits the two name-length bytes.
+static void test_missing_name_bitfield_rejected()
+{
+    ByteBuffer in;
+    for (size_t i = 0; i < 52; ++i)
+    {
+        in << uint8_t(0);
+    }
+    in << uint32_t(4);
+    in << uint32_t(1);                                            // addon blob, then nothing at all
+    CHECK(decode(in) == MopAuth::DecodeResult::ShortBody);
+
+    ByteBuffer partial;
+    for (size_t i = 0; i < 52; ++i)
+    {
+        partial << uint8_t(0);
+    }
+    partial << uint32_t(4);
+    partial << uint32_t(1);
+    partial << uint8_t(0);                                        // one of the two bytes present
+    CHECK(decode(partial) == MopAuth::DecodeResult::ShortBody);
+}
+
+static void test_name_length_zero_rejected()
+{
+    ByteBuffer in = make_legacy_body(4, 1, 0x00, 0x00, "A", 1);   // 11-bit name length 0
+    CHECK(decode(in) == MopAuth::DecodeResult::BadNameLength);
+}
+
+static void test_name_length_over_maximum_rejected()
+{
+    ByteBuffer in = make_legacy_body(4, 1, 0x02, 0x20, "AAAAAAAAAAAAAAAAA", 17);  // length 17 > 16
+    CHECK(decode(in) == MopAuth::DecodeResult::BadNameLength);
+}
+
+static void test_name_length_at_maximum_accepted()
+{
+    ByteBuffer in = make_legacy_body(4, 1, 0x02, 0x00, "AAAAAAAAAAAAAAAA", 16);   // length 16 == max
+    CHECK(decode(in) == MopAuth::DecodeResult::Ok);
+}
+
+// ReadString() truncates silently at end-of-buffer; the decoder must reject rather than shorten.
+static void test_name_truncated_rejected()
+{
+    ByteBuffer in = make_legacy_body(4, 1, 0x00, 0x40, "A", 1);   // length 2, one byte remaining
+    CHECK(decode(in) == MopAuth::DecodeResult::TruncatedName);
+}
+
+static_assert(std::is_same<decltype(MopAuth::AuthSessionFields{}.builtNumberClient), uint16_t>::value,
+              "auth build field must stay 16-bit");
+
+static void test_wire_field_widths()
+{
+    CHECK(sizeof(MopAuth::AuthSessionFields{}.builtNumberClient) == 2);
+}
+
+// NOTE: linking 'shared' drags in ACE, whose OS_main.h rewrites main() to ace_main_i() and
+// requires the (int, char**) signature. A no-argument main() therefore fails to link (LNK2019).
+int main(int /*argc*/, char** /*argv*/)
+{
+    test_short_body_rejected();
+    test_exact_valid_structure_accepted();
+    test_prefix_one_byte_short_rejected();
+    test_addon_size_below_minimum_rejected();
+    test_addon_size_beyond_remaining_rejected();
+    test_inflated_size_zero_rejected();
+    test_inflated_size_over_maximum_rejected();
+    test_inflated_size_at_maximum_accepted();
+    test_missing_name_bitfield_rejected();
+    test_name_length_zero_rejected();
+    test_name_length_over_maximum_rejected();
+    test_name_length_at_maximum_accepted();
+    test_name_truncated_rejected();
+    test_wire_field_widths();
+    std::printf(g_fail ? "FAILED (%d)\n" : "OK\n", g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/src/game/Warden/WardenMac.cpp
+++ b/src/game/Warden/WardenMac.cpp
@@ -97,14 +97,10 @@ void WardenMac::Init(WorldSession* pClient, BigNumber* K)
     _inputCrypto.Init(_inputKey);
     _outputCrypto.Init(_outputKey);
     sLog.outWarden("Server side Mac warden for client %u (build %u) initializing...", pClient->GetAccountId(), _session->GetClientBuild());
-    sLog.outWarden("C->S Key: %s", ByteArrayToHexStr(_inputKey, 16).c_str());
-    sLog.outWarden("S->C Key: %s", ByteArrayToHexStr(_outputKey, 16).c_str());
-    sLog.outWarden("  Seed: %s", ByteArrayToHexStr(_seed, 16).c_str());
     sLog.outWarden("Loading Module...");
 
     _module = GetModuleForClient();
 
-    sLog.outWarden("Module Key: %s", ByteArrayToHexStr(_module->Key, 16).c_str());
     sLog.outWarden("Module ID: %s", ByteArrayToHexStr(_module->Id, 16).c_str());
     RequestModule();
 }

--- a/src/game/Warden/WardenWin.cpp
+++ b/src/game/Warden/WardenWin.cpp
@@ -93,14 +93,10 @@ void WardenWin::Init(WorldSession* session, BigNumber* k)
     _inputCrypto.Init(_inputKey);
     _outputCrypto.Init(_outputKey);
     sLog.outWarden("Server side warden for client %u (build %u) initializing...", session->GetAccountId(), _session->GetClientBuild());
-    sLog.outWarden("C->S Key: %s", ByteArrayToHexStr(_inputKey, 16).c_str());
-    sLog.outWarden("S->C Key: %s", ByteArrayToHexStr(_outputKey, 16).c_str());
-    sLog.outWarden("  Seed: %s", ByteArrayToHexStr(_seed, 16).c_str());
     sLog.outWarden("Loading Module...");
 
     _module = GetModuleForClient();
 
-    sLog.outWarden("Module Key: %s", ByteArrayToHexStr(_module->Key, 16).c_str());
     sLog.outWarden("Module ID: %s", ByteArrayToHexStr(_module->Id, 16).c_str());
     RequestModule();
 }


### PR DESCRIPTION
## ⚠️ Read this first: **this PR activates nothing**

`WorldSocket::HandleAuthSession` has **zero call sites** before this PR and **zero call sites after it**. `ProcessIncoming`'s `case CMSG_AUTH_SESSION:` intercept still sets `CONN_AUTHENTICATING`, logs `auth deferred to Phase 3`, and returns `-1` without ever calling it — that block is byte-identical to master.

A reviewer seeing a decoder, a drain state, and a crypt commit region will reasonably assume auth now runs. **It does not.** Client-visible behaviour is unchanged: the client still reaches the world socket, completes the handshake, sends `CMSG_AUTH_SESSION`, and gets closed. Verified against a real 5.4.8.18414 client after this branch was deployed — framing OK on a live 435-byte auth packet, then the deliberate close.

**Stage 2 owns the sole activation cutover.** It is not written yet.

## Why this exists

Phase 3 (auth) was planned as one change four times. Each review round found the same defect one layer down: **3C → 2C+5H → 2C+6H → 3C+7H+1M**. The count never fell because three of the findings were one root cause, not three — `HandleAuthSession`'s *structure* could not express the correctness the spec demanded:

- it **parsed inline**, so no test could reach the parser (tests would test a copy);
- it **initialised the crypt before fallible work**, and `AuthCrypt` has no rollback — so "every failure path leaves the crypt unauthenticated" was unreachable, not merely unimplemented;
- it **queued auth errors then closed**, so the bytes were discarded (`SendPacket` only appends to `m_OutBuffer`; `handle_close` sets `closing_`; `Update()` early-returns on `closing_`).

Phase 3 was therefore split. **Stage 1 (this PR) restructures. Stage 2 adds semantics** (seeds, canonical raw-40 K, the digest scatter, the five `SMSG_AUTH_RESPONSE` variants, the post-auth burst) on top, and flips the switch.

Doing the restructure while the path is dormant is the point: it is provably zero-risk.

## What changed

**1. Extracted a callable decoder** — `MopAuthSession.{h,cpp}`, `MopAuth::DecodeAuthSession(ByteBuffer&, AuthSessionFields&)`. Production and the tests call the **same** function; the test does not contain a copy. Adds explicit bounds and typed `DecodeResult` codes for malformed input. `builtNumberClient` is `uint16_t` (the wire field is two bytes; enforced by `static_assert`).

**2. Structurally deferred Warden** — removed, not runtime-guarded. A false branch still *compiles* the `BigNumber`-based Warden consumer, keeping a fourth session-key consumer linked and hiding type errors Stage 2's raw-40 K migration needs the compiler to catch. Also removes the derived-key logging (`C->S Key` / `S->C Key`), which leaked secrets whenever Warden was enabled, and drops the now-unused `os` column from the account SELECT (it was the final column — no field index shifts).

This also deletes a latent bug: the Warden OS gate built `WorldPacket Packet(SMSG_AUTH_RESPONSE, 1)` and then called `SendPacket(packet)` — sending a *different, empty* local.

**3. Added an input-quiescing drain** — `MopSocketDrain.h` + `WorldSocket::BeginAuthErrorDrain`. Rejections now queue the response, quiesce input, and close only once the buffer has actually drained. All rejection paths funnel through one helper; `SendAuthResponseError` is gone, leaving exactly one `SMSG_AUTH_RESPONSE` construction site on the rejection path.

**4. Established a commit region** — atomic by **ordering**, not rollback. Every fallible operation (decode, validate, DB load, addon inflate, the legacy sleep) now precedes:

```cpp
m_Crypt.Init(&K);
m_connState = MopHs::CONN_AUTHED;
sWorld.AddSession(m_Session);
```

Nothing but comments sits between those three statements, so no failure is possible after the commit point and the invariant holds by construction. No rollback was added to `AuthCrypt` — that would exist only to paper over the ordering defect.

## Deliberately preserved, bug-for-bug

The decode is **moved, not fixed**. The legacy `ReadBits(11)` still has **no leading `ReadBit()`**, no `digest[]` scatter index is changed, and skipped body offset 28 remains uninterpreted. **These are Stage 2's to correct.** A refactor that also changed semantics would be unreviewable — when the live gate fails, you could not attribute it to structure vs. semantics.

Verified by mechanical extraction of both read sequences: **30/30 reads identical in order**, digest indices 0–19 each present exactly once, all seven `read_skip`s intact.

## Testing

- `ctest -C RelWithDebInfo -R "^mop_(framing|auth)$"` → **2/2**. `mop_auth` covers 14 decode vectors plus the drain decisions.
- `mangosd` builds clean (RelWithDebInfo).
- Assertions use the non-elidable `CHECK` pattern — RelWithDebInfo defines `/DNDEBUG`, so `assert()` would be **elided** and the tests would pass vacuously.
- Live smoke against a real 5.4.8.18414 client: handshake completes, 435-byte `CMSG_AUTH_SESSION` frames and parses, deliberate close. **0 malformed, 0 illegal-in-state.**
- `src/shared/` and `src/realmd/` diffs are **empty** — realmd and `BigNumber` are untouched.

**Honest coverage limits** (stated rather than papered over): the ACE drain wiring and the commit ordering have **no unit test**. `WorldSocket` is an `ACE_Svc_Handler` requiring a reactor and a peer; standing up that harness was out of scope. Both are verified by source review and will be exercised at Stage 2's live gate. The pure decision functions (`DecodeAuthSession`, `MayProcessInput`, `ShouldCloseNow`, `InputStatus`) are genuinely tested.

## ⚠️ CI note: the Codestyle check is red on master already

`apps/ci/ci-codestyle.sh` fails on **`master` (44a4c1c68)** — 19 tab-lines predating this branch:

- `src/game/Server/DBCStructure.h` (15)
- `src/game/WorldHandlers/World.cpp` (1)
- `src/tools/Extractor_projects/map-extractor/System.cpp` (3)

**Every file in this PR is clean** — zero tabs, zero trailing whitespace. The Codestyle failure is inherited, not introduced. Happy to fix it in a separate PR.

## Notes for Stage 2

- **`AuthCrypt::IsInitialized()` is a *ran-to-completion* flag, not a *succeeded* flag.** `_initialized = true` is set unconditionally, and `ARC4::Init` silently no-ops on an invalid EVP context (with no log at all). Since `IsInitialized()` is the **codec discriminator**, a silently-failed init would put **plaintext headers on the wire framed as `HDR_POSTCRYPT`**. Stage 2 must make init success observable **before** activation.
- The commit region's guarantee silently depends on `_initialized = true` remaining the **last** statement of `AuthCrypt::Init`. Stage 2 reworks that function for raw-40 K — it must not hoist the flag above the ARC4 setup or add an early return on a partial-init path. **No test covers this.**
- `WorldSession::InitWarden` still takes `BigNumber*` and now has **zero callers**, so the compiler will **not** flag it during the raw-40 migration. The rationale is inlined at the deferral comment.
- Four `sLog.outError` calls survive on rejection paths. Harmless while dormant; once live they are unbounded ERROR-level log amplification on an **unauthenticated** path. Deferred to a Stage 2 log-policy pass.
- "Exactly one `SMSG_AUTH_RESPONSE` construction site" is true only **within `WorldSocket.cpp`**. Repo-wide there are five — matching the spec's five emitters, which Stage 2 owns. This PR centralised the **rejection path only**.

## If squash-merging

`0142c0e79`'s body says the crypt init is "infallible **by signature**". That is the wrong reason — a `void` function can still throw (`BigNumber::AsByteArray` allocates). The real guarantee is that `_initialized = true` is the **last** statement of `AuthCrypt::Init`, so a mid-`Init` throw leaves the crypt inert. Worth correcting in the squash message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/13)
<!-- Reviewable:end -->
