### PR TITLE
MoP 5.4.8 login (Phase 3 Stage 2): auth semantics + the activation cutover — client reaches character-select

### DIFF
--- a/src/game/Server/MopAuthProof.cpp
+++ b/src/game/Server/MopAuthProof.cpp
@@ -1,0 +1,52 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "MopAuthProof.h"
+#include "Auth/Sha1.h"
+#include <openssl/crypto.h>
+#include <cstring>
+
+namespace MopAuth
+{
+    void ComputeAuthProof(const std::string& account, uint32 clientSeed, uint32 serverSeed,
+                          const uint8 (&K)[SESSION_KEY_LEN], uint8 out[AUTH_PROOF_LEN])
+    {
+        const uint32 zero = 0;
+
+        Sha1Hash sha;
+        sha.UpdateData(account);                                   // 1: strlen, no NUL
+        sha.UpdateData((const uint8*)&zero, 4);                    // 2: zero dword
+        sha.UpdateData((const uint8*)&clientSeed, 4);              // 3: clientSeed, raw LE
+        sha.UpdateData((const uint8*)&serverSeed, 4);              // 4: serverSeed, raw LE
+        sha.UpdateData(K, int(SESSION_KEY_LEN));                   // 5: K, 40 RAW -- never 39
+        sha.Finalize();
+
+        memcpy(out, sha.GetDigest(), AUTH_PROOF_LEN);
+    }
+
+    bool ProofEquals(const uint8* a, const uint8* b)
+    {
+        return CRYPTO_memcmp(a, b, AUTH_PROOF_LEN) == 0;
+    }
+}

--- a/src/game/Server/MopAuthProof.h
+++ b/src/game/Server/MopAuthProof.h
@@ -1,0 +1,73 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_MOPAUTHPROOF
+#define MANGOS_H_MOPAUTHPROOF
+
+#include "Common/Common.h"
+#include "Auth/MopAuthKey.h"
+#include <string>
+
+namespace MopAuth
+{
+    /** Length of the SHA-1 auth proof, in bytes. */
+    inline constexpr size_t AUTH_PROOF_LEN = 20;
+
+    /**
+     * @brief Computes the CMSG_AUTH_SESSION proof digest.
+     *
+     * CONFIRMED FROM THE CLIENT BINARY (sub_140A6F050 / sub_A5A684), spec 3.2: a SINGLE SHA1 over
+     * exactly five chunks, in order --
+     *   1. account name  strlen(), ASCII, NOT NUL-terminated
+     *   2. zero dword    4
+     *   3. clientSeed    4, raw little-endian
+     *   4. serverSeed    4, raw little-endian
+     *   5. K             40, RAW bytes
+     * Total hashed = strlen(account) + 52.
+     *
+     * There is NO de-interleave step: the client writes 20 contiguous bytes from one SHA1_Final.
+     * The scatter that spreads those 20 bytes across non-sequential body offsets is the client
+     * SERIALIZER's doing and belongs to the decoder (MopAuthSession.cpp), not here.
+     *
+     * K is taken as an array reference so the length is a compile-time fact: the client hashes 40
+     * and nothing else. Do NOT route this through Sha1Hash::UpdateBigNumbers -- it hashes
+     * GetNumBytes(), which is 39 on ~1/256 of logins, AND Sha1Hash is linked into realmd
+     * (AuthSocket.cpp:253/269/635), so it must not be changed to suit us.
+     */
+    void ComputeAuthProof(const std::string& account, uint32 clientSeed, uint32 serverSeed,
+                          const uint8 (&K)[SESSION_KEY_LEN], uint8 out[AUTH_PROOF_LEN]);
+
+    /**
+     * @brief Constant-time comparison of two 20-byte proofs.
+     *
+     * plain memcmp() short-circuits on the first differing byte, leaking how many leading bytes an
+     * attacker guessed right. OpenSSL is already a hard dependency and provides CRYPTO_memcmp; no
+     * constant-time helper existed in this tree.
+     *
+     * @return true when the proofs are equal.
+     */
+    bool ProofEquals(const uint8* a, const uint8* b);
+}
+
+#endif

--- a/src/game/Server/MopAuthResponse.cpp
+++ b/src/game/Server/MopAuthResponse.cpp
@@ -1,0 +1,173 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+// WorldPacket lives in src/shared/Utilities/, NOT src/game/Server/ -- match MopAuthSession.cpp's
+// "Utilities/ByteBuffer.h" idiom. Opcodes.h and SharedDefines.h are siblings of this file.
+#include "MopAuthResponse.h"
+#include "Utilities/WorldPacket.h"
+#include "Opcodes.h"
+#include "SharedDefines.h"
+#include "Log/Log.h"
+
+namespace
+{
+    struct ExpansionInfo
+    {
+        uint8 raceOrClass;
+        uint8 expansion;
+    };
+
+    // EXPANSION_* (SharedDefines.h:4263-4267): EXPANSION_NONE=0, EXPANSION_TBC=1, EXPANSION_WOTLK=2,
+    // EXPANSION_CATA=3, EXPANSION_MOP=4. (The plan's "CLASSIC/CATACLYSM/MISTS" spellings are
+    // SkyFire-derived and do not exist in this tree -- the values above are what is used.)
+    //
+    // GOTCHA: the bit section counts CLASS-then-RACE, but the payload is RACE-then-CLASS (see
+    // Build() below). Both loops here use { expansion, id } order -- the legacy class loop at
+    // WorldSession.cpp:1086-1087 wrote { id, expansion }, inconsistent with its own race loop;
+    // that inconsistency is the tell it was wrong.
+    const ExpansionInfo kClassExpansion[MAX_CLASSES - 1] =
+    {
+        { 1, 0 }, { 2, 0 }, { 3, 0 }, { 4, 0 }, { 5, 0 }, { 6, 2 },
+        { 7, 0 }, { 8, 0 }, { 9, 0 }, { 10, 4 }, { 11, 0 }
+    };
+
+    const ExpansionInfo kRaceExpansion[MAX_PLAYABLE_RACES] =
+    {
+        { 1, 0 }, { 2, 0 }, { 3, 0 }, { 4, 0 }, { 5, 0 }, { 6, 0 }, { 7, 0 }, { 8, 0 },
+        { 9, 3 }, { 10, 1 }, { 11, 1 }, { 22, 3 }, { 24, 4 }, { 25, 4 }, { 26, 4 }
+    };
+}
+
+namespace
+{
+    // The ONE serializer. Private to this TU: the three public entry points are the only way in,
+    // which is what makes "AUTH_OK always carries the account block" and "27 is never sent"
+    // structural rather than merely tested.
+    void Build(WorldPacket& out, uint8 code, bool queued, uint32 queuePos,
+               uint8 accountExpansion, uint8 serverExpansion)
+    {
+        const bool hasAccountData = (code == AUTH_OK);
+
+        out.Initialize(SMSG_AUTH_RESPONSE);
+
+        // ---- BIT SECTION (WriteBit packs MSB-first per byte; FlushBits zero-pads) --------------
+        out.WriteBit(hasAccountData);
+        if (hasAccountData)
+        {
+            out.WriteBits(0, 21);                   // realmCount -- no per-realm block emitted
+            out.WriteBits(MAX_CLASSES - 1, 23);     // classActivationCount
+            out.WriteBits(0, 21);                   // characterTemplateCount (none -> no template block)
+            out.WriteBit(0);                        // unknown
+            out.WriteBit(0);                        // unknown
+            out.WriteBit(0);                        // unknown
+            out.WriteBit(0);                        // unknown
+            out.WriteBits(MAX_PLAYABLE_RACES, 23);  // raceActivationCount
+            out.WriteBit(0);                        // unknown
+        }
+
+        out.WriteBit(queued);
+        if (queued)
+        {
+            out.WriteBit(0);                        // unknown queue-related bit
+        }
+
+        out.FlushBits();
+
+        // ---- BYTE SECTION ----------------------------------------------------------------------
+        if (queued)
+        {
+            out << uint32(queuePos);
+        }
+
+        if (hasAccountData)
+        {
+            // GOTCHA: the bit section counts CLASS-then-RACE, but the payload is RACE-then-CLASS.
+            for (uint8 i = 0; i < MAX_PLAYABLE_RACES; ++i)
+            {
+                out << uint8(kRaceExpansion[i].expansion);
+                out << uint8(kRaceExpansion[i].raceOrClass);
+            }
+
+            for (uint8 i = 0; i < MAX_CLASSES - 1; ++i)
+            {
+                out << uint8(kClassExpansion[i].expansion);
+                out << uint8(kClassExpansion[i].raceOrClass);
+            }
+
+            out << uint32(0);
+            out << uint8(accountExpansion);
+            out << uint32(0);                       // BillingTimeRemaining
+            out << uint32(0);                       // playtime
+            out << uint8(serverExpansion);
+            out << uint32(0);
+            out << uint32(0);
+            out << uint32(0);
+        }
+
+        out << uint8(code);                         // ALWAYS LAST
+    }
+}
+
+namespace MopAuth
+{
+    void BuildAuthResponseAccepted(WorldPacket& out, uint8 accountExpansion, uint8 serverExpansion)
+    {
+        Build(out, AUTH_OK, false, 0, accountExpansion, serverExpansion);
+    }
+
+    void BuildAuthResponseQueued(WorldPacket& out, uint32 queuePos, uint8 accountExpansion,
+                                 uint8 serverExpansion)
+    {
+        // A RELEASE is position 0, and it is BYTE-IDENTICAL to Accepted -- not a bare AUTH_OK.
+        // Routing it here rather than making callers remember keeps the rule in one place.
+        if (queuePos == 0)
+        {
+            BuildAuthResponseAccepted(out, accountExpansion, serverExpansion);
+            return;
+        }
+
+        Build(out, AUTH_OK, true, queuePos, accountExpansion, serverExpansion);
+    }
+
+    void BuildAuthResponseError(WorldPacket& out, uint8 code)
+    {
+        // Refuse the two codes that are wrong BY CONSTRUCTION on this path:
+        //   AUTH_OK (12) -- an "error" of 12 with no account block is rewritten by the client to 13
+        //     anyway (sub_140A70980), so it is a caller bug that would present as a mystery failure;
+        //   AUTH_WAIT_QUEUE (27) -- the client SYNTHESISES 27 from the queued bit. An emitted 27
+        //     lands in the != 12 path and delivers 27, i.e. failure by a confusing route. Four did
+        //     exactly this at WorldSessionMgr.cpp:248 and WorldSession.cpp:1008 before Stage 2.
+        // Coerce + log rather than silently pass: the client gets an honest failure and the operator
+        // gets told. This is what makes "never emits 27" a property of the SERIALIZER, testable
+        // without trusting any caller.
+        if (code == AUTH_OK || code == AUTH_WAIT_QUEUE)
+        {
+            sLog.outError("MopAuth::BuildAuthResponseError: refusing to emit code %u on the error "
+                          "path; sending AUTH_FAILED instead.", uint32(code));
+            code = AUTH_FAILED;
+        }
+
+        Build(out, code, false, 0, 0, 0);
+    }
+}

--- a/src/game/Server/MopAuthResponse.cpp
+++ b/src/game/Server/MopAuthResponse.cpp
@@ -43,9 +43,9 @@ namespace
     // SkyFire-derived and do not exist in this tree -- the values above are what is used.)
     //
     // GOTCHA: the bit section counts CLASS-then-RACE, but the payload is RACE-then-CLASS (see
-    // Build() below). Both loops here use { expansion, id } order -- the legacy class loop at
-    // WorldSession.cpp:1086-1087 wrote { id, expansion }, inconsistent with its own race loop;
-    // that inconsistency is the tell it was wrong.
+    // Build() below). Both loops here use { expansion, id } order -- the (now-deleted) legacy
+    // WorldSession::SendAuthResponse class loop wrote { id, expansion }, inconsistent with its
+    // own race loop; that inconsistency is the tell it was wrong.
     const ExpansionInfo kClassExpansion[MAX_CLASSES - 1] =
     {
         { 1, 0 }, { 2, 0 }, { 3, 0 }, { 4, 0 }, { 5, 0 }, { 6, 2 },

--- a/src/game/Server/MopAuthResponse.h
+++ b/src/game/Server/MopAuthResponse.h
@@ -1,0 +1,87 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_MOPAUTHRESPONSE
+#define MANGOS_H_MOPAUTHRESPONSE
+
+#include "Common/Common.h"
+
+class WorldPacket;
+
+namespace MopAuth
+{
+    /**
+     * @brief Builds SMSG_AUTH_RESPONSE -- the ONE canonical serializer for all five variants.
+     *
+     * | Variant       | code        | hasAccountData | queued | extra            |
+     * |---------------|-------------|----------------|--------|------------------|
+     * | ACCEPTED      | 12 AUTH_OK  | 1 + full block | 0      | --               |
+     * | INITIAL QUEUE | 12 AUTH_OK  | 1 + full block | 1      | queuePosition u32|
+     * | QUEUE UPDATE  | 12 AUTH_OK  | 1 + full block | 1      | queuePosition u32|
+     * | RELEASE (0)   | 12 AUTH_OK  | 1 + full block | 0      | --  (== ACCEPTED)|
+     * | ERROR         | != 12       | 0              | 0      | --               |
+     *
+     * THE RULE THAT MAKES THIS NON-OBVIOUS -- BINARY-CONFIRMED (sub_140A70980):
+     *   Every response with queued=0 MUST carry hasAccountData=1, or the client rewrites AUTH_OK
+     *   (12) into AUTH_FAILED (13) and delivers failure while the server believes it succeeded.
+     *   With queued=1 the queue branch overwrites that 13 with 27, MASKING the defect on every
+     *   update packet so it only bites on the RELEASE -- which is why SkyFire (PlayerLimit=100 by
+     *   default) never caught it. This builder always sets hasAccountData for AUTH_OK, so the rule
+     *   cannot be violated by a caller.
+     *
+     *   NEVER send code 27 (AUTH_WAIT_QUEUE) on the wire: the client SYNTHESISES it from the queued
+     *   bit. Sending 27 lands in the != 12 path and delivers 27 -- effectively a failure. Four did
+     *   this at WorldSessionMgr.cpp:248 and WorldSession.cpp:1008 before this serializer landed.
+     *   Callers pass AUTH_OK and queued=true; they never pass 27.
+     *
+     * [HYPOTHESIS -- SkyFire-derived; the SHAPE is corroborated by the client struct, the BIT ORDER
+     * IS NOT. The deserializer was not located; two independent tracks failed to find it. Settled
+     * at Gate 3b -- the client accepting this is what confirms it.]
+     *
+     * THREE ENTRY POINTS, DELIBERATELY. A single Build(code, queued, ...) leaves both binary-
+     * confirmed rules expressible-but-wrong: a caller can pass AUTH_OK with queued=0 and no account
+     * block (-> client rewrites 12 to 13), or pass 27 directly (-> client delivers failure). A test
+     * can only ever prove that THIS caller did not; it cannot prove the serializer refuses. So the
+     * shapes the protocol allows are the only shapes the API offers:
+     *   - Accepted / Queued force code = AUTH_OK and hasAccountData = 1. 27 is UNREPRESENTABLE.
+     *   - Error takes a code, and REJECTS both AUTH_OK and AUTH_WAIT_QUEUE at runtime.
+     *
+     * @param out              receives the packet; cleared first.
+     * @param accountExpansion the account's entitlement, already clamped to the realm
+     *                         (WorldSession::Expansion(); EXPANSION_NONE=0 .. EXPANSION_MOP=4).
+     * @param serverExpansion  the realm's configured cap (CONFIG_UINT32_EXPANSION).
+     */
+    void BuildAuthResponseAccepted(WorldPacket& out, uint8 accountExpansion, uint8 serverExpansion);
+
+    /// As Accepted, plus the queued bit and a position. code is AUTH_OK -- the client SYNTHESISES
+    /// its own 27 from the bit. @param queuePos 1-based; position 0 is a RELEASE, i.e. Accepted.
+    void BuildAuthResponseQueued(WorldPacket& out, uint32 queuePos, uint8 accountExpansion,
+                                 uint8 serverExpansion);
+
+    /// An AUTH_* failure. hasAccountData=0 is safe here: code != 12 never enters the client's
+    /// forcing branch. AUTH_OK and AUTH_WAIT_QUEUE are REJECTED (coerced to AUTH_FAILED + logged).
+    void BuildAuthResponseError(WorldPacket& out, uint8 code);
+}
+
+#endif

--- a/src/game/Server/MopAuthSession.cpp
+++ b/src/game/Server/MopAuthSession.cpp
@@ -108,15 +108,19 @@ namespace MopAuth
             // usable addon info", never "reject this login". The blob is passed through as-is and
             // ReadAddonsInfo applies its own bound at the point it actually inflates.
 
-            // ReadBits(11) consumes two bytes; require them explicitly rather than via a throw.
+            // The flag bit + the 11-bit length span two bytes; require them explicitly rather than
+            // via a throw.
             if (in.size() - in.rpos() < 2)
             {
                 return DecodeResult::ShortBody;
             }
 
-            // BUG-FOR-BUG: the legacy path issued ReadBits(11) with NO preceding ReadBit().
-            // That is wrong for a real 5.4.8 client, but correcting it is out of scope here;
-            // this extraction must not change behaviour for input the legacy code accepted.
+            // Spec 3.4: ONE flag bit, THEN an 11-bit length -- both MSB-first. The legacy path
+            // issued ReadBits(11) with no leading ReadBit(), which reads the wrong 11 bits: the
+            // gate2 capture's `00 D0` (strlen 13, flag 0) decodes to 6 that way and to 13 this way.
+            // Do NOT collapse this into a single ReadBits(12): equivalent only while the flag is 0,
+            // and it silently rejects a valid packet (length >= 2048) the moment it is ever 1.
+            parsed.useIPv6 = in.ReadBit() != 0;
             uint32_t const nameLength = in.ReadBits(11);
 
             // There is deliberately NO cap on nameLength, and no rejection of 0. The legacy path

--- a/src/game/Server/MopAuthSession.cpp
+++ b/src/game/Server/MopAuthSession.cpp
@@ -103,7 +103,7 @@ namespace MopAuth
 
             // The blob's self-described inflated size is deliberately NOT inspected here, and must
             // never decide authentication. The real consumer, WorldSession::ReadAddonsInfo
-            // (WorldSession.cpp:1329-1341), treats both out-of-range cases as benign: size 0 returns
+            // (WorldSession::ReadAddonsInfo), treats both out-of-range cases as benign: size 0 returns
             // immediately, and size > 0xFFFFF logs "addon info too big" and returns. Both mean "no
             // usable addon info", never "reject this login". The blob is passed through as-is and
             // ReadAddonsInfo applies its own bound at the point it actually inflates.

--- a/src/game/Server/MopAuthSession.h
+++ b/src/game/Server/MopAuthSession.h
@@ -45,7 +45,8 @@ class ByteBuffer;
  *
  * The digest[] scatter and the seven read_skips are NOT a legacy quirk and must not be "cleaned
  * up": they reproduce the client serializer's own permutation, binary-confirmed in both x86 and
- * x64 (facts/FACTS_mop548_digest_permutation.md 2). Body 23 is a constant 1 -- not digest[20] --
+ * x64 (facts/FACTS_mop548_digest_permutation.md 2; campaign research doc, not in this tree).
+ * Body 23 is a constant 1 -- not digest[20] --
  * and body 28 is an 8-byte field the server deliberately does NOT interpret (spec 3.3 trap 2:
  * [OPEN]; the facts doc's 5 still claims it must be echoed -- that claim was RETRACTED).
  *

--- a/src/game/Server/MopAuthSession.h
+++ b/src/game/Server/MopAuthSession.h
@@ -36,10 +36,18 @@ class ByteBuffer;
  * @brief Bounded decoder for the legacy CMSG_AUTH_SESSION body.
  *
  * This is a behaviour-preserving extraction of the inline reads that used to live in
- * WorldSocket::HandleAuthSession. The read/skip order and the digest[] scatter are
- * reproduced bug-for-bug on purpose: notably ReadBits(11) is issued with NO preceding
- * ReadBit(), which is wrong for a real 5.4.8 client but is what the legacy path did.
- * Correcting the wire semantics is deliberately out of scope here.
+ * WorldSocket::HandleAuthSession, EXCEPT for the name-length bit read, which Stage 2 corrected.
+ *
+ * The name-length block reads ONE flag bit then an 11-bit length (spec 3.4), which is what a real
+ * 5.4.8 client writes: the gate2 capture's `00 D0` decodes to flag=0, length=13 only under this
+ * reading. Stage 1 preserved the legacy ReadBits(11)-with-no-leading-ReadBit bug-for-bug while the
+ * handler was dormant; Stage 2 corrected it.
+ *
+ * The digest[] scatter and the seven read_skips are NOT a legacy quirk and must not be "cleaned
+ * up": they reproduce the client serializer's own permutation, binary-confirmed in both x86 and
+ * x64 (facts/FACTS_mop548_digest_permutation.md 2). Body 23 is a constant 1 -- not digest[20] --
+ * and body 28 is an 8-byte field the server deliberately does NOT interpret (spec 3.3 trap 2:
+ * [OPEN]; the facts doc's 5 still claims it must be echoed -- that claim was RETRACTED).
  *
  * The added value over the inline version is malformed-input safety: every read is
  * bounds-checked up front and the output is written atomically (only on Ok), so a
@@ -72,6 +80,7 @@ namespace MopAuth
         uint32_t addonSize;
         std::vector<uint8_t> addonData;
         std::string account;
+        bool useIPv6;               // body 420 flag bit; name inferred (TC), OFFSET confirmed
     };
 
     /**

--- a/src/game/Server/MopWireCodec.h
+++ b/src/game/Server/MopWireCodec.h
@@ -48,8 +48,10 @@ namespace MopWire
     /// "frame out of range" and returns -1 -- never silent). 536 values in Opcodes.h still exceed
     /// 0x1FFF (279 of them SMSG, e.g. SMSG_MESSAGECHAT = 0x2026) because they retain their 4.3.4
     /// values. This is UNREACHABLE for all of Phase 2 (crypt is never initialized, so postCrypt is
-    /// always false), but once Phase 3 calls m_Crypt.Init() those sends begin failing unless the
-    /// Phase 1b opcode-table migration has already remapped them into the 13-bit space.
+    /// always false), but as of the Phase 3 cutover -- once `AuthCrypt::Prepare()` /
+    /// `AuthCrypt::Activate()` have run for a session -- this is LIVE for every authenticated
+    /// send unless the Phase 1b opcode-table migration has already remapped the opcode into the
+    /// 13-bit space.
     inline bool BuildServerHeader(bool postCrypt, size_t payloadSize, uint32_t cmd, uint8_t out[4])
     {
         if (postCrypt)

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -65,6 +65,7 @@
 #include "SocialMgr.h"
 #include "Auth/AuthCrypt.h"
 #include "Auth/HMACSHA1.h"
+#include "Auth/MopAuthKey.h"
 #include "zlib.h"
 #ifdef ENABLE_ELUNA
 #include "LuaEngine.h"
@@ -1467,10 +1468,20 @@ void WorldSession::SendRedirectClient(std::string& ip, uint16 port)
 
     pkt << uint32(0);                                       // unknown
 
-    HMACSHA1 sha1(40, m_Socket->GetSessionKey().AsByteArray());
+    // GetSessionKey() returns m_s -- the SRP6 SALT, not K -- and AsByteArray() returns
+    // GetNumBytes() bytes while this asked for 40: a heap OVER-READ whenever the value is shorter.
+    // Both are fixed by using the canonical raw-40 K. (SendRedirectClient has ZERO call sites, so
+    // neither bug is live today; it is migrated because Phase 3 puts it on a reachable path and
+    // because leaving one BigNumber K consumer behind is how the short-K bug returns.)
+    HMACSHA1 sha1(uint32(MopAuth::SESSION_KEY_LEN), m_Socket->GetSessionKeyRaw());
     sha1.UpdateData((uint8*)&ip2, 4);
     sha1.UpdateData((uint8*)&port, 2);
     sha1.Finalize();
+    if (!sha1.IsValid())
+    {
+        sLog.outError("WorldSession::SendRedirectClient: HMAC-SHA1 failed; redirect not sent.");
+        return;
+    }
     pkt.append(sha1.GetDigest(), 20);                       // hmacsha1(ip+port) w/ sessionkey as seed
 
     SendPacket(&pkt);

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -195,6 +195,24 @@ WorldSession::~WorldSession()
     }
 }
 
+/// Release the session's extra socket reference without closing the socket.
+///
+/// Valid only before the session has been published to World: it balances the single
+/// sock->AddReference() taken by the constructor. m_Socket is nulled FIRST so ~WorldSession()
+/// skips its own CloseSocket()/RemoveReference() teardown -- the socket must stay alive to drain
+/// an auth error through it, and re-releasing here would over-release the reference.
+void WorldSession::AbandonUnpublishedSocket() noexcept
+{
+    if (!m_Socket)
+    {
+        return;
+    }
+
+    WorldSocket* socket = m_Socket;
+    m_Socket = NULL;                    // destructor must not CloseSocket() on the auth-error drain
+    socket->RemoveReference();          // release the AddReference() taken by the constructor
+}
+
 /**
  * @brief Logs an invalid client packet size for the current opcode.
  *

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -1016,8 +1016,9 @@ void WorldSession::SendAuthWaitQue(uint32 position)
     // (13); with queued=0 there is no queue branch to mask it, so the release was the one packet
     // where the defect actually bit.
     //
-    // Expansion() is the account's entitlement ALREADY CLAMPED to the realm (WorldSocket.cpp:1253);
-    // the config value is the realm's own cap. They differ only for a restricted account.
+    // Expansion() is the account's entitlement ALREADY CLAMPED to the realm (see
+    // WorldSocket::HandleAuthSession's expansion clamp); the config value is the realm's own cap.
+    // They differ only for a restricted account.
     // BuildAuthResponseQueued routes position 0 to Accepted itself, so the release rule lives in
     // the serializer rather than in every caller that has to remember it.
     WorldPacket packet;

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -66,6 +66,7 @@
 #include "Auth/AuthCrypt.h"
 #include "Auth/HMACSHA1.h"
 #include "Auth/MopAuthKey.h"
+#include "MopAuthResponse.h"
 #include "zlib.h"
 #ifdef ENABLE_ELUNA
 #include "LuaEngine.h"
@@ -992,117 +993,18 @@ void WorldSession::Handle_Deprecated(WorldPacket& recvPacket)
  */
 void WorldSession::SendAuthWaitQue(uint32 position)
 {
-    if (position == 0)
-    {
-        WorldPacket packet( SMSG_AUTH_RESPONSE, 2 );
-        packet.WriteBit(false);
-        packet.WriteBit(false);
-        packet << uint8(AUTH_OK);
-        SendPacket(&packet);
-    }
-    else
-    {
-        WorldPacket packet(SMSG_AUTH_RESPONSE, 1 + 4 + 1);
-        packet.WriteBit(false);
-        packet.WriteBit(true);
-        packet.WriteBit(false);
-        packet << uint8(AUTH_WAIT_QUEUE);
-        packet << uint32(position);
-        SendPacket(&packet);
-    }
-}
-struct ExpansionInfoStrunct
-{
-    uint8 raceOrClass;
-    uint8 expansion;
-};
-
-ExpansionInfoStrunct classExpansionInfo[MAX_CLASSES - 1] =
-{
-    { 1, 0 },
-    { 2, 0 },
-    { 3, 0 },
-    { 4, 0 },
-    { 5, 0 },
-    { 6, 2 },
-    { 7, 0 },
-    { 8, 0 },
-    { 9, 0 },
-    { 10, 4 },
-    { 11, 0 }
-};
-
-ExpansionInfoStrunct raceExpansionInfo[MAX_PLAYABLE_RACES] =
-{
-    { 1, 0 },
-    { 2, 0 },
-    { 3, 0 },
-    { 4, 0 },
-    { 5, 0 },
-    { 6, 0 },
-    { 7, 0 },
-    { 8, 0 },
-    { 9, 3 },
-    { 10, 1 },
-    { 11, 1 },
-    { 22, 3 },
-    { 24, 4 },
-    { 25, 4 },
-    { 26, 4 }
-};
-
-void WorldSession::SendAuthResponse(uint8 code, bool queued, uint32 queuePos)
-{
-    bool hasAccountData = true;
-
-    WorldPacket packet(SMSG_AUTH_RESPONSE, 1 /*bits*/ + 4 + 1 + 4 + 1 + 4 + 1 + 1 + (queued ? 4 : 0));
-    packet << uint8(code);
-    packet.WriteBit(queued);                            // IsInQueue
-    if (queued)
-    {
-        packet.WriteBit(1);                             // unk
-    }
-
-    packet.WriteBit(hasAccountData);
-
-    if (hasAccountData)
-    {
-        packet.WriteBits(MAX_CLASSES - 1, 23);
-        packet.WriteBits(0, 21);
-        packet.WriteBit(0);
-        packet.WriteBit(0);
-        packet.WriteBit(0);
-        packet.WriteBit(0);
-        packet.WriteBits(MAX_PLAYABLE_RACES, 23);
-        packet.WriteBit(0);
-
-        for (uint8 i = 0; i < MAX_PLAYABLE_RACES; ++i)
-        {
-            packet << uint8(raceExpansionInfo[i].expansion);
-            packet << uint8(raceExpansionInfo[i].raceOrClass);
-        }
-
-        for (uint8 i = 0; i < MAX_CLASSES - 1; ++i)
-        {
-            packet << uint8(classExpansionInfo[i].raceOrClass);
-            packet << uint8(classExpansionInfo[i].expansion);
-        }
-
-        packet << uint32(0);
-        packet << uint8(Expansion());
-        packet << uint32(Expansion());
-        packet << uint32(0);
-        packet << uint8(Expansion());
-        packet << uint32(0);
-        packet << uint32(0);
-        packet << uint32(0);
-    }
-
-    if (queued)
-    {
-        packet << uint32(queuePos);
-    }
-
+    // position 0 is the RELEASE, and it is BYTE-IDENTICAL to ACCEPTED -- not a bare AUTH_OK.
+    // The old code sent AUTH_OK with hasAccountData=0, which the client rewrites to AUTH_FAILED
+    // (13); with queued=0 there is no queue branch to mask it, so the release was the one packet
+    // where the defect actually bit.
+    //
+    // Expansion() is the account's entitlement ALREADY CLAMPED to the realm (WorldSocket.cpp:1253);
+    // the config value is the realm's own cap. They differ only for a restricted account.
+    // BuildAuthResponseQueued routes position 0 to Accepted itself, so the release rule lives in
+    // the serializer rather than in every caller that has to remember it.
+    WorldPacket packet;
+    MopAuth::BuildAuthResponseQueued(packet, position, Expansion(),
+                                     uint8(sWorld.getConfig(CONFIG_UINT32_EXPANSION)));
     SendPacket(&packet);
 }
 

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -447,7 +447,6 @@ class WorldSession
         void SendNameQueryOpcode(Player* p);
         void SendNameQueryOpcodeFromDB(ObjectGuid guid);
         static void SendNameQueryOpcodeFromDBCallBack(QueryResult* result, uint32 accountId);
-        void SendAuthResponse(uint8 code, bool queued, uint32 queuePos = 0);
 
         void SendTrainerList(ObjectGuid guid);
         void SendTrainerList(ObjectGuid guid, const std::string& strTitle);

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -1086,6 +1086,12 @@ class WorldSession
 
         void HandleLoadScreenOpcode(WorldPacket& recvPacket);
     private:
+        friend class WorldSocket;
+
+        /// Release the session's extra socket reference without closing the socket. Valid only
+        /// before the session has been published to World.
+        void AbandonUnpublishedSocket() noexcept;
+
         // private trade methods
         void moveItems(Item* myItems[], Item* hisItems[]);
         bool VerifyMovementInfo(MovementInfo const& movementInfo, ObjectGuid const& guid) const;

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -441,7 +441,7 @@ class WorldSession
 
         bool Update(PacketFilter& updater);
 
-        /// Handle the authentication waiting queue (to be completed)
+        /// Sends SMSG_AUTH_RESPONSE for the login queue (see MopAuthResponse.h).
         void SendAuthWaitQue(uint32 position);
 
         void SendNameQueryOpcode(Player* p);

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -62,6 +62,7 @@
 #include "MopWireCodec.h"
 #include "MopAuthSession.h"
 #include "MopAuthProof.h"
+#include "MopAuthResponse.h"
 
 #include "Util.h"
 #include "World.h"
@@ -474,11 +475,9 @@ int WorldSocket::BeginAuthErrorDrain(uint8 code)
         return -1;                                            // nothing queued yet
     }
 
-    // 3. Construct the legacy error response (unchanged wire shape).
-    WorldPacket packet(SMSG_AUTH_RESPONSE, 1);
-    packet.WriteBit(0); // has account info
-    packet.WriteBit(0); // has queue info
-    packet << uint8(code);
+    // 3. Construct the error response via the canonical serializer (unchanged wire shape).
+    WorldPacket packet;
+    MopAuth::BuildAuthResponseError(packet, code);
 
     // 4. Queue it. If it never reached the buffer there is nothing to drain, so close now.
     bool sent = false;

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -56,6 +56,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <exception>
 
 #include "WorldSocket.h"
 #include "Common.h"
@@ -1175,6 +1176,42 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
 }
 
 /**
+ * @brief Tears down a WorldSession allocated but never published to World.
+ *
+ * The single cleanup path for every post-allocation rejection in HandleAuthSession.
+ * AbandonUnpublishedSocket() nulls the session's m_Socket before this deletes it, so
+ * ~WorldSession() does NOT CloseSocket() the socket we are still draining an auth error through,
+ * and it releases exactly the one extra reference the WorldSession constructor took.
+ */
+void WorldSocket::DestroyUnpublishedSession() noexcept
+{
+    if (!m_Session)
+    {
+        return;
+    }
+
+    m_Session->AbandonUnpublishedSocket();
+    delete m_Session;
+    m_Session = NULL;
+}
+
+/**
+ * @brief Infallible auth commit run by World::AddSession under the add-queue lock.
+ *
+ * Activates the prepared crypt (PREPARED -> ACTIVE, a single state store that cannot fail) and
+ * stores CONN_AUTHED. Runs while the queue lock is held and the queued session is not yet visible
+ * to the world thread; unlocking after this returns is the publication point. Must stay noexcept.
+ *
+ * @param context The originating WorldSocket, passed opaque through AddSession.
+ */
+void WorldSocket::CommitAuthenticatedSession(void* context) noexcept
+{
+    WorldSocket* socket = static_cast<WorldSocket*>(context);
+    socket->m_Crypt.Activate();
+    socket->m_connState = MopHs::CONN_AUTHED;
+}
+
+/**
  * @brief Authenticates a new client session and creates the world session.
  *
  * @param recvPacket The authentication packet.
@@ -1433,31 +1470,70 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // entered nothing below it can fail, so no failure path can observe an initialised crypt on an
     // unauthenticated session. AuthCrypt has no rollback and deliberately does not gain one --
     // rollback would exist only to paper over the ordering defect this reorder removes.
-    m_Session->LoadGlobalAccountData();
-    m_Session->LoadTutorialsData();
-    m_Session->ReadAddonsInfo(addonsData);
+    //
+    // ReadAddonsInfo inflates attacker-controlled zlib and CAN throw ByteBufferException. Without
+    // this local catch the outer ProcessIncoming ByteBufferException handler would close the socket
+    // while handle_close() only nulls m_Session, leaking the freshly allocated session. Every catch
+    // routes through the single DestroyUnpublishedSession() path and drains an error. Never log
+    // addon bytes.
+    try
+    {
+        m_Session->LoadGlobalAccountData();
+        m_Session->LoadTutorialsData();
+        m_Session->ReadAddonsInfo(addonsData);
+    }
+    catch (ByteBufferException const&)
+    {
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session "
+                      "(malformed addon data for account %u).", id);
+        DestroyUnpublishedSession();
+        return BeginAuthErrorDrain(AUTH_FAILED);
+    }
+    catch (std::exception const& e)
+    {
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session "
+                      "(session load failed for account %u: %s).", id, e.what());
+        DestroyUnpublishedSession();
+        return BeginAuthErrorDrain(AUTH_SYSTEM_ERROR);
+    }
+    catch (...)
+    {
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session "
+                      "(unknown session-load failure for account %u).", id);
+        DestroyUnpublishedSession();
+        return BeginAuthErrorDrain(AUTH_SYSTEM_ERROR);
+    }
 
     // In case needed sometime the second arg is in microseconds 1 000 000 = 1 sec
     // Legacy delay, semantics unchanged; hoisted above the commit region because a delay may not
     // appear between the three commit statements.
     ACE_OS::sleep(ACE_Time_Value(0, 10000));
 
-    // ================ COMMIT REGION ================
+    // ================= AUTH PUBLICATION TRANSACTION =================
     // Everything fallible already ran ABOVE: crypt Prepare() (HMAC, ARC4 keying, drop-1024), the
-    // session allocation, the DB loads and the addon inflate. Activate() is the ONLY
-    // PREPARED->ACTIVE transition and is infallible -- a single state store. It publishes the
-    // prepared crypt: from here IsInitialized() is true, so the wire codec frames POST-crypt.
-    // Because success is now observable (Prepare returned true above), this is no longer merely a
-    // SOURCE-ordering guarantee as it was in Stage 1 -- a silently failed init cannot reach here.
+    // session allocation, the DB loads and the addon inflate. World::AddSession now performs the
+    // ONLY remaining fallible operation -- queue insertion -- while its lock is held. Only after
+    // that succeeds does it invoke CommitAuthenticatedSession(), still under the lock, so the world
+    // thread cannot observe the queued session until crypt and state are committed. Unlock is the
+    // publication point:
+    //   reserve queue node (locked) -> crypt ACTIVE -> CONN_AUTHED -> unlock/publish.
+    // Activate() is the ONLY PREPARED->ACTIVE transition and is infallible -- a single state store.
     //
-    // INTERMEDIATE STATE (Task 3): sWorld.AddSession below is still the old one-arg fallible call,
-    // so this region is NOT yet cutover-ready. Task 8 replaces it with the queue-lock publication
-    // transaction (reserve node locked -> Activate -> CONN_AUTHED -> unlock/publish). The handler
-    // is dormant (zero call sites) until Task 9, so this intermediate ordering is unreachable.
-    m_Crypt.Activate();
-    m_connState = MopHs::CONN_AUTHED;
-    sWorld.AddSession(m_Session);
+    // On false the callback did not run: crypt remains PREPARED/inert, state remains
+    // CONN_AUTHENTICATING, and the queue is unchanged. DestroyUnpublishedSession releases the
+    // session's extra socket reference without closing this socket, allowing the auth error to
+    // drain normally.
+    if (!sWorld.AddSession(m_Session, &WorldSocket::CommitAuthenticatedSession, this))
+    {
+        DestroyUnpublishedSession();
+        return BeginAuthErrorDrain(AUTH_SYSTEM_ERROR);
+    }
 
+    // GATE 3b EVIDENCE. AddSession returned only after unlocking, so the queue entry is now visible
+    // and crypt/state were committed before publication. This does NOT claim AddSession_ has already
+    // inserted into m_sessions or sent SMSG_AUTH_RESPONSE; those happen on the world thread.
+    DEBUG_LOG("WorldSocket::HandleAuthSession: account %u CONN_AUTHED "
+              "(crypt activated, session enqueue published).", id);
     return 0;
 }
 

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -106,6 +106,9 @@ WorldSocket::WorldSocket(void) :
 {
     reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
 
+    // Canonical raw-40 session key: populated by HandleAuthSession via MopAuth::SessionKeyFromHex.
+    memset(m_sessionKey, 0, sizeof(m_sessionKey));
+
     msg_queue()->high_water_mark(8 * 1024 * 1024);
     msg_queue()->low_water_mark(8 * 1024 * 1024);
 }
@@ -222,9 +225,14 @@ int WorldSocket::SendPacket(const WorldPacket& pct, bool* sent)
                       pct.size(), pct.GetOpcode(), int(postCrypt));
         return -1;
     }
-    if (postCrypt)
+    if (postCrypt && !m_Crypt.EncryptSend(header, sizeof(header)))
     {
-        m_Crypt.EncryptSend(header, sizeof(header));
+        // The header is UNDEFINED on an EVP failure: in-place processing may have partially written
+        // it. Dropping the packet is the only safe answer; the socket closes rather than transmit
+        // plaintext or garbage under a post-crypt frame.
+        sLog.outError("WorldSocket::SendPacket: header encryption failed (opcode 0x%.4X); closing.",
+                      pct.GetOpcode());
+        return -1;
     }
 
     if (m_OutBuffer->space() >= pct.size() + sizeof(header) && msg_queue()->is_empty())
@@ -930,8 +938,19 @@ int WorldSocket::handle_input_missing_data(void)
 /// MopFrameReader::DecryptFn hook (Phase 2 wire framing): in-place ARC4 on the header only.
 bool WorldSocket::DecryptHeaderHook(void* ctx, uint8* header, size_t len)
 {
-    static_cast<WorldSocket*>(ctx)->m_Crypt.DecryptRecv(header, len);
-    return true;   // no-op pre-crypt (m_Crypt.DecryptRecv() is itself a no-op before Init())
+    WorldSocket* const self = static_cast<WorldSocket*>(ctx);
+
+    // Pre-crypt frames are not decrypted at all -- the reader must not treat that as a failure.
+    // AuthCrypt::DecryptRecv returns false when not ACTIVE, which is the pre-crypt case, so the
+    // question has to be asked HERE rather than inferred from the return value.
+    if (!self->m_Crypt.IsInitialized())
+    {
+        return true;
+    }
+
+    // Post-crypt: a false return means the header is UNDECRYPTED, so parsing it would read garbage.
+    // Reject the frame (MF_DECRYPT) instead of guessing.
+    return self->m_Crypt.DecryptRecv(header, len);
 }
 
 /// MopFrameReader::CmdValidFn hook (Phase 2 wire framing): game rule; false rejects the frame.
@@ -1171,7 +1190,7 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     LocaleConstant locale;
     std::string account;
     Sha1Hash sha1;
-    BigNumber v, s, g, N, K;
+    BigNumber v, s, g, N;
 
     // Read the content of the packet.
     // The read order, the scattered digest[] indices and the missing leading ReadBit() before
@@ -1287,7 +1306,35 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
         security = SEC_ADMINISTRATOR;
     }
 
-    K.SetHexStr(fields[2].GetString());
+    // ---- Ladder step 1 (spec 5.1): guard the sessionkey with its own distinct log line. -------
+    // Until now K.SetHexStr(fields[2].GetString()) ran UNGUARDED: a NULL or empty value yields a
+    // garbage BigNumber and an AUTH_FAILED indistinguishable from a wrong seed, a wrong
+    // permutation, or a byte-reversed K. Naming the cause is the whole point.
+    //
+    // VALIDATE STRUCTURALLY -- NEVER BRANCH ON A SPECIFIC LENGTH. realmd stores K via AsHexStr()
+    // (= BN_bn2hex), which DROPS LEADING ZERO BYTES: one leading zero gives 78 hex chars, two give
+    // 76, and so on with NO floor. Rule: non-NULL, non-empty, hex-only, EVEN length, <= 80 ->
+    // convert -> assert the CONVERTED value is 1..40 bytes. "" is vacuously hex-only, even (0) and
+    // <= 80, and would zero-fill into forty 0x00s -- a K of zeros that looks well-formed to every
+    // consumer downstream; that confounder is precisely what this guard catches, so empty is a
+    // HARD REJECT.
+    const char* const sessionKeyHex = fields[2].GetString();
+
+    // ONE call owns the whole chain: validate -> BigNumber -> raw-40 -> re-check. Do NOT
+    // re-implement any of it here. SessionKeyFromHex is covered end-to-end by
+    // test_sessionkey_from_hex_roundtrip, which drives realmd's own SetBinary/AsHexStr write path.
+    // sessionKeyHex points INTO the query result, so this must run BEFORE any `delete result`.
+    if (!MopAuth::SessionKeyFromHex(sessionKeyHex, m_sessionKey))
+    {
+        delete result;                                        // 'fields' dies with it -- see below
+        // Payload-free by construction: the account id only, never the key text. `id` is a LOCAL
+        // copy taken above, so it survives the delete; fields[] does NOT.
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session "
+                      "(account %u has a NULL, empty or malformed sessionkey; realmd may not have "
+                      "authenticated this account yet).",
+                      id);
+        return BeginAuthErrorDrain(AUTH_SESSION_EXPIRED);
+    }
 
     time_t mutetime = time_t (fields[8].GetUInt64());
 
@@ -1351,13 +1398,31 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     sha.UpdateData((uint8*) & t, 4);
     sha.UpdateData((uint8*) & clientSeed, 4);
     sha.UpdateData((uint8*) & seed, 4);
-    sha.UpdateBigNumbers(&K, NULL);
+    // Task 3 bridge: hash the canonical raw-40 K (not a BigNumber). This is exactly what Task 4's
+    // MopAuth::ComputeAuthProof will formalize; it also fixes the short-K bug (UpdateBigNumbers
+    // hashed GetNumBytes(), which is 39 on ~1/256 of logins). Removing the last BigNumber K
+    // consumer here is what lets the K local be dropped.
+    sha.UpdateData(m_sessionKey, int(MopAuth::SESSION_KEY_LEN));
     sha.Finalize();
 
     if (memcmp(sha.GetDigest(), digest, 20))
     {
         sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (authentication failed).");
         return BeginAuthErrorDrain(AUTH_FAILED);
+    }
+
+    // ---- Crypt: PREPARE here, ACTIVATE in the commit region. --------------------------------
+    // Everything about the crypt that can fail happens HERE: the HMAC-SHA1 key derivation, both
+    // ARC4 keyings, and the 1024-byte drop. All of it precedes ACE_NEW_RETURN, so a failure has
+    // nothing allocated to clean up and can simply drain an error like every other rejection in
+    // this function. Prepare() does NOT publish: IsInitialized() stays false until Activate(), so
+    // the crypt is inert and the wire codec still frames PRE-crypt through the fallible loads below.
+    if (!m_Crypt.Prepare(m_sessionKey))
+    {
+        // Payload-free: no K, no digest. Prepare has already logged the specific OpenSSL cause.
+        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session "
+                      "(crypt could not be prepared for account %u).", id);
+        return BeginAuthErrorDrain(AUTH_SYSTEM_ERROR);
     }
 
     std::string address = GetRemoteAddress();
@@ -1393,34 +1458,19 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // appear between the three commit statements.
     ACE_OS::sleep(ACE_Time_Value(0, 10000));
 
-    // ================ COMMIT REGION -- no program failure path exists below ================
-    // Exactly three statements, in this order, with nothing between them: no log, no packet send,
-    // no validation, no branch, no delay, no allocation, no early return. Publication ends the
-    // region. The claim is precise: no early return, no explicit failure and no fallible call
-    // appears below the commit point -- NOT that no exception can be thrown here.
+    // ================ COMMIT REGION ================
+    // Everything fallible already ran ABOVE: crypt Prepare() (HMAC, ARC4 keying, drop-1024), the
+    // session allocation, the DB loads and the addon inflate. Activate() is the ONLY
+    // PREPARED->ACTIVE transition and is infallible -- a single state store. It publishes the
+    // prepared crypt: from here IsInitialized() is true, so the wire codec frames POST-crypt.
+    // Because success is now observable (Prepare returned true above), this is no longer merely a
+    // SOURCE-ordering guarantee as it was in Stage 1 -- a silently failed init cannot reach here.
     //
-    // A throw IS possible: m_Crypt.Init(&K) -> HMACSHA1::ComputeHash -> BigNumber::AsByteArray
-    // does new uint8[length] and can throw std::bad_alloc inside this region's FIRST statement.
-    // The invariant survives it for two reasons, both of which live in AuthCrypt::Init:
-    //   (a) _initialized = true is the LAST statement of AuthCrypt::Init (AuthCrypt.cpp:71), and
-    //       DecryptRecv/EncryptSend early-return on !_initialized -- so a mid-Init throw leaves
-    //       the crypt inert, not half-keyed.
-    //   (b) both throw sites precede _clientDecrypt.Init/_serverEncrypt.Init (AuthCrypt.cpp:55-56),
-    //       so a throw also leaves the ARC4 contexts un-keyed.
-    // A bad_alloc therefore unwinds past an unauthenticated, non-crypting session -- the same
-    // outcome as an ordinary early return.
-    //
-    // WARNING TO STAGE 2: that guarantee is SILENT and structural. Stage 2 reworks AuthCrypt::Init
-    // for the raw-40 K migration; this region's correctness depends on _initialized = true staying
-    // the last statement of Init. It must not be hoisted above the ARC4 setup, and no early return
-    // may be added on a partial-init path -- either change turns a throw here into a half-keyed
-    // crypt on an unauthenticated session, silently. NO TEST COVERS THIS.
-    //
-    // LIMITATION (Stage 1 scope): AuthCrypt::Init is void and does NOT report OpenSSL failure, so
-    // this proves SOURCE ORDERING only -- it cannot prove initialisation SUCCEEDED. Stage 2 owns
-    // making init success observable during its atomic raw-40 K migration, before activation.
-    // Do not read this region as a proof of cryptographic atomicity.
-    m_Crypt.Init(&K);
+    // INTERMEDIATE STATE (Task 3): sWorld.AddSession below is still the old one-arg fallible call,
+    // so this region is NOT yet cutover-ready. Task 8 replaces it with the queue-lock publication
+    // transaction (reserve node locked -> Activate -> CONN_AUTHED -> unlock/publish). The handler
+    // is dormant (zero call sites) until Task 9, so this intermediate ordering is unreachable.
+    m_Crypt.Activate();
     m_connState = MopHs::CONN_AUTHED;
     sWorld.AddSession(m_Session);
 

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -61,6 +61,7 @@
 #include "Common.h"
 #include "MopWireCodec.h"
 #include "MopAuthSession.h"
+#include "MopAuthProof.h"
 
 #include "Util.h"
 #include "World.h"
@@ -1189,7 +1190,6 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     uint8 expansion = 0;
     LocaleConstant locale;
     std::string account;
-    Sha1Hash sha1;
     BigNumber v, s, g, N;
 
     // Read the content of the packet.
@@ -1388,24 +1388,13 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     //    first encrypted server packet -- ahead of SMSG_AUTH_RESPONSE. Re-enabling must decide
     //    that ordering deliberately rather than inherit it.
 
-    // Check that Key and account name are the same on client and server
-    Sha1Hash sha;
+    // Check that Key and account name are the same on client and server (spec 3.2).
+    uint8 serverProof[MopAuth::AUTH_PROOF_LEN];
+    MopAuth::ComputeAuthProof(account, clientSeed, m_Seed, m_sessionKey, serverProof);
 
-    uint32 t = 0;
-    uint32 seed = m_Seed;
-
-    sha.UpdateData(account);
-    sha.UpdateData((uint8*) & t, 4);
-    sha.UpdateData((uint8*) & clientSeed, 4);
-    sha.UpdateData((uint8*) & seed, 4);
-    // Task 3 bridge: hash the canonical raw-40 K (not a BigNumber). This is exactly what Task 4's
-    // MopAuth::ComputeAuthProof will formalize; it also fixes the short-K bug (UpdateBigNumbers
-    // hashed GetNumBytes(), which is 39 on ~1/256 of logins). Removing the last BigNumber K
-    // consumer here is what lets the K local be dropped.
-    sha.UpdateData(m_sessionKey, int(MopAuth::SESSION_KEY_LEN));
-    sha.Finalize();
-
-    if (memcmp(sha.GetDigest(), digest, 20))
+    // CRYPTO_memcmp, not memcmp: a short-circuiting compare leaks how many leading proof bytes an
+    // attacker guessed right, one online attempt at a time.
+    if (!MopAuth::ProofEquals(serverProof, digest))
     {
         sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (authentication failed).");
         return BeginAuthErrorDrain(AUTH_FAILED);

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -1190,7 +1190,6 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     uint8 expansion = 0;
     LocaleConstant locale;
     std::string account;
-    BigNumber v, s, g, N;
 
     // Read the content of the packet.
     // The read order, the scattered digest[] indices and the missing leading ReadBit() before
@@ -1225,17 +1224,17 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
         addonsData.append(authFields.addonData.data(), authFields.addonData.size());
     }
 
-    DEBUG_LOG("WorldSocket::HandleAuthSession: client build %u, account %s, clientseed %X",
-              BuiltNumberClient,
-              account.c_str(),
-              clientSeed);
+    DEBUG_LOG("WorldSocket::HandleAuthSession: client build %u.", BuiltNumberClient);
 
     // Check the version of client trying to connect
     if (!IsAcceptableClientBuild(BuiltNumberClient))
     {
         // Claims only the decision, not the delivery: BeginAuthErrorDrain can return -1 having sent
         // nothing, and it reports the actual send outcome itself. Keep payload-free.
-        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (version mismatch).");
+        // BASIC_LOG, not sLog.outError: operator-actionable and low volume (a version mismatch
+        // means a client/server build skew, not an attacker), so it belongs at default log level
+        // rather than error level.
+        BASIC_LOG("WorldSocket::HandleAuthSession: rejecting auth session (version mismatch).");
         return BeginAuthErrorDrain(AUTH_VERSION_MISMATCH);
     }
 
@@ -1244,6 +1243,12 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     LoginDatabase.escape_string(safe_account);
     // No SQL injection, username escaped.
 
+    // ACCEPTED RISK, scoped precisely (spec 2): the account name is a query parameter, so it
+    // reaches the DB layer's SQL log whenever SQL logging is enabled. That logging is config-gated,
+    // OFF by default, pre-existing, and lives in code SHARED WITH REALMD -- Phase 3 cannot suppress
+    // it without violating "never touch realmd". Account name only, SQL layer only, opt-in only.
+    // NO exception exists for K, the proof, s or v: none of them is a query parameter, and after
+    // this task v and s are not even SELECTed.
     QueryResult* result =
         LoginDatabase.PQuery("SELECT "
                              "`id`, "                      // 0
@@ -1251,11 +1256,9 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
                              "`sessionkey`, "              // 2
                              "`last_ip`, "                 // 3
                              "`locked`, "                  // 4
-                             "`v`, "                       // 5
-                             "`s`, "                       // 6
-                             "`expansion`, "               // 7
-                             "`mutetime`, "                // 8
-                             "`locale` "                   // 9
+                             "`expansion`, "               // 5  (was 7)
+                             "`mutetime`, "                // 6  (was 8)
+                             "`locale` "                   // 7  (was 9)
                              "FROM `account` "
                              "WHERE `username` = '%s'",
                              safe_account.c_str());
@@ -1263,30 +1266,16 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // Stop if the account is not found
     if (!result)
     {
-        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (unknown account).");
+        // DEBUG_LOG, not sLog.outError: attacker-driven volume on an unauthenticated path -- a
+        // typo'd or scanned username is not an operator event and must not drive unbounded
+        // error-level disk writes.
+        DEBUG_LOG("WorldSocket::HandleAuthSession: rejecting auth session (unknown account).");
         return BeginAuthErrorDrain(AUTH_UNKNOWN_ACCOUNT);
     }
 
     Field* fields = result->Fetch();
 
-    expansion = ((sWorld.getConfig(CONFIG_UINT32_EXPANSION) > fields[7].GetUInt8()) ? fields[7].GetUInt8() : sWorld.getConfig(CONFIG_UINT32_EXPANSION));
-
-    N.SetHexStr("894B645E89E1535BBDAD5B8B290650530801B18EBFBF5E8FAB3C82872A3E9BB7");
-    g.SetDword(7);
-
-    v.SetHexStr(fields[5].GetString());
-    s.SetHexStr(fields[6].GetString());
-    m_s = s;
-
-    const char* sStr = s.AsHexStr();                        // Must be freed by OPENSSL_free()
-    const char* vStr = v.AsHexStr();                        // Must be freed by OPENSSL_free()
-
-    DEBUG_LOG("WorldSocket::HandleAuthSession: (s,v) check s: %s v: %s",
-              sStr,
-              vStr);
-
-    OPENSSL_free((void*) sStr);
-    OPENSSL_free((void*) vStr);
+    expansion = ((sWorld.getConfig(CONFIG_UINT32_EXPANSION) > fields[5].GetUInt8()) ? fields[5].GetUInt8() : sWorld.getConfig(CONFIG_UINT32_EXPANSION));
 
     ///- Re-check ip locking (same check as in realmd).
     if (fields[4].GetUInt8() == 1)  // if ip is locked
@@ -1329,16 +1318,19 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
         delete result;                                        // 'fields' dies with it -- see below
         // Payload-free by construction: the account id only, never the key text. `id` is a LOCAL
         // copy taken above, so it survives the delete; fields[] does NOT.
-        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session "
-                      "(account %u has a NULL, empty or malformed sessionkey; realmd may not have "
-                      "authenticated this account yet).",
-                      id);
+        // BASIC_LOG, not sLog.outError: ladder step 1 (spec 5.1) must stay visible at default log
+        // level -- it is the gate's first question, and demoting it below default would hide the
+        // most common ordering mistake (HandleAuthSession racing realmd's own auth write).
+        BASIC_LOG("WorldSocket::HandleAuthSession: rejecting auth session "
+                  "(account %u has a NULL, empty or malformed sessionkey; realmd may not have "
+                  "authenticated this account yet).",
+                  id);
         return BeginAuthErrorDrain(AUTH_SESSION_EXPIRED);
     }
 
-    time_t mutetime = time_t (fields[8].GetUInt64());
+    time_t mutetime = time_t (fields[6].GetUInt64());
 
-    locale = LocaleConstant(fields[9].GetUInt8());
+    locale = LocaleConstant(fields[7].GetUInt8());
     if (locale >= MAX_LOCALE)
     {
         locale = LOCALE_enUS;
@@ -1357,7 +1349,9 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     {
         delete banresult;
 
-        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (account banned).");
+        // BASIC_LOG, not sLog.outError: operator-actionable and bounded by the size of the ban
+        // list, so it belongs at default log level rather than error level.
+        BASIC_LOG("WorldSocket::HandleAuthSession: rejecting auth session (account banned).");
         return BeginAuthErrorDrain(AUTH_BANNED);
     }
 
@@ -1396,7 +1390,10 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     // attacker guessed right, one online attempt at a time.
     if (!MopAuth::ProofEquals(serverProof, digest))
     {
-        sLog.outError("WorldSocket::HandleAuthSession: rejecting auth session (authentication failed).");
+        // DEBUG_LOG, not sLog.outError: this is the credential-spray path -- an attacker driving
+        // wrong-password attempts against valid or invalid usernames alike hits this rejection on
+        // every try, so at error level that traffic drives unbounded error-level disk writes.
+        DEBUG_LOG("WorldSocket::HandleAuthSession: rejecting auth session (authentication failed).");
         return BeginAuthErrorDrain(AUTH_FAILED);
     }
 
@@ -1416,16 +1413,15 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
 
     std::string address = GetRemoteAddress();
 
-    DEBUG_LOG("WorldSocket::HandleAuthSession: Client '%s' authenticated successfully from %s.",
-              account.c_str(),
+    DEBUG_LOG("WorldSocket::HandleAuthSession: account %u authenticated successfully from %s.",
+              id,
               address.c_str());
 
-    // Update the last_ip in the database
-    // No SQL injection, username escaped.
-    static SqlStatementID updAccount;
-
-    SqlStatement stmt = LoginDatabase.CreateStatement(updAccount, "UPDATE `account` SET `last_ip` = ? WHERE `username` = ?");
-    stmt.PExecute(address.c_str(), account.c_str());
+    // Phase 3 performs NO writes to the `account` row on the auth path (spec 2, 6.7). This
+    // last_ip UPDATE was the only one, and it is not load-bearing: realmd rewrites last_ip on
+    // EVERY authentication (src/realmd/Auth/AuthSocket.cpp:714), so the column stays current
+    // without it. It also fed the account NAME to the SQL layer a second time, on a path that had
+    // no need to.
 
     // NOTE ATM the socket is single-threaded, have this in mind ...
     // Allocation stays ahead of its own load calls below; ACE_NEW_RETURN is an explicit early

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -1076,13 +1076,32 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
             case CMSG_PING:
                 return HandlePing(*new_pct);
             case CMSG_AUTH_SESSION:
-                // Phase 2: framing proven. Do NOT enter the legacy auth path (HandleAuthSession -> m_Crypt.Init).
-                // The allowlist above guarantees we are in CONN_CHALLENGED here, so this is the LEGAL transition.
-                // The ENABLE_ELUNA OnPacketReceive hook for this opcode is intentionally NOT invoked here;
-                // it is deferred to Phase 3 along with the rest of the auth path.
+                // THE PHASE 3 STAGE 2 CUTOVER. Phase 2 proved framing here and deliberately returned
+                // -1 without authenticating; Stage 1 restructured the dormant handler; Stage 2 gave
+                // it correct semantics. This line is where all of it becomes reachable.
+                //
+                // The allowlist above guarantees CONN_CHALLENGED here, so this is the legal
+                // transition. HandleAuthSession owns every outcome from here:
+                //   0  = EITHER the session committed (crypt -> CONN_AUTHED -> publish), OR a
+                //        rejection was queued and the drain armed -- BeginAuthErrorDrain returns 0
+                //        on success, and the socket stays open until Update() sees it drained and
+                //        closes it. Returning 0 is what lets the error reach the client.
+                //   -1 = nothing was queued (cancel_wakeup failed / SendPacket failed / Eluna
+                //        vetoed), so there is nothing to drain and the socket closes immediately.
+                // DO NOT "fix" this to return -1 on rejection: that closes the socket on top of the
+                // unsent response and reintroduces the exact Stage 1 defect (Codex C1) that
+                // BeginAuthErrorDrain exists to fix.
+                //
+                // The 6->4-byte inbound header switch needs no code: the reader derives the header
+                // kind fresh per call from m_Crypt.IsInitialized() (:862), so the first frame after
+                // a successful commit is read post-crypt automatically.
+                //
+                // The Eluna OnPacketReceive hook for this opcode remains deliberately NOT invoked:
+                // Phase 2 deferred it to Phase 3 along with the rest of the auth path, and invoking
+                // it here would let a script observe the raw auth body, including the proof, which
+                // spec 2 forbids. This is a Phase 4 decision, not an oversight.
                 m_connState = MopHs::CONN_AUTHENTICATING;
-                DEBUG_LOG("WorldSocket: CMSG_AUTH_SESSION accepted; CONN_CHALLENGED -> CONN_AUTHENTICATING; auth deferred to Phase 3 (framing OK, len %zu, body redacted); closing.", new_pct->size());
-                return -1;
+                return HandleAuthSession(*new_pct);
             case CMSG_KEEP_ALIVE:
                 DEBUG_LOG("CMSG_KEEP_ALIVE ,size: %zu ", new_pct->size());
 

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -72,7 +72,6 @@
 #include "ByteBuffer.h"
 #include "Opcodes.h"
 #include "Database/DatabaseEnv.h"
-#include "Auth/Sha1.h"
 #include "WorldSession.h"
 #include "WorldSocketMgr.h"
 #include "Log.h"
@@ -1093,8 +1092,8 @@ int WorldSocket::ProcessIncoming(WorldPacket* new_pct)
                 // BeginAuthErrorDrain exists to fix.
                 //
                 // The 6->4-byte inbound header switch needs no code: the reader derives the header
-                // kind fresh per call from m_Crypt.IsInitialized() (:862), so the first frame after
-                // a successful commit is read post-crypt automatically.
+                // kind fresh per call from m_Crypt.IsInitialized() (see DecryptHeaderHook below), so
+                // the first frame after a successful commit is read post-crypt automatically.
                 //
                 // The Eluna OnPacketReceive hook for this opcode remains deliberately NOT invoked:
                 // Phase 2 deferred it to Phase 3 along with the rest of the auth path, and invoking
@@ -1211,6 +1210,10 @@ void WorldSocket::DestroyUnpublishedSession() noexcept
 
     m_Session->AbandonUnpublishedSocket();
     delete m_Session;
+    // Unlocked write is safe ONLY because this runs on the reactor upcall path (HandleAuthSession),
+    // which the reactor serializes against handle_close(), and m_Session is not yet published to
+    // World -- no other thread can observe or race this store. If this cleanup is ever moved off
+    // the upcall path, re-add the m_SessionLock guard used elsewhere in this file.
     m_Session = NULL;
 }
 
@@ -1485,10 +1488,12 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
 
     // Every fallible step -- DB loads, addon inflate -- runs BEFORE the commit region. Their
     // internal semantics are unchanged from the pre-Task-4 code; only their position moved above
-    // m_Crypt.Init. This is what makes the region atomic BY ORDERING: once the commit region is
-    // entered nothing below it can fail, so no failure path can observe an initialised crypt on an
-    // unauthenticated session. AuthCrypt has no rollback and deliberately does not gain one --
-    // rollback would exist only to paper over the ordering defect this reorder removes.
+    // the crypt Prepare()/Activate() split (Prepare() already ran above, before session
+    // allocation; Activate() runs inside the AUTH PUBLICATION TRANSACTION below). This is what
+    // makes the region atomic BY ORDERING: once the commit region is entered nothing below it can
+    // fail, so no failure path can observe an activated crypt on an unauthenticated session.
+    // AuthCrypt has no rollback and deliberately does not gain one -- rollback would exist only to
+    // paper over the ordering defect this reorder removes.
     //
     // ReadAddonsInfo inflates attacker-controlled zlib and CAN throw ByteBufferException. Without
     // this local catch the outer ProcessIncoming ByteBufferException handler would close the socket

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -136,6 +136,11 @@ class WorldSocket : protected WorldHandler
         /// Return the session key
         BigNumber& GetSessionKey() { return m_s; }
 
+        /// Return the canonical session key: EXACTLY MopAuth::SESSION_KEY_LEN raw bytes.
+        /// Valid only after HandleAuthSession has populated it. NOT the same thing as
+        /// GetSessionKey(), which returns m_s -- the SRP6 SALT, despite its name (Task 5 deletes it).
+        const uint8* GetSessionKeyRaw() const { return m_sessionKey; }
+
     protected:
         /// things called by ACE framework.
         WorldSocket(void);
@@ -263,6 +268,11 @@ class WorldSocket : protected WorldHandler
         uint32 m_Seed;
 
         BigNumber m_s;
+
+        /// Canonical raw-40 session key: converted ONCE at the DB read and used verbatim by every
+        /// consumer (proof digest, both crypt directions, redirect). Never round-tripped through
+        /// BigNumber -- see MopAuthKey.h.
+        uint8 m_sessionKey[MopAuth::SESSION_KEY_LEN];
 
         /// Phase 2 wire framing: current handshake state (unused until later tasks).
         MopHs::ConnectionState m_connState;

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -48,7 +48,6 @@
 
 #include "Common.h"
 #include "Auth/AuthCrypt.h"
-#include "Auth/BigNumber.h"
 #include "MopHandshake.h"
 #include "MopFrameReader.h"
 #include "MopSocketDrain.h"

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -192,6 +192,16 @@ class WorldSocket : protected WorldHandler
         /// MopFrameReader::CmdValidFn hook (Phase 2 wire framing).
         static bool CmdValidHook(void*, uint32, bool);
 
+        /// Tear down a WorldSession that was allocated but never published to World. Releases the
+        /// session's extra socket reference WITHOUT closing this socket, so an auth error can still
+        /// drain through it. One cleanup path for every post-allocation rejection in HandleAuthSession.
+        void DestroyUnpublishedSession() noexcept;
+
+        /// Infallible auth commit invoked by World::AddSession while the add-queue lock is held:
+        /// activates the prepared crypt and stores CONN_AUTHED. Must stay noexcept -- the queue
+        /// lock is held across it and the function-pointer type statically enforces noexcept.
+        static void CommitAuthenticatedSession(void* context) noexcept;
+
     private:
         /// Queue the legacy auth error response and enter the drain state.
         ///

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -133,12 +133,9 @@ class WorldSocket : protected WorldHandler
         /// Remove reference to this object.
         long RemoveReference(void);
 
-        /// Return the session key
-        BigNumber& GetSessionKey() { return m_s; }
-
         /// Return the canonical session key: EXACTLY MopAuth::SESSION_KEY_LEN raw bytes.
-        /// Valid only after HandleAuthSession has populated it. NOT the same thing as
-        /// GetSessionKey(), which returns m_s -- the SRP6 SALT, despite its name (Task 5 deletes it).
+        /// Valid only after HandleAuthSession has populated it. Task 5 deleted the old
+        /// GetSessionKey(), which returned m_s -- the SRP6 SALT, despite its name.
         const uint8* GetSessionKeyRaw() const { return m_sessionKey; }
 
     protected:
@@ -266,8 +263,6 @@ class WorldSocket : protected WorldHandler
         std::atomic<bool> m_sendInFlight;
 
         uint32 m_Seed;
-
-        BigNumber m_s;
 
         /// Canonical raw-40 session key: converted ONCE at the DB read and used verbatim by every
         /// consumer (proof digest, both crypt directions, redirect). Never round-tripped through

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -24,7 +24,8 @@ add_test(NAME mop_framing COMMAND mop_framing_test)
 
 add_executable(mop_auth_test
     mop_auth_test.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../MopAuthSession.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../MopAuthSession.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../MopAuthProof.cpp)
 target_include_directories(mop_auth_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_SOURCE_DIR}/src/shared)

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -25,10 +25,21 @@ add_test(NAME mop_framing COMMAND mop_framing_test)
 add_executable(mop_auth_test
     mop_auth_test.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../MopAuthSession.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../MopAuthProof.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../MopAuthProof.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../MopAuthResponse.cpp)
 target_include_directories(mop_auth_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..
     ${CMAKE_SOURCE_DIR}/src/shared)
 set_target_properties(mop_auth_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
-target_link_libraries(mop_auth_test PRIVATE shared)
+# MopAuthResponse.cpp includes Opcodes.h, which (per its own comment, ":39") includes the FULL
+# WorldSession.h so the opcode table's OpcodeHandler struct size matches across translation units.
+# That chain pulls in Item.h/AuctionHouseMgr.h/LFGMgr.h/DBCStructure.h/Object.h/Eluna's LuaValue.h --
+# i.e. most of the game module's own header surface. Adding those include dirs one at a time here
+# (Object, then AuctionHouseBot, then vmap, then Eluna, ...) chases an unbounded list; linking the
+# real 'game' target instead inherits its already-correct PUBLIC include set (and, when
+# SCRIPT_LIB_ELUNA is on, Eluna's own include dirs) via CMake usage requirements, which is bounded
+# and matches how Server/*.cpp already compiles inside the real game library. mop_auth_test itself
+# calls nothing from 'game' -- only enum values and struct layouts are used -- so no game .obj
+# beyond what the headers require gets pulled into the test binary.
+target_link_libraries(mop_auth_test PRIVATE game)
 add_test(NAME mop_auth COMMAND mop_auth_test)

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -25,7 +25,11 @@
 #include "MopAuthSession.h"
 #include "MopAuthProof.h"
 #include "MopSocketDrain.h"
+#include "MopAuthResponse.h"
 #include "Utilities/ByteBuffer.h"
+#include "Utilities/WorldPacket.h"
+#include "Opcodes.h"
+#include "SharedDefines.h"
 #include "Auth/MopAuthKey.h"
 #include "Auth/AuthCrypt.h"
 #include "Auth/BigNumber.h"
@@ -819,6 +823,192 @@ static void test_proof_equals_constant_time()
     CHECK(!MopAuth::ProofEquals(a, b));
 }
 
+// ---------------------------------------------------------------------------------------------
+// MopAuth::BuildAuthResponse{Accepted,Queued,Error} -- the ONE canonical SMSG_AUTH_RESPONSE
+// serializer (Server/MopAuthResponse.h / .cpp). Full byte vectors from tools/mop_stage2_fixtures.py
+// (spec/plan §S5), not spot-checks -- see the file header there for why a size/first-bit check
+// gates nothing.
+// ---------------------------------------------------------------------------------------------
+
+// The five variants (spec 6.6a), from the client's own parser (sub_140A70980):
+//   1. hasQueueInfo=0 REQUIRES hasAccountData=1, or AUTH_OK (12) is FORCED to AUTH_FAILED (13).
+//   2. code 27 (AUTH_WAIT_QUEUE) is NEVER sent -- the client SYNTHESISES it from the queued bit.
+//   3. With hasQueueInfo=1 the queue branch overwrites the forced 13, MASKING hasAccountData=0 on
+//      updates so it only bites on the RELEASE. That is why SkyFire never caught it.
+//
+// [HYPOTHESIS] The BIT ORDER these vectors encode is SkyFire-derived and NOT confirmed; only the
+// shape is corroborated by the client struct. If Gate 3b fails, the builder and
+// tools/mop_stage2_fixtures.py are wrong TOGETHER and must be changed together -- keeping them
+// independent is what makes that a two-place edit instead of a silent one.
+static void check_bytes(WorldPacket const& pkt, uint8 const* expect, size_t expectLen,
+                        char const* label)
+{
+    CHECK(pkt.size() == expectLen);
+    if (pkt.size() != expectLen)
+    {
+        std::fprintf(stderr, "  %s: size %zu, expected %zu\n", label, pkt.size(), expectLen);
+        return;
+    }
+    for (size_t i = 0; i < expectLen; ++i)
+    {
+        if (pkt.contents()[i] != expect[i])
+        {
+            std::fprintf(stderr, "  %s: byte %zu = 0x%02X, expected 0x%02X\n",
+                         label, i, pkt.contents()[i], expect[i]);
+        }
+        CHECK(pkt.contents()[i] == expect[i]);
+    }
+}
+
+// ACCEPTED: AUTH_OK, hasAccountData=1 + full block, queued=0. account/server expansion both MISTS.
+static const uint8 kExpectResponse_Accepted[91] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x00, 0x01, 0x00, 0x02,
+    0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00, 0x08, 0x03, 0x09, 0x01, 0x0A,
+    0x01, 0x0B, 0x03, 0x16, 0x04, 0x18, 0x04, 0x19, 0x04, 0x1A, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+    0x00, 0x04, 0x00, 0x05, 0x02, 0x06, 0x00, 0x07, 0x00, 0x08, 0x00, 0x09, 0x04, 0x0A, 0x00, 0x0B,
+    0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0C };
+
+// INITIAL QUEUE: AUTH_OK, hasAccountData=1, queued=1, position 2. Exactly ACCEPTED + a u32.
+static const uint8 kExpectResponse_InitialQueue[95] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7A, 0x02, 0x00, 0x00, 0x00,
+    0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00, 0x08,
+    0x03, 0x09, 0x01, 0x0A, 0x01, 0x0B, 0x03, 0x16, 0x04, 0x18, 0x04, 0x19, 0x04, 0x1A, 0x00, 0x01,
+    0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x02, 0x06, 0x00, 0x07, 0x00, 0x08, 0x00, 0x09,
+    0x04, 0x0A, 0x00, 0x0B, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0C };
+
+// QUEUE UPDATE: identical to INITIAL QUEUE but position 1 -- pins the position's OFFSET and its
+// little-endian encoding, which a size-only check cannot.
+static const uint8 kExpectResponse_QueueUpdate[95] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7A, 0x01, 0x00, 0x00, 0x00,
+    0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00, 0x08,
+    0x03, 0x09, 0x01, 0x0A, 0x01, 0x0B, 0x03, 0x16, 0x04, 0x18, 0x04, 0x19, 0x04, 0x1A, 0x00, 0x01,
+    0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x02, 0x06, 0x00, 0x07, 0x00, 0x08, 0x00, 0x09,
+    0x04, 0x0A, 0x00, 0x0B, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0C };
+
+// ERROR: code != 12, so hasAccountData=0 is SAFE (it never enters the forcing branch). Two bytes:
+// one flushed bit-byte, then the code. NOTE this is byte-identical to what Stage 1 already emits
+// at WorldSocket.cpp:469-472 -- the ERROR path's wire output does NOT change in Stage 2, which is
+// a useful negative result: a Gate 3b error-render regression cannot be blamed on these bytes.
+static const uint8 kExpectResponse_Error[2] = { 0x00, 0x14 };
+
+// ACCEPTED with the account restricted BELOW the realm cap -- the ONLY case where the two
+// expansion fields differ. Pins that they occupy DISTINCT offsets; passing one value for both
+// (as every legacy emitter did) makes this vector unreachable.
+static const uint8 kExpectResponse_AcceptedSplitExpansion[91] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x58, 0x00, 0x00, 0x00, 0x00, 0x00, 0x78, 0x00, 0x01, 0x00, 0x02,
+    0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06, 0x00, 0x07, 0x00, 0x08, 0x03, 0x09, 0x01, 0x0A,
+    0x01, 0x0B, 0x03, 0x16, 0x04, 0x18, 0x04, 0x19, 0x04, 0x1A, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,
+    0x00, 0x04, 0x00, 0x05, 0x02, 0x06, 0x00, 0x07, 0x00, 0x08, 0x00, 0x09, 0x04, 0x0A, 0x00, 0x0B,
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0C };
+
+static void test_auth_response_byte_vectors()
+{
+    WorldPacket accepted;
+    MopAuth::BuildAuthResponseAccepted(accepted, EXPANSION_MOP, EXPANSION_MOP);
+    check_bytes(accepted, kExpectResponse_Accepted, sizeof(kExpectResponse_Accepted), "ACCEPTED");
+
+    WorldPacket initial;
+    MopAuth::BuildAuthResponseQueued(initial, 2, EXPANSION_MOP, EXPANSION_MOP);
+    check_bytes(initial, kExpectResponse_InitialQueue, sizeof(kExpectResponse_InitialQueue),
+                "INITIAL QUEUE");
+
+    WorldPacket update;
+    MopAuth::BuildAuthResponseQueued(update, 1, EXPANSION_MOP, EXPANSION_MOP);
+    check_bytes(update, kExpectResponse_QueueUpdate, sizeof(kExpectResponse_QueueUpdate),
+                "QUEUE UPDATE");
+
+    WorldPacket error;
+    MopAuth::BuildAuthResponseError(error, AUTH_VERSION_MISMATCH);
+    check_bytes(error, kExpectResponse_Error, sizeof(kExpectResponse_Error), "ERROR");
+}
+
+// RELEASE is not a variant of its own: position 0 must produce ACCEPTED, byte for byte. A bare
+// AUTH_OK -- what SendAuthWaitQue(0) sent before Stage 2 -- is PROVEN HARMFUL: with queued=0 there
+// is no queue branch to overwrite the forced 13, so the release was the one packet where
+// hasAccountData=0 actually bit.
+static void test_auth_response_release_is_byte_identical_to_accepted()
+{
+    WorldPacket release;
+    MopAuth::BuildAuthResponseQueued(release, 0, EXPANSION_MOP, EXPANSION_MOP);  // pos 0 = RELEASE
+    check_bytes(release, kExpectResponse_Accepted, sizeof(kExpectResponse_Accepted), "RELEASE");
+}
+
+// The two expansion fields must land at DISTINCT offsets. Exactly one byte may differ from
+// ACCEPTED; if the builder collapsed them, either zero or two bytes would.
+static void test_auth_response_expansions_are_distinct_fields()
+{
+    WorldPacket split;
+    MopAuth::BuildAuthResponseAccepted(split, EXPANSION_WOTLK, EXPANSION_MOP);
+    check_bytes(split, kExpectResponse_AcceptedSplitExpansion,
+                sizeof(kExpectResponse_AcceptedSplitExpansion), "ACCEPTED split-expansion");
+
+    size_t differing = 0;
+    for (size_t i = 0; i < sizeof(kExpectResponse_Accepted); ++i)
+    {
+        if (kExpectResponse_AcceptedSplitExpansion[i] != kExpectResponse_Accepted[i])
+        {
+            ++differing;
+        }
+    }
+    CHECK(differing == 1);
+}
+
+// The forcing rule is the whole reason this serializer exists; assert a CALLER cannot violate it.
+static void test_auth_ok_always_carries_account_data()
+{
+    static const uint32 positions[] = { 0, 1, 5 };
+    for (uint32 pos : positions)
+    {
+        WorldPacket pkt;
+        MopAuth::BuildAuthResponseQueued(pkt, pos, EXPANSION_MOP, EXPANSION_MOP);
+        CHECK((pkt.contents()[0] & 0x80) != 0);
+        CHECK(pkt.contents()[pkt.size() - 1] == AUTH_OK);
+    }
+
+    WorldPacket accepted;
+    MopAuth::BuildAuthResponseAccepted(accepted, EXPANSION_MOP, EXPANSION_MOP);
+    CHECK((accepted.contents()[0] & 0x80) != 0);
+}
+
+// Code 27 must never reach the wire -- the client SYNTHESISES it from the queued bit, and an emitted
+// 27 lands in the != 12 path and delivers failure.
+//
+// This asserts SERIALIZER ENFORCEMENT, not caller discipline. An earlier draft only ever called the
+// builder with AUTH_OK and then declared "never emits 27" -- which proved what that test did, not
+// what the serializer permits. The Accepted/Queued entry points cannot express 27 at all (they hard-
+// code AUTH_OK), and Error REJECTS it. Both halves are checked.
+static void test_auth_response_never_emits_code_27()
+{
+    // (a) the AUTH_OK paths cannot express 27: there is no code parameter to pass it through.
+    static const uint32 positions[] = { 0, 1, 3 };
+    for (uint32 pos : positions)
+    {
+        WorldPacket pkt;
+        MopAuth::BuildAuthResponseQueued(pkt, pos, EXPANSION_MOP, EXPANSION_MOP);
+        CHECK(pkt.contents()[pkt.size() - 1] == AUTH_OK);
+    }
+
+    // (b) the ERROR path REJECTS it -- the serializer coerces to AUTH_FAILED and logs.
+    {
+        WorldPacket pkt;
+        MopAuth::BuildAuthResponseError(pkt, AUTH_WAIT_QUEUE);
+        CHECK(pkt.contents()[pkt.size() - 1] == AUTH_FAILED);
+        CHECK(pkt.contents()[pkt.size() - 1] != AUTH_WAIT_QUEUE);
+    }
+
+    // (c) and it rejects AUTH_OK on the error path too: an "error" of 12 with no account block is
+    //     rewritten by the client to 13 anyway, so passing it is a caller bug worth surfacing.
+    {
+        WorldPacket pkt;
+        MopAuth::BuildAuthResponseError(pkt, AUTH_OK);
+        CHECK(pkt.contents()[pkt.size() - 1] == AUTH_FAILED);
+    }
+}
+
 // NOTE: linking 'shared' drags in ACE, whose OS_main.h rewrites main() to ace_main_i() and
 // requires the (int, char**) signature. A no-argument main() therefore fails to link (LNK2019).
 int main(int /*argc*/, char** /*argv*/)
@@ -861,6 +1051,11 @@ int main(int /*argc*/, char** /*argv*/)
     test_auth_proof_digest();
     test_auth_proof_digest_zero_top_byte_k();
     test_proof_equals_constant_time();
+    test_auth_response_byte_vectors();
+    test_auth_response_release_is_byte_identical_to_accepted();
+    test_auth_response_expansions_are_distinct_fields();
+    test_auth_ok_always_carries_account_data();
+    test_auth_response_never_emits_code_27();
     std::printf(g_fail ? "FAILED (%d)\n" : "OK\n", g_fail);
     return g_fail ? 1 : 0;
 }

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -144,7 +144,7 @@ static void test_addon_size_beyond_remaining_rejected()
 }
 
 // The embedded inflated size must NOT decide authentication. The real consumer,
-// WorldSession::ReadAddonsInfo (WorldSession.cpp:1329-1341), treats size 0 as "no addon info"
+// WorldSession::ReadAddonsInfo, treats size 0 as "no addon info"
 // and simply returns -- it does not reject the login. Auth must be equally tolerant.
 static void test_inflated_size_zero_accepted()
 {
@@ -255,8 +255,9 @@ static void test_name_truncated_rejected()
 }
 
 // Pins the PRODUCTION decoder's digest scatter to the binary-derived map in
-// facts/FACTS_mop548_digest_permutation.md 2 (serializer x86 sub_66F7E0 / x64 sub_1403DFD80,
-// vtable off_140ED6F70 slot 1; digest base PROVEN via SHA1_Final's destination, not assumed).
+// facts/FACTS_mop548_digest_permutation.md 2 (campaign research doc, not in this tree; serializer
+// x86 sub_66F7E0 / x64 sub_1403DFD80, vtable off_140ED6F70 slot 1; digest base PROVEN via
+// SHA1_Final's destination, not assumed).
 //
 // A bijection check is NOT sufficient -- a transposed table is still a bijection, which is exactly
 // how an earlier design's test would have passed on a wrong map. This asserts ENTRY BY ENTRY.
@@ -268,7 +269,7 @@ static void test_name_truncated_rejected()
 static void test_digest_scatter_matches_binary()
 {
     // digestIndex -> bodyOffset, written out independently from the facts doc's inverse map.
-    static const uint8_t kExpectDigestToBody[20] = {
+    static constexpr uint8_t kExpectDigestToBody[20] = {
         12, 50, 25, 10, 11, 41, 42, 47, 43, 26, 51, 17, 27, 48, 9, 49, 40, 46, 8, 22
     };
 
@@ -620,8 +621,9 @@ static void test_authcrypt_kat()
 
 // THE STAGE 1 BLOCKER, closed. IsInitialized() used to be a RAN-TO-COMPLETION flag, not a SUCCEEDED
 // flag: AuthCrypt set _initialized = true unconditionally while ARC4 discarded every EVP return
-// value. Since IsInitialized() is the codec discriminator (WorldSocket.cpp:218 send / :862 recv), a
-// failed init would have framed PLAINTEXT headers as HDR_POSTCRYPT.
+// value. Since IsInitialized() is the codec discriminator (WorldSocket::SendPacket's post-crypt
+// branch on send / WorldSocket::DecryptHeaderHook on recv), a failed init would have framed
+// PLAINTEXT headers as HDR_POSTCRYPT.
 static void test_authcrypt_prepare_reports_success()
 {
     static const uint8 kK_FULL[40] = { 0x03,0x0A,0x11,0x18,0x1F,0x26,0x2D,0x34,0x3B,0x42,
@@ -638,9 +640,10 @@ static void test_authcrypt_prepare_reports_success()
 // *** THE COMMIT-REGION INVARIANT, AS A TEST. ***
 // Between Prepare() and Activate() the ARC4 contexts are fully keyed -- but the crypt must still be
 // INERT: IsInitialized() false, so Decrypt/Encrypt no-op AND the wire codec discriminator
-// (WorldSocket.cpp:218/862) still frames PRE-crypt. That is what lets HandleAuthSession do every
-// fallible thing -- allocate the session, load account data, inflate addons -- AFTER the crypt is
-// prepared, with a throw still leaving the socket exactly as unauthenticated as it started.
+// (WorldSocket::SendPacket's post-crypt branch / WorldSocket::DecryptHeaderHook) still frames
+// PRE-crypt. That is what lets HandleAuthSession do every fallible thing -- allocate the session,
+// load account data, inflate addons -- AFTER the crypt is prepared, with a throw still leaving the
+// socket exactly as unauthenticated as it started.
 //
 // Stage 1's equivalent ordering rule was load-bearing and its own ledger said "NO TEST COVERS THIS".
 // This is that test.
@@ -654,9 +657,11 @@ static void test_authcrypt_prepare_does_not_activate()
     CHECK(crypt.Prepare(kK_FULL));
     CHECK(!crypt.IsInitialized());                 // keyed, but NOT published
 
-    uint8 header[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
-    CHECK(!crypt.EncryptSend(header, 4));          // still refuses...
-    CHECK(header[0] == 0xDE && header[3] == 0xEF); // ...and has not touched the buffer
+    static const uint8 kOriginal[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
+    uint8 header[4];
+    std::memcpy(header, kOriginal, 4);
+    CHECK(!crypt.EncryptSend(header, 4));                          // still refuses...
+    CHECK(std::memcmp(header, kOriginal, 4) == 0);                 // ...and has not touched the buffer
 
     crypt.Activate();
     CHECK(crypt.IsInitialized());
@@ -672,9 +677,11 @@ static void test_authcrypt_activate_without_prepare_is_inert()
     crypt.Activate();                              // no Prepare
     CHECK(!crypt.IsInitialized());
 
-    uint8 header[4] = { 0x11, 0x22, 0x33, 0x44 };
+    static const uint8 kOriginal[4] = { 0x11, 0x22, 0x33, 0x44 };
+    uint8 header[4];
+    std::memcpy(header, kOriginal, 4);
     CHECK(!crypt.EncryptSend(header, 4));
-    CHECK(header[0] == 0x11 && header[3] == 0x44);
+    CHECK(std::memcmp(header, kOriginal, 4) == 0);
 }
 
 // A repeated Prepare while PREPARED is an invalid transition. It must poison the unpublished
@@ -890,8 +897,9 @@ static const uint8 kExpectResponse_QueueUpdate[95] = {
 
 // ERROR: code != 12, so hasAccountData=0 is SAFE (it never enters the forcing branch). Two bytes:
 // one flushed bit-byte, then the code. NOTE this is byte-identical to what Stage 1 already emits
-// at WorldSocket.cpp:469-472 -- the ERROR path's wire output does NOT change in Stage 2, which is
-// a useful negative result: a Gate 3b error-render regression cannot be blamed on these bytes.
+// at the MopAuth::BuildAuthResponseError call site in WorldSocket::HandleAuthSession's error
+// drain -- the ERROR path's wire output does NOT change in Stage 2, which is a useful negative
+// result: a Gate 3b error-render regression cannot be blamed on these bytes.
 static const uint8 kExpectResponse_Error[2] = { 0x00, 0x14 };
 
 // ACCEPTED with the account restricted BELOW the realm cap -- the ONLY case where the two

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -38,8 +38,9 @@
 static int g_fail = 0;
 #define CHECK(c) do { if (!(c)) { std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #c); ++g_fail; } } while (0)
 
-// The legacy 11-bit name length is read MSB-first across two bytes with no leading ReadBit(),
-// so the encoded value is (bits0 << 3) | (bits1 >> 5). Vectors below are hand-encoded to that.
+// The name-length block is ONE flag bit then an 11-bit length, both MSB-first (spec 3.4):
+//   value = ((bits0 & 0x7F) << 4) | (bits1 >> 4)
+// Vectors below are hand-encoded to that (see name_bits0()/name_bits1() further down).
 static ByteBuffer make_legacy_body(uint32_t addonSize, uint32_t inflatedSize,
                                    uint8_t nameBits0, uint8_t nameBits1,
                                    char const* name, size_t nameBytes)
@@ -92,7 +93,7 @@ static void test_short_body_rejected()
 // Structure only: the legacy decode is bug-compatible, so field values are deliberately not asserted.
 static void test_exact_valid_structure_accepted()
 {
-    ByteBuffer in = make_legacy_body(4, 1, 0x00, 0x20, "A", 1);   // 11-bit name length 1
+    ByteBuffer in = make_legacy_body(4, 1, 0x00, 0x10, "A", 1);   // flag=0, name length 1
     CHECK(decode(in) == MopAuth::DecodeResult::Ok);
 }
 
@@ -116,7 +117,7 @@ static void test_small_addon_sizes_accepted()
 {
     for (uint32_t addonSize = 0; addonSize < 4; ++addonSize)
     {
-        ByteBuffer in = make_legacy_body(addonSize, 0, 0x00, 0x20, "A", 1);
+        ByteBuffer in = make_legacy_body(addonSize, 0, 0x00, 0x10, "A", 1);
         MopAuth::AuthSessionFields out{};
         CHECK(MopAuth::DecodeAuthSession(in, out) == MopAuth::DecodeResult::Ok);
         CHECK(out.addonSize == addonSize);
@@ -143,7 +144,7 @@ static void test_addon_size_beyond_remaining_rejected()
 // and simply returns -- it does not reject the login. Auth must be equally tolerant.
 static void test_inflated_size_zero_accepted()
 {
-    ByteBuffer in = make_legacy_body(4, 0, 0x00, 0x20, "A", 1);
+    ByteBuffer in = make_legacy_body(4, 0, 0x00, 0x10, "A", 1);
     CHECK(decode(in) == MopAuth::DecodeResult::Ok);
 }
 
@@ -151,13 +152,13 @@ static void test_inflated_size_zero_accepted()
 // skipped addon parse, not a failed authentication.
 static void test_inflated_size_over_maximum_accepted()
 {
-    ByteBuffer in = make_legacy_body(4, 0x100000, 0x00, 0x20, "A", 1);
+    ByteBuffer in = make_legacy_body(4, 0x100000, 0x00, 0x10, "A", 1);
     CHECK(decode(in) == MopAuth::DecodeResult::Ok);
 }
 
 static void test_inflated_size_at_maximum_accepted()
 {
-    ByteBuffer in = make_legacy_body(4, 0xFFFFF, 0x00, 0x20, "A", 1);
+    ByteBuffer in = make_legacy_body(4, 0xFFFFF, 0x00, 0x10, "A", 1);
     CHECK(decode(in) == MopAuth::DecodeResult::Ok);
 }
 
@@ -198,17 +199,19 @@ static void test_missing_name_bitfield_rejected()
     CHECK(decode(partial) == MopAuth::DecodeResult::ShortBody);
 }
 
-// The 11-bit name length is read MSB-first across two bytes with no leading ReadBit(), so the
-// encoded value is (bits0 << 3) | (bits1 >> 5). Derived rather than hand-written: 2047 in
-// particular is easy to mis-encode by hand.
-static uint8_t name_bits0(uint32_t len)
+// The name-length block is ONE flag bit then an 11-bit length, both MSB-first (spec 3.4):
+//   value = ((bits0 & 0x7F) << 4) | (bits1 >> 4)
+// Self-check against the gate2 capture: len=13, flag=0 -> bits0=0x00, bits1=0xD0 -> `00 D0`, which
+// is byte-for-byte what the real client sent. Derived rather than hand-written: 2047 in particular
+// is easy to mis-encode by hand.
+static uint8_t name_bits0(uint32_t len, bool flag)
 {
-    return uint8_t(len >> 3);
+    return uint8_t((flag ? 0x80 : 0x00) | ((len >> 4) & 0x7F));
 }
 
 static uint8_t name_bits1(uint32_t len)
 {
-    return uint8_t((len & 7) << 5);
+    return uint8_t((len & 0xF) << 4);
 }
 
 // The decoder applies NO cap to the name length, because the legacy path applied none:
@@ -232,7 +235,7 @@ static void test_name_lengths_uncapped()
     for (uint32_t len : lengths)
     {
         std::string const name(len, 'A');
-        ByteBuffer in = make_legacy_body(4, 1, name_bits0(len), name_bits1(len),
+        ByteBuffer in = make_legacy_body(4, 1, name_bits0(len, false), name_bits1(len),
                                          name.c_str(), name.size());
         MopAuth::AuthSessionFields out{};
         CHECK(MopAuth::DecodeAuthSession(in, out) == MopAuth::DecodeResult::Ok);
@@ -243,8 +246,94 @@ static void test_name_lengths_uncapped()
 // ReadString() truncates silently at end-of-buffer; the decoder must reject rather than shorten.
 static void test_name_truncated_rejected()
 {
-    ByteBuffer in = make_legacy_body(4, 1, 0x00, 0x40, "A", 1);   // length 2, one byte remaining
+    ByteBuffer in = make_legacy_body(4, 1, 0x00, 0x20, "A", 1);   // length 2, one byte remaining
     CHECK(decode(in) == MopAuth::DecodeResult::TruncatedName);
+}
+
+// Pins the PRODUCTION decoder's digest scatter to the binary-derived map in
+// facts/FACTS_mop548_digest_permutation.md 2 (serializer x86 sub_66F7E0 / x64 sub_1403DFD80,
+// vtable off_140ED6F70 slot 1; digest base PROVEN via SHA1_Final's destination, not assumed).
+//
+// A bijection check is NOT sufficient -- a transposed table is still a bijection, which is exactly
+// how an earlier design's test would have passed on a wrong map. This asserts ENTRY BY ENTRY.
+//
+// It works by marking each body offset with its own index, so the decoded digest[] reads back the
+// offset each slot came from. That tests the shipped read sequence rather than a table copied
+// alongside it -- there IS no table, and deliberately so: the permutation lives in the decoder as
+// straight-line reads, so there is nothing to hand-copy and nothing to transpose.
+static void test_digest_scatter_matches_binary()
+{
+    // digestIndex -> bodyOffset, written out independently from the facts doc's inverse map.
+    static const uint8_t kExpectDigestToBody[20] = {
+        12, 50, 25, 10, 11, 41, 42, 47, 43, 26, 51, 17, 27, 48, 9, 49, 40, 46, 8, 22
+    };
+
+    // A 56-byte prefix where body[i] == i, so a digest byte reveals its own source offset.
+    // Offsets 0..51 are all < 52, so every marker is unambiguous.
+    ByteBuffer in;
+    for (uint32_t i = 0; i < 52; ++i)
+    {
+        in << uint8_t(i);
+    }
+    in << uint32_t(4);                                     // addonSize at body 52..55
+    in << uint32_t(1);                                     // the 4-byte addon blob
+    in << name_bits0(1, false) << name_bits1(1);           // flag=0, name length 1
+    in << uint8_t('A');
+
+    MopAuth::AuthSessionFields out{};
+    CHECK(MopAuth::DecodeAuthSession(in, out) == MopAuth::DecodeResult::Ok);
+
+    for (uint8_t d = 0; d < 20; ++d)
+    {
+        CHECK(out.digest[d] == kExpectDigestToBody[d]);    // catches ANY transposition
+    }
+
+    // The capture anchors the permutation had no freedom to fit (facts 4). clientSeed is at body
+    // 18..21, so with body[i] == i it reads back 0x15141312 little-endian.
+    CHECK(out.clientSeed == 0x15141312u);
+    CHECK(out.builtNumberClient == 0x2D2Cu);               // body 44..45
+    CHECK(out.addonSize == 4u);                            // body 52..55
+
+    // TRAP (facts 5): body 23 is the constant 1, NOT digest[20]. It must never appear in digest[].
+    // With body[i] == i, marker 23 in any digest slot would mean an off-by-one past the digest.
+    for (uint8_t d = 0; d < 20; ++d)
+    {
+        CHECK(out.digest[d] != 23);
+    }
+}
+
+// Spec 3.4 / facts 4: body 420 is ONE flag bit (TC calls it "UseIPv6"; the OFFSET is confirmed, the
+// NAME is inferred) followed by an 11-bit name length. The legacy path issued ReadBits(11) with NO
+// leading ReadBit(), which silently reads the WRONG 11 bits.
+//
+// The capture settles it. gate2 carries strlen=13, flag=0, wire bytes `00 D0`:
+//   ReadBits(11) alone      -> byte0[7:0] then byte1[7:5] -> 0b00000000110 = 6   WRONG
+//   ReadBit() + ReadBits(11)-> flag=byte0[7]; byte0[6:0] then byte1[7:4] -> 0b00000001101 = 13  RIGHT
+// This is not a style question: today's decoder mis-reads every real client's name length.
+//
+// (This does NOT reopen "11 vs 12 bits" -- both readings consume the same 12 bits. It is about
+// which model the code states. A 12-bit read is equivalent ONLY while the flag is 0, and silently
+// rejects a valid packet -- length >= 2048 -- the moment it is ever 1.)
+static void test_name_length_flag_bit_then_11_bits()
+{
+    // The capture's own bytes, byte-for-byte.
+    ByteBuffer in = make_legacy_body(4, 1, 0x00, 0xD0, "ACCOUNTNAME13", 13);
+    MopAuth::AuthSessionFields out{};
+    CHECK(MopAuth::DecodeAuthSession(in, out) == MopAuth::DecodeResult::Ok);
+    CHECK(out.account == "ACCOUNTNAME13");
+    CHECK(out.account.size() == 13);
+    CHECK(out.useIPv6 == false);
+}
+
+// The flag must be READ, not skipped, and must not corrupt the length. With flag=1 the 11 bits are
+// unchanged; a 12-bit read would yield 2048+13 and reject a perfectly valid packet.
+static void test_name_length_flag_set()
+{
+    ByteBuffer in = make_legacy_body(4, 1, name_bits0(13, true), name_bits1(13), "ACCOUNTNAME13", 13);
+    MopAuth::AuthSessionFields out{};
+    CHECK(MopAuth::DecodeAuthSession(in, out) == MopAuth::DecodeResult::Ok);
+    CHECK(out.account.size() == 13);
+    CHECK(out.useIPv6 == true);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -746,6 +835,9 @@ int main(int /*argc*/, char** /*argv*/)
     test_missing_name_bitfield_rejected();
     test_name_lengths_uncapped();
     test_name_truncated_rejected();
+    test_digest_scatter_matches_binary();
+    test_name_length_flag_bit_then_11_bits();
+    test_name_length_flag_set();
     test_wire_field_widths();
     test_open_state_processes_input();
     test_flushing_state_rejects_coalesced_next_frame();

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -25,7 +25,11 @@
 #include "MopAuthSession.h"
 #include "MopSocketDrain.h"
 #include "Utilities/ByteBuffer.h"
+#include "Auth/MopAuthKey.h"
+#include "Auth/BigNumber.h"
+#include <openssl/crypto.h>
 #include <cstdio>
+#include <cstring>
 #include <string>
 #include <type_traits>
 
@@ -331,6 +335,148 @@ static void test_wire_field_widths()
     CHECK(sizeof(MopAuth::AuthSessionFields{}.builtNumberClient) == 2);
 }
 
+// ---------------------------------------------------------------------------------------------
+// MopAuth::SessionKeyFromHex -- the canonical account.sessionkey hex -> raw-40 K adapter
+// (Auth/MopAuthKey.h / .cpp).
+// ---------------------------------------------------------------------------------------------
+
+// The pure primitive: copy little-endian bytes, pad the TAIL. A named function rather than an
+// inline memcpy so the tail-vs-head rule has one place to live and one place to be tested.
+static void test_raw40_from_littleendian()
+{
+    // (a) full 40 bytes: a straight copy.
+    {
+        uint8 le[40];
+        for (int i = 0; i < 40; ++i)
+        {
+            le[i] = uint8(i);
+        }
+        uint8 out[40] = { 0xEE };
+        CHECK(MopAuth::Raw40FromLittleEndian(le, 40, out));
+        for (int i = 0; i < 40; ++i)
+        {
+            CHECK(out[i] == uint8(i));
+        }
+    }
+    // (b) THE TRAP: a short value pads at the TAIL. AsByteArray(40) pads at the HEAD and shifts
+    //     every real byte by one.
+    {
+        uint8 le[39];
+        for (int i = 0; i < 39; ++i)
+        {
+            le[i] = uint8(i);
+        }
+        uint8 out[40] = { 0xEE };
+        CHECK(MopAuth::Raw40FromLittleEndian(le, 39, out));
+        for (int i = 0; i < 39; ++i)
+        {
+            CHECK(out[i] == uint8(i));
+        }
+        CHECK(out[39] == 0x00);
+    }
+    // (c) TWO leading zeros -> 38. "LENGTH IN (78,80)" was an incomplete enumeration: there is no
+    //     floor. BN_bn2hex emits the BIGNUM's numeric byte count.
+    {
+        uint8 le[38] = { 0 };
+        uint8 out[40] = { 0xEE };
+        CHECK(MopAuth::Raw40FromLittleEndian(le, 38, out));
+        CHECK(out[38] == 0x00);
+        CHECK(out[39] == 0x00);
+    }
+    // (d) over-long must be REJECTED, never truncated.
+    {
+        uint8 le[41] = { 0 };
+        uint8 out[40] = { 0xEE };
+        CHECK(!MopAuth::Raw40FromLittleEndian(le, 41, out));
+    }
+    // (e) null input rejected.
+    {
+        uint8 out[40] = { 0xEE };
+        CHECK(!MopAuth::Raw40FromLittleEndian(NULL, 0, out));
+    }
+    // (f) a ZERO-LENGTH decode is REJECTED, not silently zero-filled (spec 6.2a, Codex round 3 H3).
+    //     "" is vacuously hex-only, even-length and <= 80; it converts to zero bytes, which would
+    //     pad into forty 0x00s -- a K of all zeros that looks well-formed to every consumer
+    //     downstream. That is EXACTLY the stale/NULL-K confounder the ladder exists to eliminate.
+    {
+        uint8 le[1] = { 0 };
+        uint8 out[40] = { 0xEE };
+        CHECK(!MopAuth::Raw40FromLittleEndian(le, 0, out));
+    }
+}
+
+// *** THE TEST THAT CATCHES THE DOUBLE REVERSAL. ***
+//
+// It drives the REAL adapter over the REAL chain, simulating realmd's own write path:
+//     realmd:  vK[40] --SetBinary--> BigNumber --AsHexStr--> account.sessionkey
+//     world:   hex --SessionKeyFromHex--> canonical raw-40 K
+// and asserts the round trip returns vK BYTE FOR BYTE.
+//
+// This is the ONLY test that can see an endianness mismatch. Plan v2 fed AsByteArray() -- which is
+// ALREADY little-endian (BigNumber.cpp:194 std::reverse) -- into a helper that reverses, producing
+// a big-endian K, a deterministic proof failure, and a total auth outage. Every hand-crafted
+// byte-array test still passed, because none of them ever called BigNumber. The defect lived in the
+// SEAM between the helper's contract and the call site, so the test has to span the seam.
+static void test_sessionkey_from_hex_roundtrip()
+{
+    // (a) all 40 bytes significant -> BN_num_bytes() == 40 -> 80 hex chars, the no-pad path.
+    {
+        uint8 vK[40];
+        for (int i = 0; i < 40; ++i)
+        {
+            vK[i] = uint8(i * 7 + 3);
+        }
+        CHECK(vK[39] != 0);
+
+        BigNumber bn;                              // exactly what realmd does (AuthSocket.cpp:668)
+        bn.SetBinary(vK, 40);
+        const char* hex = bn.AsHexStr();           // AuthSocket.cpp:707 -> the DB column
+        CHECK(hex != NULL);
+        CHECK(std::strlen(hex) == 80);
+
+        uint8 out[40] = { 0xEE };
+        CHECK(MopAuth::SessionKeyFromHex(hex, out));
+        for (int i = 0; i < 40; ++i)
+        {
+            CHECK(out[i] == vK[i]);                // a reversed K fails on byte 0
+        }
+        OPENSSL_free((void*)hex);                  // AsHexStr = BN_bn2hex; the caller frees
+    }
+    // (b) THE ~1/256 CASE: most-significant raw byte zero -> BN_bn2hex DROPS it -> 78 hex chars.
+    //     78 is NORMAL, not corruption. The tail pad must restore vK[39] == 0.
+    {
+        uint8 vK[40];
+        for (int i = 0; i < 40; ++i)
+        {
+            vK[i] = uint8(i * 7 + 3);
+        }
+        vK[39] = 0x00;
+
+        BigNumber bn;
+        bn.SetBinary(vK, 40);
+        const char* hex = bn.AsHexStr();
+        CHECK(hex != NULL);
+        CHECK(std::strlen(hex) == 78);             // the row IS short, and that is FINE
+
+        uint8 out[40] = { 0xEE };
+        CHECK(MopAuth::SessionKeyFromHex(hex, out));
+        for (int i = 0; i < 40; ++i)
+        {
+            CHECK(out[i] == vK[i]);                // incl. out[39] == 0x00, padded at the TAIL
+        }
+        OPENSSL_free((void*)hex);
+    }
+    // (c) the adapter REJECTS what it must, at its own boundary.
+    {
+        uint8 out[40] = { 0xEE };
+        CHECK(!MopAuth::SessionKeyFromHex(NULL, out));
+        CHECK(!MopAuth::SessionKeyFromHex("", out));                 // empty -> would be K of zeros
+        CHECK(!MopAuth::SessionKeyFromHex("ABC", out));              // odd length
+        CHECK(!MopAuth::SessionKeyFromHex("ZZZZ", out));             // non-hex
+        CHECK(!MopAuth::SessionKeyFromHex(std::string(82, 'A').c_str(), out));   // 41 bytes
+    }
+}
+
 // NOTE: linking 'shared' drags in ACE, whose OS_main.h rewrites main() to ace_main_i() and
 // requires the (int, char**) signature. A no-argument main() therefore fails to link (LNK2019).
 int main(int /*argc*/, char** /*argv*/)
@@ -357,6 +503,8 @@ int main(int /*argc*/, char** /*argv*/)
     test_in_flight_send_vetoes_with_pending_output();
     test_open_state_never_closes();
     test_drain_never_requests_reactor_reentry();
+    test_raw40_from_littleendian();
+    test_sessionkey_from_hex_roundtrip();
     std::printf(g_fail ? "FAILED (%d)\n" : "OK\n", g_fail);
     return g_fail ? 1 : 0;
 }

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -26,6 +26,7 @@
 #include "MopSocketDrain.h"
 #include "Utilities/ByteBuffer.h"
 #include "Auth/MopAuthKey.h"
+#include "Auth/AuthCrypt.h"
 #include "Auth/BigNumber.h"
 #include <openssl/crypto.h>
 #include <cstdio>
@@ -477,6 +478,185 @@ static void test_sessionkey_from_hex_roundtrip()
     }
 }
 
+// ---------------------------------------------------------------------------------------------
+// AuthCrypt -- the two-phase Prepare()/Activate() crypt and its MoP world seeds
+// (Auth/AuthCrypt.h / .cpp, Auth/ARC4.*, Auth/HMACSHA1.*).
+// ---------------------------------------------------------------------------------------------
+
+// AuthCrypt known-answer test. Fixtures from the spec-derived oracle (tools/mop_stage2_fixtures.py),
+// which asserts these vectors genuinely discriminate: direction (A != B), the 1024-byte drop
+// (drop != no-drop), and short-K (40 bytes != 39). A test that cannot fail on those is decorative.
+//
+// Seeds are BINARY-CONFIRMED in both client binaries (spec 3.1):
+//   A server-encrypt/client-decrypt 08F1959F47E5D2DBA13D778F3F3EE700  Wow-64 0x140F4CCA0 / Wow 0xDC6FD0
+//   B server-decrypt/client-encrypt 40AAD392267143473A3108A6E7DC982A  Wow-64 0x140F4CCB0 / Wow 0xDC6FE0
+static void test_authcrypt_kat()
+{
+    static const uint8 kK_FULL[40] = {
+        0x03,0x0A,0x11,0x18,0x1F,0x26,0x2D,0x34,0x3B,0x42,0x49,0x50,0x57,0x5E,0x65,0x6C,
+        0x73,0x7A,0x81,0x88,0x8F,0x96,0x9D,0xA4,0xAB,0xB2,0xB9,0xC0,0xC7,0xCE,0xD5,0xDC,
+        0xE3,0xEA,0xF1,0xF8,0xFF,0x06,0x0D,0x14 };
+    static const uint8 kKs_SeedA_serverEncrypt[4] = { 0xF6, 0x05, 0x69, 0xC6 };
+    static const uint8 kKs_SeedB_serverDecrypt[4] = { 0x18, 0xEF, 0x76, 0x35 };
+
+    AuthCrypt crypt;
+    CHECK(!crypt.IsInitialized());
+    CHECK(crypt.IsUsable());                       // RC4 selected + sized by the ctor
+    CHECK(crypt.Prepare(kK_FULL));
+    crypt.Activate();
+    CHECK(crypt.IsInitialized());
+
+    // Encrypting zeros yields the keystream verbatim (ARC4 is XOR), so this pins seed A's
+    // direction AND the drop-1024 in one assertion. The return value is CHECKED: a silent false
+    // would leave `send` as zeros, and an unchecked call would then "pass" nothing at all.
+    uint8 send[4] = { 0, 0, 0, 0 };
+    CHECK(crypt.EncryptSend(send, 4));
+    for (int i = 0; i < 4; ++i)
+    {
+        CHECK(send[i] == kKs_SeedA_serverEncrypt[i]);
+    }
+
+    uint8 recv[4] = { 0, 0, 0, 0 };
+    CHECK(crypt.DecryptRecv(recv, 4));
+    for (int i = 0; i < 4; ++i)
+    {
+        CHECK(recv[i] == kKs_SeedB_serverDecrypt[i]);
+    }
+}
+
+// THE STAGE 1 BLOCKER, closed. IsInitialized() used to be a RAN-TO-COMPLETION flag, not a SUCCEEDED
+// flag: AuthCrypt set _initialized = true unconditionally while ARC4 discarded every EVP return
+// value. Since IsInitialized() is the codec discriminator (WorldSocket.cpp:218 send / :862 recv), a
+// failed init would have framed PLAINTEXT headers as HDR_POSTCRYPT.
+static void test_authcrypt_prepare_reports_success()
+{
+    static const uint8 kK_FULL[40] = { 0x03,0x0A,0x11,0x18,0x1F,0x26,0x2D,0x34,0x3B,0x42,
+                                       0x49,0x50,0x57,0x5E,0x65,0x6C,0x73,0x7A,0x81,0x88,
+                                       0x8F,0x96,0x9D,0xA4,0xAB,0xB2,0xB9,0xC0,0xC7,0xCE,
+                                       0xD5,0xDC,0xE3,0xEA,0xF1,0xF8,0xFF,0x06,0x0D,0x14 };
+    AuthCrypt crypt;
+    const bool prepared = crypt.Prepare(kK_FULL);
+    CHECK(prepared);
+    crypt.Activate();
+    CHECK(crypt.IsInitialized());                  // success, not merely two false values agreeing
+}
+
+// *** THE COMMIT-REGION INVARIANT, AS A TEST. ***
+// Between Prepare() and Activate() the ARC4 contexts are fully keyed -- but the crypt must still be
+// INERT: IsInitialized() false, so Decrypt/Encrypt no-op AND the wire codec discriminator
+// (WorldSocket.cpp:218/862) still frames PRE-crypt. That is what lets HandleAuthSession do every
+// fallible thing -- allocate the session, load account data, inflate addons -- AFTER the crypt is
+// prepared, with a throw still leaving the socket exactly as unauthenticated as it started.
+//
+// Stage 1's equivalent ordering rule was load-bearing and its own ledger said "NO TEST COVERS THIS".
+// This is that test.
+static void test_authcrypt_prepare_does_not_activate()
+{
+    static const uint8 kK_FULL[40] = { 0x03,0x0A,0x11,0x18,0x1F,0x26,0x2D,0x34,0x3B,0x42,
+                                       0x49,0x50,0x57,0x5E,0x65,0x6C,0x73,0x7A,0x81,0x88,
+                                       0x8F,0x96,0x9D,0xA4,0xAB,0xB2,0xB9,0xC0,0xC7,0xCE,
+                                       0xD5,0xDC,0xE3,0xEA,0xF1,0xF8,0xFF,0x06,0x0D,0x14 };
+    AuthCrypt crypt;
+    CHECK(crypt.Prepare(kK_FULL));
+    CHECK(!crypt.IsInitialized());                 // keyed, but NOT published
+
+    uint8 header[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
+    CHECK(!crypt.EncryptSend(header, 4));          // still refuses...
+    CHECK(header[0] == 0xDE && header[3] == 0xEF); // ...and has not touched the buffer
+
+    crypt.Activate();
+    CHECK(crypt.IsInitialized());
+    CHECK(crypt.EncryptSend(header, 4));           // only now
+}
+
+// FAIL-CLOSED: Activate() without a successful Prepare() must leave the crypt inert, never
+// half-active. If this ever passes as "initialized", a failed Prepare would publish an unkeyed
+// crypt and the codec would frame plaintext as post-crypt -- the blocker, by another route.
+static void test_authcrypt_activate_without_prepare_is_inert()
+{
+    AuthCrypt crypt;
+    crypt.Activate();                              // no Prepare
+    CHECK(!crypt.IsInitialized());
+
+    uint8 header[4] = { 0x11, 0x22, 0x33, 0x44 };
+    CHECK(!crypt.EncryptSend(header, 4));
+    CHECK(header[0] == 0x11 && header[3] == 0x44);
+}
+
+// A repeated Prepare while PREPARED is an invalid transition. It must poison the unpublished
+// preparation so a caller that ignores the false return cannot Activate stale key material.
+static void test_authcrypt_second_prepare_cannot_activate_stale_key()
+{
+    static const uint8 kK_FULL[40] = { 0x03,0x0A,0x11,0x18,0x1F,0x26,0x2D,0x34,0x3B,0x42,
+                                       0x49,0x50,0x57,0x5E,0x65,0x6C,0x73,0x7A,0x81,0x88,
+                                       0x8F,0x96,0x9D,0xA4,0xAB,0xB2,0xB9,0xC0,0xC7,0xCE,
+                                       0xD5,0xDC,0xE3,0xEA,0xF1,0xF8,0xFF,0x06,0x0D,0x14 };
+    AuthCrypt crypt;
+    CHECK(crypt.Prepare(kK_FULL));
+    CHECK(!crypt.Prepare(kK_FULL));                // rejected before either context is touched
+    CHECK(!crypt.Prepare(kK_FULL));                // FAILED is terminal; no retry/re-key path
+    crypt.Activate();                              // must NOT publish the earlier preparation
+    CHECK(!crypt.IsInitialized());
+}
+
+// Prepare after activation must be rejected before touching the live stream. The next four bytes
+// must therefore be bytes 4..7 of the SAME keystream, not a restarted/re-keyed stream.
+static void test_authcrypt_prepare_after_activate_does_not_mutate_stream()
+{
+    static const uint8 kK_FULL[40] = { 0x03,0x0A,0x11,0x18,0x1F,0x26,0x2D,0x34,0x3B,0x42,
+                                       0x49,0x50,0x57,0x5E,0x65,0x6C,0x73,0x7A,0x81,0x88,
+                                       0x8F,0x96,0x9D,0xA4,0xAB,0xB2,0xB9,0xC0,0xC7,0xCE,
+                                       0xD5,0xDC,0xE3,0xEA,0xF1,0xF8,0xFF,0x06,0x0D,0x14 };
+    // Both arrays are emitted by tools/mop_stage2_fixtures.py's independent RC4 oracle.
+    static const uint8 first[4] = { 0xF6, 0x05, 0x69, 0xC6 };
+    static const uint8 next[4]  = { 0x3A, 0xED, 0x33, 0xFB };
+
+    AuthCrypt crypt;
+    CHECK(crypt.Prepare(kK_FULL));
+    crypt.Activate();
+
+    uint8 bytes[4] = { 0, 0, 0, 0 };
+    CHECK(crypt.EncryptSend(bytes, 4));
+    CHECK(std::memcmp(bytes, first, 4) == 0);
+
+    CHECK(!crypt.Prepare(kK_FULL));                 // ACTIVE -> Prepare rejected, stream untouched
+    CHECK(crypt.IsInitialized());
+    std::memset(bytes, 0, sizeof(bytes));
+    CHECK(crypt.EncryptSend(bytes, 4));
+    CHECK(std::memcmp(bytes, next, 4) == 0);
+}
+
+// An UNINITIALIZED crypt must REFUSE, never silently pass the data through. This is the property
+// that makes the blocker unreachable: if the crypt cannot encrypt, the caller must find out rather
+// than ship the buffer untouched.
+static void test_authcrypt_refuses_before_init()
+{
+    AuthCrypt crypt;
+    CHECK(!crypt.IsInitialized());
+
+    uint8 header[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
+    CHECK(!crypt.EncryptSend(header, 4));          // must report failure...
+    CHECK(header[0] == 0xDE && header[1] == 0xAD && header[2] == 0xBE && header[3] == 0xEF);
+    CHECK(!crypt.DecryptRecv(header, 4));          // ...and leave the buffer untouched
+    CHECK(header[0] == 0xDE && header[1] == 0xAD && header[2] == 0xBE && header[3] == 0xEF);
+}
+
+// MopAuth::IsPlausibleSessionKeyHex edge cases -- the text half of the sessionkey rule
+// (Auth/MopAuthKey.h). test_sessionkey_from_hex_roundtrip covers it THROUGH the adapter; this pins
+// the predicate's own edges, where the "even and <=80 admits the empty string" bug lived.
+static void test_sessionkey_hex_validation()
+{
+    CHECK(!MopAuth::IsPlausibleSessionKeyHex(NULL));
+    CHECK(!MopAuth::IsPlausibleSessionKeyHex(""));            // empty -> would zero-fill; REJECT
+    CHECK(!MopAuth::IsPlausibleSessionKeyHex("ABC"));         // odd length
+    CHECK(!MopAuth::IsPlausibleSessionKeyHex("ABCG"));        // non-hex
+    CHECK(!MopAuth::IsPlausibleSessionKeyHex(std::string(82, 'A').c_str()));  // 41 bytes
+    CHECK(MopAuth::IsPlausibleSessionKeyHex(std::string(80, 'A').c_str()));   // 40 bytes, normal
+    CHECK(MopAuth::IsPlausibleSessionKeyHex(std::string(78, 'A').c_str()));   // one leading zero
+    CHECK(MopAuth::IsPlausibleSessionKeyHex(std::string(76, 'A').c_str()));   // two -- also normal
+    CHECK(MopAuth::IsPlausibleSessionKeyHex(std::string(2, 'A').c_str()));    // no floor exists
+}
+
 // NOTE: linking 'shared' drags in ACE, whose OS_main.h rewrites main() to ace_main_i() and
 // requires the (int, char**) signature. A no-argument main() therefore fails to link (LNK2019).
 int main(int /*argc*/, char** /*argv*/)
@@ -505,6 +685,14 @@ int main(int /*argc*/, char** /*argv*/)
     test_drain_never_requests_reactor_reentry();
     test_raw40_from_littleendian();
     test_sessionkey_from_hex_roundtrip();
+    test_authcrypt_kat();
+    test_authcrypt_prepare_reports_success();
+    test_authcrypt_prepare_does_not_activate();
+    test_authcrypt_activate_without_prepare_is_inert();
+    test_authcrypt_second_prepare_cannot_activate_stale_key();
+    test_authcrypt_prepare_after_activate_does_not_mutate_stream();
+    test_authcrypt_refuses_before_init();
+    test_sessionkey_hex_validation();
     std::printf(g_fail ? "FAILED (%d)\n" : "OK\n", g_fail);
     return g_fail ? 1 : 0;
 }

--- a/src/game/Server/tests/mop_auth_test.cpp
+++ b/src/game/Server/tests/mop_auth_test.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "MopAuthSession.h"
+#include "MopAuthProof.h"
 #include "MopSocketDrain.h"
 #include "Utilities/ByteBuffer.h"
 #include "Auth/MopAuthKey.h"
@@ -657,6 +658,78 @@ static void test_sessionkey_hex_validation()
     CHECK(MopAuth::IsPlausibleSessionKeyHex(std::string(2, 'A').c_str()));    // no floor exists
 }
 
+// ---------------------------------------------------------------------------------------------
+// MopAuth::ComputeAuthProof / ProofEquals -- the spec 3.2 five-chunk SHA1 proof digest, over the
+// canonical raw-40 K, and its constant-time compare (Server/MopAuthProof.h / .cpp).
+// ---------------------------------------------------------------------------------------------
+
+// Spec 3.2's five chunks, in order:
+//   account name (strlen, no NUL) | zero dword (4) | clientSeed (4 LE) | serverSeed (4 LE) | K (40 raw)
+// Total = strlen(account) + 52. There is NO de-interleave step -- one SHA1_Final writes 20
+// contiguous bytes; the forks' "digest[18]; digest[14]; ..." models the SERIALIZER's scatter, which
+// is a different thing entirely and lives in the decoder.
+//
+// CIRCULARITY, STATED HONESTLY (spec 10.7): these expected digests are a FIXTURE derived from 3.2's
+// field table by a standalone script (tools/mop_stage2_fixtures.py) written from the SPEC TEXT,
+// not from this source. They are NOT an independent oracle: a mis-transcription of 3.2 itself would
+// propagate into both and this test would pass. The only true oracle is a real capture, and it
+// cannot serve -- verifying a digest needs that session's K, which is long gone. What this DOES
+// catch is the implementation drifting from the spec, which is what it is for.
+static void test_auth_proof_digest()
+{
+    static const uint8 kK_FULL[40] = {
+        0x03,0x0A,0x11,0x18,0x1F,0x26,0x2D,0x34,0x3B,0x42,0x49,0x50,0x57,0x5E,0x65,0x6C,
+        0x73,0x7A,0x81,0x88,0x8F,0x96,0x9D,0xA4,0xAB,0xB2,0xB9,0xC0,0xC7,0xCE,0xD5,0xDC,
+        0xE3,0xEA,0xF1,0xF8,0xFF,0x06,0x0D,0x14 };
+    static const uint8 kExpect_K_FULL[20] = {
+        0xA7,0x90,0x8C,0xC2,0x5A,0xF4,0xA7,0x21,0x21,0x9A,
+        0x7E,0x7F,0x27,0x36,0x82,0x65,0xF7,0x71,0x32,0xB3 };
+
+    uint8 got[20] = { 0 };
+    MopAuth::ComputeAuthProof("TESTACCOUNT", 0x11223344, 0x55667788, kK_FULL, got);
+    for (int i = 0; i < 20; ++i)
+    {
+        CHECK(got[i] == kExpect_K_FULL[i]);
+    }
+}
+
+// THE ~1/256 CASE. A 40-byte fixture has GetNumBytes() == 40 and takes the no-pad path, so it
+// passes while the bug is fully present. This vector is the one that fails if K is ever hashed as
+// 39 bytes (Sha1Hash::UpdateBigNumbers) or byte-rotated (BigNumber::AsByteArray(40)).
+static void test_auth_proof_digest_zero_top_byte_k()
+{
+    static const uint8 kK_ZERO_TOP[40] = {
+        0x03,0x0A,0x11,0x18,0x1F,0x26,0x2D,0x34,0x3B,0x42,0x49,0x50,0x57,0x5E,0x65,0x6C,
+        0x73,0x7A,0x81,0x88,0x8F,0x96,0x9D,0xA4,0xAB,0xB2,0xB9,0xC0,0xC7,0xCE,0xD5,0xDC,
+        0xE3,0xEA,0xF1,0xF8,0xFF,0x06,0x0D,0x00 };
+    static const uint8 kExpect_K_ZERO_TOP[20] = {
+        0xB3,0xC7,0x52,0xB8,0x7B,0x64,0xE2,0x64,0x98,0x14,
+        0xAA,0x65,0x58,0x36,0x70,0x1E,0x3E,0xC2,0x03,0xD2 };
+
+    uint8 got[20] = { 0 };
+    MopAuth::ComputeAuthProof("TESTACCOUNT", 0x11223344, 0x55667788, kK_ZERO_TOP, got);
+    for (int i = 0; i < 20; ++i)
+    {
+        CHECK(got[i] == kExpect_K_ZERO_TOP[i]);
+    }
+    // The two K vectors differ ONLY in the most-significant byte, so identical digests would mean
+    // the 40th byte never reached the hash.
+    static const uint8 kExpect_K_FULL_first = 0xA7;
+    CHECK(got[0] != kExpect_K_FULL_first);
+}
+
+static void test_proof_equals_constant_time()
+{
+    uint8 a[20], b[20];
+    for (int i = 0; i < 20; ++i) { a[i] = uint8(i); b[i] = uint8(i); }
+    CHECK(MopAuth::ProofEquals(a, b));
+    b[19] ^= 0x01;                                   // last byte -- the one a short compare misses
+    CHECK(!MopAuth::ProofEquals(a, b));
+    b[19] ^= 0x01;
+    b[0] ^= 0x80;
+    CHECK(!MopAuth::ProofEquals(a, b));
+}
+
 // NOTE: linking 'shared' drags in ACE, whose OS_main.h rewrites main() to ace_main_i() and
 // requires the (int, char**) signature. A no-argument main() therefore fails to link (LNK2019).
 int main(int /*argc*/, char** /*argv*/)
@@ -693,6 +766,9 @@ int main(int /*argc*/, char** /*argv*/)
     test_authcrypt_prepare_after_activate_does_not_mutate_stream();
     test_authcrypt_refuses_before_init();
     test_sessionkey_hex_validation();
+    test_auth_proof_digest();
+    test_auth_proof_digest_zero_top_byte_k();
+    test_proof_equals_constant_time();
     std::printf(g_fail ? "FAILED (%d)\n" : "OK\n", g_fail);
     return g_fail ? 1 : 0;
 }

--- a/src/game/Warden/WardenWin.cpp
+++ b/src/game/Warden/WardenWin.cpp
@@ -336,9 +336,15 @@ void WardenWin::RequestData()
             {
                 uint32 seed = rand32();
                 buff << uint32(seed);
-                HMACSHA1 hmac(4, (uint8*)&seed);
+                HMACSHA1 hmac(sizeof(seed), reinterpret_cast<const uint8*>(&seed));
                 hmac.UpdateData(wd->Str);
                 hmac.Finalize();
+                if (!hmac.IsValid())
+                {
+                    sLog.outWarden("MODULE_CHECK HMAC-SHA1 failed, CheckId %u account Id %u",
+                                   *itr, _session->GetAccountId());
+                    return;                       // do not encrypt/send a request with a bad digest
+                }
                 buff.append(hmac.GetDigest(), hmac.GetLength());
                 break;
             }

--- a/src/game/WorldHandlers/CharacterHandler.cpp
+++ b/src/game/WorldHandlers/CharacterHandler.cpp
@@ -219,6 +219,16 @@ void WorldSession::HandleCharEnum(QueryResult* result)
  */
 void WorldSession::HandleCharEnumOpcode(WorldPacket & /*recv_data*/)
 {
+    // GATE 3b EVIDENCE (Phase 3). Reaching this line PROVES dispatch past the opcode legality
+    // check: CMSG_CHAR_ENUM is registered STATUS_AUTHED (opcode_register.inc:4), so ExecuteOpcode
+    // is the only route in and it runs only for an authenticated session. Inbound packet logging
+    // (WorldSocket.cpp:806) happens BEFORE that check, so a "CLIENT:" line proves receipt only --
+    // which is why this marker exists rather than a grep of the packet log.
+    // Payload-free: account id only, never the name (spec 2). Kept beyond Phase 3: Phase 4 builds
+    // the character response here and will want the same boundary marked.
+    DEBUG_LOG("WorldSession::HandleCharEnumOpcode: CMSG_CHAR_ENUM dispatched for account %u.",
+              GetAccountId());
+
     /// get all the data necessary for loading all characters (along with their pets) on the account
     CharacterDatabase.AsyncPQuery(&chrHandler, &CharacterHandler::HandleCharEnumCallback, GetAccountId(),
                                   !sWorld.getConfig(CONFIG_BOOL_DECLINED_NAMES_USED) ?

--- a/src/game/WorldHandlers/CharacterHandler.cpp
+++ b/src/game/WorldHandlers/CharacterHandler.cpp
@@ -221,9 +221,10 @@ void WorldSession::HandleCharEnumOpcode(WorldPacket & /*recv_data*/)
 {
     // GATE 3b EVIDENCE (Phase 3). Reaching this line PROVES dispatch past the opcode legality
     // check: CMSG_CHAR_ENUM is registered STATUS_AUTHED (opcode_register.inc:4), so ExecuteOpcode
-    // is the only route in and it runs only for an authenticated session. Inbound packet logging
-    // (WorldSocket.cpp:806) happens BEFORE that check, so a "CLIENT:" line proves receipt only --
-    // which is why this marker exists rather than a grep of the packet log.
+    // is the only route in and it runs only for an authenticated session. WorldSocket's inbound
+    // packet-logging (before the state-legality check) happens BEFORE that check, so a "CLIENT:"
+    // line proves receipt only -- which is why this marker exists rather than a grep of the
+    // packet log.
     // Payload-free: account id only, never the name (spec 2). Kept beyond Phase 3: Phase 4 builds
     // the character response here and will want the same boundary marked.
     DEBUG_LOG("WorldSession::HandleCharEnumOpcode: CMSG_CHAR_ENUM dispatched for account %u.",

--- a/src/game/WorldHandlers/World.h
+++ b/src/game/WorldHandlers/World.h
@@ -533,7 +533,13 @@ class World
         void CleanupsBeforeStop();
 
         WorldSession* FindSession(uint32 id) const;
-        void AddSession(WorldSession* s);
+
+        /// Infallible auth-commit callback invoked by AddSession while the add-queue lock is held.
+        using SessionPublishCommit = void (*)(void*) noexcept;
+
+        /// Reserve/enqueue while locked, invoke the infallible auth commit, then unlock/publish.
+        /// Returns false with no queue change and without invoking commit when lock/allocation fails.
+        bool AddSession(WorldSession* s, SessionPublishCommit commit, void* context);
         bool RemoveSession(uint32 id);
         /// Get the number of current active sessions
         void UpdateMaxSessionCounters();

--- a/src/game/WorldHandlers/WorldSessionMgr.cpp
+++ b/src/game/WorldHandlers/WorldSessionMgr.cpp
@@ -31,6 +31,8 @@
 #include "Database/DatabaseEnv.h"
 #include "Log.h"
 
+#include <exception>
+
 /**
  * @file WorldSessionMgr.cpp
  * @brief Cohesion split of World.cpp -- session management: zone player lookup, session add/remove and the login wait-queue. Same World class; no behaviour change. CMake file(GLOB) picks this file up automatically; World.h is unchanged.
@@ -95,15 +97,50 @@ bool World::RemoveSession(uint32 id)
 }
 
 /**
- * @brief Queues a new session for addition during the world update.
+ * @brief Enqueues a new session and publishes the authenticated commit as one queue-lock transaction.
  *
- * @param s The session to add.
+ * The ONLY fallible operation -- queue insertion -- runs first, while the lock is held. Only after
+ * it succeeds does the infallible commit callback run, still under the lock, so the world thread
+ * cannot observe or pop the queued session until crypt and connection state have been committed.
+ * Releasing the lock is the externally visible publication point.
+ *
+ * @param s       The session to add.
+ * @param commit  Infallible (noexcept) callback performing the auth commit; runs only on success.
+ * @param context Opaque argument forwarded to @p commit.
+ * @return true once the session is enqueued and committed; false with no queue change and without
+ *         invoking @p commit if the arguments are invalid or enqueue fails.
  */
-void World::AddSession(WorldSession* s)
+bool World::AddSession(WorldSession* s, SessionPublishCommit commit, void* context)
 {
-    std::lock_guard<std::mutex> guard(m_sessionAddQueueLock);
+    if (!s || !commit || !context)
+    {
+        sLog.outError("World::AddSession: refusing invalid publication arguments.");
+        return false;
+    }
 
-    m_sessionAddQueue.push_back(s);
+    try
+    {
+        std::lock_guard<std::mutex> guard(m_sessionAddQueueLock);
+
+        // std::deque::push_back has the strong exception guarantee here: if allocation throws,
+        // the queue is unchanged and the commit callback has not run.
+        m_sessionAddQueue.push_back(s);
+
+        // Still under the queue lock: the world thread cannot observe/pop the new session yet.
+        // The function-pointer type is noexcept and the callback performs stores only.
+        commit(context);
+        return true;                    // guard unlocks: THIS is externally visible publication
+    }
+    catch (std::exception const& e)
+    {
+        sLog.outError("World::AddSession: could not enqueue session: %s", e.what());
+        return false;
+    }
+    catch (...)
+    {
+        sLog.outError("World::AddSession: could not enqueue session (unknown exception).");
+        return false;
+    }
 }
 
 void

--- a/src/game/WorldHandlers/WorldSessionMgr.cpp
+++ b/src/game/WorldHandlers/WorldSessionMgr.cpp
@@ -26,6 +26,7 @@
 #include "WorldSession.h"
 #include "WorldPacket.h"
 #include "Opcodes.h"
+#include "MopAuthResponse.h"
 #include "Player.h"
 #include "Database/DatabaseEnv.h"
 #include "Log.h"
@@ -162,18 +163,9 @@ World::AddSession_(WorldSession* s)
         return;
     }
 
-    WorldPacket packet(SMSG_AUTH_RESPONSE, 17);
-
-    packet.WriteBit(false);                                 // has queue
-    packet.WriteBit(true);                                  // has account info
-
-    packet << uint32(0);                                    // Unknown - 4.3.2
-    packet << uint8(s->Expansion());                        // 0 - normal, 1 - TBC, 2 - WotLK, 3 - CT. must be set in database manually for each account
-    packet << uint32(0);                                    // BillingTimeRemaining
-    packet << uint8(s->Expansion());                        // 0 - normal, 1 - TBC, 2 - WotLK, 3 - CT. Must be set in database manually for each account.
-    packet << uint32(0);                                    // BillingTimeRested
-    packet << uint8(0);                                     // BillingPlanFlags
-    packet << uint8(AUTH_OK);
+    WorldPacket packet;
+    MopAuth::BuildAuthResponseAccepted(packet, s->Expansion(),
+                                       uint8(getConfig(CONFIG_UINT32_EXPANSION)));
 
     s->SendPacket(&packet);
 
@@ -233,20 +225,9 @@ void World::AddQueuedSession(WorldSession* sess)
     m_QueuedSessions.push_back(sess);
 
     // The 1st SMSG_AUTH_RESPONSE needs to contain other info too.
-    WorldPacket packet (SMSG_AUTH_RESPONSE, 21);
-
-    packet.WriteBit(true);                                  // has queue
-    packet.WriteBit(false);                                 // unk queue-related
-    packet.WriteBit(true);                                  // has account data
-
-    packet << uint32(0);                                    // Unknown - 4.3.2
-    packet << uint8(sess->Expansion());                     // 0 - normal, 1 - TBC, 2 - WotLK, 3 - CT. must be set in database manually for each account
-    packet << uint32(0);                                    // BillingTimeRemaining
-    packet << uint8(sess->Expansion());                     // 0 - normal, 1 - TBC, 2 - WotLK, 3 - CT. Must be set in database manually for each account.
-    packet << uint32(0);                                    // BillingTimeRested
-    packet << uint8(0);                                     // BillingPlanFlags
-    packet << uint8(AUTH_WAIT_QUEUE);
-    packet << uint32(GetQueuedSessionPos(sess));            // position in queue
+    WorldPacket packet;
+    MopAuth::BuildAuthResponseQueued(packet, GetQueuedSessionPos(sess), sess->Expansion(),
+                                     uint8(getConfig(CONFIG_UINT32_EXPANSION)));
 
     sess->SendPacket(&packet);
 }

--- a/src/shared/Auth/ARC4.cpp
+++ b/src/shared/Auth/ARC4.cpp
@@ -52,14 +52,14 @@
  * @note On OpenSSL 3.x, this automatically initializes the legacy provider
  * required for ARC4 support.
  */
-ARC4::ARC4(uint8 len) : m_cipherContext()
+ARC4::ARC4(uint8 len) : m_cipherContext(), m_ready(false), m_keyed(false)
 {
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
     // Provider management is now handled by OpenSSLProviderManager
     if (!m_providerManager.IsInitialized())
     {
         sLog.outError("ARC4: Failed to initialize OpenSSL providers");
-        return;
+        return;                                  // m_ready stays false -- the context is NOT usable
     }
 #endif
 
@@ -69,42 +69,28 @@ ARC4::ARC4(uint8 len) : m_cipherContext()
         return;
     }
 
-    EVP_EncryptInit_ex(m_cipherContext.Get(), EVP_rc4(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_set_key_length(m_cipherContext.Get(), len);
-}
-
-/**
- * @brief Construct ARC4 cipher with initial key
- * @param seed Pointer to the key bytes
- * @param len Length of the key in bytes
- *
- * Creates an ARC4 cipher context and initializes it with the provided key.
- * The cipher is ready to use for encryption/decryption immediately after
- * construction.
- *
- * @note On OpenSSL 3.x, this automatically initializes the legacy provider
- * required for ARC4 support.
- */
-ARC4::ARC4(uint8 *seed, uint8 len) : m_cipherContext()
-{
-#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
-    // Provider management is now handled by OpenSSLProviderManager
-    if (!m_providerManager.IsInitialized())
+    // EVP_rc4() returns NULL when RC4 is unavailable. On OpenSSL 3 RC4 is a LEGACY algorithm, so
+    // this is a real deployment failure, not a theoretical one -- and the old code ignored it.
+    const EVP_CIPHER* cipher = EVP_rc4();
+    if (!cipher)
     {
-        sLog.outError("ARC4: Failed to initialize OpenSSL providers");
-        return;
-    }
-#endif
-
-    if (!m_cipherContext.IsValid())
-    {
-        sLog.outError("ARC4: Failed to create cipher context");
+        sLog.outError("ARC4: RC4 cipher unavailable (OpenSSL legacy provider not loaded?)");
         return;
     }
 
-    EVP_EncryptInit_ex(m_cipherContext.Get(), EVP_rc4(), NULL, NULL, NULL);
-    EVP_CIPHER_CTX_set_key_length(m_cipherContext.Get(), len);
-    EVP_EncryptInit_ex(m_cipherContext.Get(), NULL, NULL, seed, NULL);
+    if (EVP_EncryptInit_ex(m_cipherContext.Get(), cipher, NULL, NULL, NULL) != 1)
+    {
+        sLog.outError("ARC4: EVP_EncryptInit_ex(RC4) failed");
+        return;
+    }
+
+    if (EVP_CIPHER_CTX_set_key_length(m_cipherContext.Get(), len) != 1)
+    {
+        sLog.outError("ARC4: EVP_CIPHER_CTX_set_key_length(%u) failed", uint32(len));
+        return;
+    }
+
+    m_ready = true;                              // selected + sized; still needs a key via Init()
 }
 
 /**
@@ -127,12 +113,25 @@ ARC4::~ARC4()
  *
  * @note The key length must match the length specified in the constructor.
  */
-void ARC4::Init(uint8 *seed)
+bool ARC4::Init(uint8* seed)
 {
-    if (m_cipherContext.IsValid())
+    if (!m_ready)
     {
-        EVP_EncryptInit_ex(m_cipherContext.Get(), NULL, NULL, seed, NULL);
+        sLog.outError("ARC4::Init: cipher was never selected; refusing to key.");
+        return false;
     }
+
+    if (EVP_EncryptInit_ex(m_cipherContext.Get(), NULL, NULL, seed, NULL) != 1)
+    {
+        // Fail CLOSED: after a rejected re-key the cipher's internal state is unknown, so it must
+        // not be treated as usable just because it was usable a moment ago.
+        sLog.outError("ARC4::Init: EVP_EncryptInit_ex(key) failed");
+        m_keyed = false;
+        return false;
+    }
+
+    m_keyed = true;
+    return true;
 }
 
 /**
@@ -147,15 +146,45 @@ void ARC4::Init(uint8 *seed)
  * @warning The cipher must be initialized with a key before calling this.
  * @note The output length will always equal the input length for ARC4.
  */
-void ARC4::UpdateData(int len, uint8 *data)
+bool ARC4::UpdateData(int len, uint8* data)
 {
-    if (!m_cipherContext.IsValid())
+    if (!IsReady())
     {
-        sLog.outError("ARC4: Invalid cipher context, cannot update data");
-        return;
+        sLog.outError("ARC4::UpdateData: cipher not ready; refusing to process %d bytes.", len);
+        return false;
     }
 
+    // NO EVP_EncryptFinal_ex. The old code called it after EVERY chunk, which is wrong twice over:
+    //   1. OpenSSL's contract: after EVP_EncryptFinal_ex "the encryption operation is finished and
+    //      no further calls to EVP_EncryptUpdate() should be made". This context is used for the
+    //      1024-byte drop and then for EVERY packet header for the socket's whole life, so
+    //      finalizing between chunks ends the very stream we depend on continuing.
+    //   2. RC4 is a STREAM cipher: there is no block to flush and no padding to write, so Final has
+    //      nothing to do. It "worked" only because EVP short-circuits Final for block_size == 1 --
+    //      an implementation detail, not a guarantee, and one the OpenSSL 3 provider path is under
+    //      no obligation to preserve.
+    // Removing it changes no bytes on the wire (Final produced none) and removes a documented-
+    // invalid call. NOTE this also removes a hazard the return-value checks would otherwise have
+    // INTRODUCED: had a provider ever returned 0 from that Final, the old code ignored it while a
+    // checked version would have failed the whole auth.
     int outlen = 0;
-    EVP_EncryptUpdate(m_cipherContext.Get(), data, &outlen, data, len);
-    EVP_EncryptFinal_ex(m_cipherContext.Get(), data, &outlen);
+    if (EVP_EncryptUpdate(m_cipherContext.Get(), data, &outlen, data, len) != 1)
+    {
+        // Fail CLOSED: after a failed operation the keystream position is unknown, so every later
+        // header would be garbage even if the next call "succeeds". Refuse to be used again.
+        sLog.outError("ARC4::UpdateData: EVP_EncryptUpdate failed on %d bytes; cipher invalidated.", len);
+        m_keyed = false;
+        return false;
+    }
+
+    // A stream cipher must consume and produce exactly len. Anything else means the keystream and
+    // the data have desynchronised, which on the wire is indistinguishable from a wrong key.
+    if (outlen != len)
+    {
+        sLog.outError("ARC4::UpdateData: produced %d bytes for %d in; cipher invalidated.", outlen, len);
+        m_keyed = false;
+        return false;
+    }
+
+    return true;
 }

--- a/src/shared/Auth/ARC4.h
+++ b/src/shared/Auth/ARC4.h
@@ -45,31 +45,51 @@ class ARC4
          */
         ARC4(uint8 len);
         /**
-         * @brief Constructor with seed data
-         * @param seed Pointer to the seed/key data
-         * @param len Length of the seed data in bytes
-         */
-        ARC4(uint8 *seed, uint8 len);
-        /**
          * @brief Destructor
          */
         ~ARC4();
+
         /**
-         * @brief Initialize the cipher with seed data
-         * @param seed Pointer to the seed/key data
+         * @brief Install or replace the cipher key.
+         * @return false if the cipher is not ready or OpenSSL rejected the key. On false the
+         *         object is left UNUSABLE (m_keyed cleared) rather than half-keyed.
          */
-        void Init(uint8 *seed);
+        bool Init(uint8* seed);
+
         /**
-         * @brief Update/encrypt data using the cipher
-         * @param len Length of the data to process
-         * @param data Pointer to the data to encrypt/decrypt
+         * @brief Encrypt/decrypt in place. Advances the ONE continuous RC4 keystream.
+         *
+         * Does NOT finalize: RC4 is a stream cipher and this context lives for the whole socket, so
+         * there is nothing to flush between headers and finalizing would end the stream.
+         *
+         * @return false if the cipher is not ready, OpenSSL failed, or the output length did not
+         *         match the input. On false `data`'s contents are UNDEFINED -- EVP works in place
+         *         and may have partially written before failing -- so the caller must DISCARD the
+         *         frame or packet. It must never be sent or parsed, and it must not be assumed
+         *         unchanged.
          */
-        void UpdateData(int len, uint8 *data);
+        bool UpdateData(int len, uint8* data);
+
+        /**
+         * @brief Whether this cipher is selected, key-length-accepted and keyed -- i.e. UpdateData
+         *        can be expected to work.
+         *
+         * NOT a pointer check. m_cipherContext can be non-null while the cipher was never given
+         * EVP_rc4() (the ctor returns early if the OpenSSL 3 legacy provider is unavailable, and
+         * RC4 lives in that provider). Asking the pointer would answer "fine" on a box that cannot
+         * do RC4 at all.
+         */
+        bool IsReady() const { return m_ready && m_keyed; }
+
+        /// Cipher selected and key length accepted; a key may not be installed yet.
+        bool IsSelected() const { return m_ready; }
     private:
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
         OpenSSLProviderManager m_providerManager;  /**< RAII provider management */
 #endif
         OpenSSLCipherContext m_cipherContext;        /**< RAII cipher context */
+        bool m_ready;                                /**< cipher selected + key length accepted */
+        bool m_keyed;                                /**< a key has been installed */
 };
 
 #endif

--- a/src/shared/Auth/AuthCrypt.cpp
+++ b/src/shared/Auth/AuthCrypt.cpp
@@ -25,74 +25,156 @@
 #include "AuthCrypt.h"
 #include "HMACSHA1.h"
 #include "Log/Log.h"
-#include "BigNumber.h"
 
 /**
  * Initializes the authentication crypt state in an uninitialized state.
  */
 AuthCrypt::AuthCrypt() : _clientDecrypt(SHA_DIGEST_LENGTH), _serverEncrypt(SHA_DIGEST_LENGTH)
 {
-    _initialized = false;
+    _state = CRYPT_FRESH;
 }
 
 AuthCrypt::~AuthCrypt()
 {
 }
 
-void AuthCrypt::Init(BigNumber* K)
+// World-crypt HMAC seeds for 5.4.8.18414. BINARY-CONFIRMED IN BOTH CLIENT BINARIES (spec 3.1) --
+// not fork-derived. Construction confirmed at sub_140A7F0B0 / sub_A6331B; the object is the world
+// PacketPipe. Direction was DERIVED from the client's send/recv paths, not assumed.
+//
+// DO NOT substitute the Battle.net seeds (68E0C72E.../DEA965AE... @ 0x14100DD10): different
+// subsystem (BSN::Hard::Decoder, SHA256).
+//
+// These REPLACED the 4.3.4-era seeds (CC98AE04... / C2B3723C...) that shipped here through Stage 1.
+// Those are wrong for MoP and fail the crypt indistinguishably from a wrong K.
+
+/// Server-encrypt / client-decrypt. Wow-64 VA 0x140F4CCA0 / Wow.exe VA 0xDC6FD0.
+static const uint8 SeedServerEncrypt[SEED_KEY_SIZE] =
 {
-    uint8 ServerEncryptionKey[SEED_KEY_SIZE] = { 0xCC, 0x98, 0xAE, 0x04, 0xE8, 0x97, 0xEA, 0xCA, 0x12, 0xDD, 0xC0, 0x93, 0x42, 0x91, 0x53, 0x57 };
+    0x08, 0xF1, 0x95, 0x9F, 0x47, 0xE5, 0xD2, 0xDB, 0xA1, 0x3D, 0x77, 0x8F, 0x3F, 0x3E, 0xE7, 0x00
+};
 
-    HMACSHA1 serverEncryptHmac(SEED_KEY_SIZE, (uint8*)ServerEncryptionKey);
-    uint8* encryptHash = serverEncryptHmac.ComputeHash(K);
+/// Server-decrypt / client-encrypt. Wow-64 VA 0x140F4CCB0 / Wow.exe VA 0xDC6FE0.
+static const uint8 SeedServerDecrypt[SEED_KEY_SIZE] =
+{
+    0x40, 0xAA, 0xD3, 0x92, 0x26, 0x71, 0x43, 0x47, 0x3A, 0x31, 0x08, 0xA6, 0xE7, 0xDC, 0x98, 0x2A
+};
 
-    uint8 ServerDecryptionKey[SEED_KEY_SIZE] = { 0xC2, 0xB3, 0x72, 0x3C, 0xC6, 0xAE, 0xD9, 0xB5, 0x34, 0x3C, 0x53, 0xEE, 0x2F, 0x43, 0x67, 0xCE };
+bool AuthCrypt::Prepare(const uint8 (&K)[MopAuth::SESSION_KEY_LEN])
+{
+    // ONE-SHOT STATE MACHINE. Reject repeats before touching either live stream.
+    //
+    // A repeated call while PREPARED poisons that unpublished preparation: a caller that ignored
+    // the false return must not be able to Activate() stale key material from the earlier success.
+    // A call while ACTIVE is rejected without changing state or touching either ARC4 context, so it
+    // cannot corrupt an already-live stream.
+    if (_state != CRYPT_FRESH)
+    {
+        sLog.outError("AuthCrypt::Prepare: invalid state transition from %u.", uint32(_state));
+        if (_state == CRYPT_PREPARED)
+        {
+            _state = CRYPT_FAILED;
+        }
+        return false;
+    }
 
-    HMACSHA1 clientDecryptHmac(SEED_KEY_SIZE, (uint8*)ServerDecryptionKey);
-    uint8* decryptHash = clientDecryptHmac.ComputeHash(K);
+    // Pessimistically enter FAILED before the first fallible operation. Every early return below
+    // therefore leaves an explicit terminal failure state, never a fresh-looking or activatable
+    // half-keyed object.
+    _state = CRYPT_FAILED;
 
-    // SARC4 _serverDecrypt(encryptHash);
-    _clientDecrypt.Init(decryptHash);
-    _serverEncrypt.Init(encryptHash);
-    // SARC4 _clientEncrypt(decryptHash);
+    if (!IsUsable())
+    {
+        sLog.outError("AuthCrypt::Prepare: RC4 unavailable; crypt NOT prepared.");
+        return false;
+    }
 
+    // Per direction: HMAC-SHA1(key = 16-byte seed, message = K [40 raw]) -> 20-byte digest
+    //             -> ARC4 KSA -> drop-1024. Shape binary-confirmed; drop-1024 binary-confirmed.
+    // The raw-40 K is passed straight through: HMACSHA1::ComputeHash(BigNumber*) would hash
+    // GetNumBytes(), not 40, reintroducing the short-K bug this migration removes.
+    HMACSHA1 serverEncryptHmac(SEED_KEY_SIZE, SeedServerEncrypt);
+    serverEncryptHmac.UpdateData(K, int(MopAuth::SESSION_KEY_LEN));
+    serverEncryptHmac.Finalize();
+
+    HMACSHA1 clientDecryptHmac(SEED_KEY_SIZE, SeedServerDecrypt);
+    clientDecryptHmac.UpdateData(K, int(MopAuth::SESSION_KEY_LEN));
+    clientDecryptHmac.Finalize();
+
+    if (!serverEncryptHmac.IsValid() || !clientDecryptHmac.IsValid())
+    {
+        sLog.outError("AuthCrypt::Prepare: HMAC-SHA1 failed; crypt NOT prepared.");
+        return false;
+    }
+
+    uint8* encryptHash = serverEncryptHmac.GetDigest();
+    uint8* decryptHash = clientDecryptHmac.GetDigest();
+
+    // EVERY step below is checked. This is the whole point of the task: ARC4 used to swallow every
+    // EVP failure, so "Init ran" and "Init worked" were indistinguishable -- and IsInitialized() is
+    // what selects the post-crypt header, so the difference is plaintext on the wire.
+    if (!_clientDecrypt.Init(decryptHash) || !_serverEncrypt.Init(encryptHash))
+    {
+        sLog.outError("AuthCrypt::Prepare: ARC4 keying failed; crypt NOT prepared.");
+        return false;
+    }
+
+    // drop-1024 (binary-confirmed). Checked too: a failed drop leaves the keystream at the wrong
+    // position, which desynchronises every subsequent header exactly like a wrong key -- and
+    // silently.
     uint8 syncBuf[1024];
 
     memset(syncBuf, 0, 1024);
-
-    _serverEncrypt.UpdateData(1024, syncBuf);
-    //_clientEncrypt.UpdateData(1024, syncBuf);
+    if (!_serverEncrypt.UpdateData(1024, syncBuf))
+    {
+        sLog.outError("AuthCrypt::Prepare: server-encrypt drop-1024 failed; crypt NOT prepared.");
+        return false;
+    }
 
     memset(syncBuf, 0, 1024);
+    if (!_clientDecrypt.UpdateData(1024, syncBuf))
+    {
+        sLog.outError("AuthCrypt::Prepare: client-decrypt drop-1024 failed; crypt NOT prepared.");
+        return false;
+    }
 
-    //_serverDecrypt.UpdateData(1024, syncBuf);
-    _clientDecrypt.UpdateData(1024, syncBuf);
-
-    _initialized = true;
+    // MUST REMAIN THE LAST STATE CHANGE, and it is only reached when the ENTIRE chain succeeded:
+    // RC4 selected -> HMAC digests valid -> both directions keyed -> drop-1024 applied to both.
+    //
+    // NOTE THIS SETS PREPARED, NOT ACTIVE. The crypt is now fully keyed but still INERT:
+    // IsInitialized() is false, so Decrypt/Encrypt no-op and the wire codec still frames pre-crypt.
+    // Only Activate() publishes it. That separation is what makes the caller's commit region
+    // infallible -- see Activate()'s doc and Task 8.
+    //
+    // Hoisting this, or adding an early return BELOW it, silently turns a failure into an
+    // activatable half-keyed crypt. The state-transition tests pin fresh, prepared, failed and
+    // active behaviour -- unlike Stage 1, where the equivalent rule had no test.
+    _state = CRYPT_PREPARED;
+    return true;
 }
 
 /**
  * Decrypts the fixed-size encrypted receive header in place.
  */
-void AuthCrypt::DecryptRecv(uint8* data, size_t len)
+bool AuthCrypt::DecryptRecv(uint8* data, size_t len)
 {
-    if (!_initialized)
+    if (_state != CRYPT_ACTIVE)
     {
-        return;
+        return false;                            // pre-crypt: nothing to do, and nothing was done
     }
 
-    _clientDecrypt.UpdateData(len, data);
+    return _clientDecrypt.UpdateData(int(len), data);
 }
 
 /**
  * Encrypts the fixed-size outgoing packet header in place.
  */
-void AuthCrypt::EncryptSend(uint8* data, size_t len)
+bool AuthCrypt::EncryptSend(uint8* data, size_t len)
 {
-    if (!_initialized)
+    if (_state != CRYPT_ACTIVE)
     {
-        return;
+        return false;
     }
 
-    _serverEncrypt.UpdateData(len, data);
+    return _serverEncrypt.UpdateData(int(len), data);
 }

--- a/src/shared/Auth/AuthCrypt.h
+++ b/src/shared/Auth/AuthCrypt.h
@@ -64,9 +64,10 @@ class AuthCrypt
          *         while ACTIVE is rejected before touching the live streams.
          *         On false the object is INERT unless it was already ACTIVE.
          *         DecryptRecv/EncryptSend no-op while not ACTIVE and
-         *         IsInitialized() -- the wire codec discriminator (WorldSocket.cpp:218/862) --
-         *         still reports pre-crypt. Callers MUST check it: proceeding on false puts
-         *         PLAINTEXT HEADERS on the wire framed as encrypted.
+         *         IsInitialized() -- the wire codec discriminator (WorldSocket::SendPacket's
+         *         post-crypt branch / WorldSocket::DecryptHeaderHook) -- still reports pre-crypt.
+         *         Callers MUST check it: proceeding on false puts PLAINTEXT HEADERS on the wire
+         *         framed as encrypted.
          */
         bool Prepare(const uint8 (&K)[MopAuth::SESSION_KEY_LEN]);
 
@@ -80,8 +81,9 @@ class AuthCrypt
          *
          * Between Prepare() and Activate() the ARC4 contexts are fully keyed but IsInitialized()
          * still reports FALSE -- so Decrypt/Encrypt no-op and, critically, the wire codec
-         * discriminator (WorldSocket.cpp:218/862) still frames PRE-crypt. A throw or early return
-         * in that window therefore leaves the socket exactly as unauthenticated as it started.
+         * discriminator (WorldSocket::SendPacket's post-crypt branch /
+         * WorldSocket::DecryptHeaderHook) still frames PRE-crypt. A throw or early return in that
+         * window therefore leaves the socket exactly as unauthenticated as it started.
          *
          * FAIL-CLOSED: activating from any state other than PREPARED is a no-op. Do not "simplify"
          * this to an unconditional boolean store.

--- a/src/shared/Auth/AuthCrypt.h
+++ b/src/shared/Auth/AuthCrypt.h
@@ -27,8 +27,7 @@
 
 #include "Common/Common.h"
 #include "ARC4.h"
-
-class BigNumber;
+#include "MopAuthKey.h"
 
 /**
  * @brief Authentication encryption/decryption for World of Warcraft protocol
@@ -52,32 +51,105 @@ class AuthCrypt
 
 
         /**
-         * @brief Initialize the encryption/decryption state
-         * @param K Session key used to seed the cipher state
+         * @brief Initialize the encryption/decryption state from the canonical session key.
+         *
+         * @param K The session key as EXACTLY 40 raw bytes. The client hashes 40 raw bytes
+         *          [BINARY sub_140A6F050]; a BigNumber-shaped key silently yields 39 on ~1/256 of
+         *          logins (leading zero dropped by BN_bn2hex), which fails the crypt
+         *          indistinguishably. The array reference makes the length a compile-time fact.
+         * @return true when BOTH ARC4 directions were keyed and dropped successfully. This is a
+         *         ONE-SHOT transition: only FRESH may prepare. On any operational failure the state
+         *         becomes FAILED; a second Prepare while PREPARED poisons that unpublished
+         *         preparation rather than allowing stale key material to be activated; Prepare
+         *         while ACTIVE is rejected before touching the live streams.
+         *         On false the object is INERT unless it was already ACTIVE.
+         *         DecryptRecv/EncryptSend no-op while not ACTIVE and
+         *         IsInitialized() -- the wire codec discriminator (WorldSocket.cpp:218/862) --
+         *         still reports pre-crypt. Callers MUST check it: proceeding on false puts
+         *         PLAINTEXT HEADERS on the wire framed as encrypted.
          */
-        void Init(BigNumber* K);
-        /**
-         * @brief Decrypt received data from client
-         * @param data Pointer to data buffer to decrypt
-         * @param len Length of data to decrypt
-         */
-        void DecryptRecv(uint8* data, size_t len);
-        /**
-         * @brief Encrypt data to send to client
-         * @param data Pointer to data buffer to encrypt
-         * @param len Length of data to encrypt
-         */
-        void EncryptSend(uint8* data, size_t len);
+        bool Prepare(const uint8 (&K)[MopAuth::SESSION_KEY_LEN]);
 
         /**
-         * @brief Check if the crypt object is initialized
-         * @return True if initialized, false otherwise
+         * @brief Publish a prepared crypt. `noexcept`, and the ONLY PREPARED -> ACTIVE transition.
+         *
+         * Split from Prepare() so that every fallible step -- HMAC, ARC4 keying, the drop-1024 --
+         * happens BEFORE the caller allocates anything, while activation itself is a single store
+         * that cannot fail. That is what lets HandleAuthSession's commit region be genuinely
+         * infallible instead of merely short (spec 6.6b).
+         *
+         * Between Prepare() and Activate() the ARC4 contexts are fully keyed but IsInitialized()
+         * still reports FALSE -- so Decrypt/Encrypt no-op and, critically, the wire codec
+         * discriminator (WorldSocket.cpp:218/862) still frames PRE-crypt. A throw or early return
+         * in that window therefore leaves the socket exactly as unauthenticated as it started.
+         *
+         * FAIL-CLOSED: activating from any state other than PREPARED is a no-op. Do not "simplify"
+         * this to an unconditional boolean store.
          */
-        bool IsInitialized() { return _initialized; }
+        void Activate() noexcept
+        {
+            if (_state == CRYPT_PREPARED)
+            {
+                _state = CRYPT_ACTIVE;
+            }
+        }
+
+        /**
+         * @brief Decrypt the received header in place.
+         *
+         * @return false if the crypt is uninitialized or OpenSSL failed. The two false cases differ
+         *         and callers must assume the WEAKER one:
+         *           - uninitialized -> EVP was never called, so `data` is genuinely untouched;
+         *           - OpenSSL failure -> `data` is UNDEFINED (EVP works in place and may have
+         *             partially written before failing).
+         *         So: on false, DISCARD the frame. Never parse it, and never assume it is the
+         *         original ciphertext.
+         */
+        bool DecryptRecv(uint8* data, size_t len);
+
+        /**
+         * @brief Encrypt the outgoing header in place.
+         *
+         * @return false if the crypt is uninitialized or OpenSSL failed. On false `data` is either
+         *         untouched (uninitialized) or UNDEFINED (mid-EVP failure) -- in both cases it is
+         *         NOT validly encrypted. The caller must DROP the packet: sending it puts plaintext
+         *         or garbage on the wire under a post-crypt frame.
+         */
+        bool EncryptSend(uint8* data, size_t len);
+
+        /**
+         * @brief Check if the crypt object is active (published).
+         * @return True if activated, false otherwise
+         */
+        bool IsInitialized() const { return _state == CRYPT_ACTIVE; }
+
+        /**
+         * @brief Whether Prepare() has a chance of succeeding -- both ciphers selected and sized.
+         *
+         * NOT a pointer check (see ARC4::IsSelected). Pure and stable: the ARC4 members select
+         * their cipher in this object's constructor, so the answer is fixed for the socket's
+         * lifetime. That is what lets HandleAuthSession check crypt readiness BEFORE it allocates
+         * a session and still rely on it at the commit region.
+         *
+         * It is NOT a substitute for checking Prepare()'s return value: the HMAC, the keying and the
+         * drop-1024 can all still fail after this returns true. It exists only so a caller can
+         * cheaply refuse before doing expensive work.
+         */
+        bool IsUsable() const { return _clientDecrypt.IsSelected() && _serverEncrypt.IsSelected(); }
 
     private:
+        enum CryptState
+        {
+            CRYPT_FRESH,
+            CRYPT_FAILED,
+            CRYPT_PREPARED,
+            CRYPT_ACTIVE
+        };
+
         ARC4 _clientDecrypt;
         ARC4 _serverEncrypt;
-        bool _initialized; /**< Initialization status */
+        // Deliberately not two booleans: two booleans admit impossible combinations and cannot
+        // distinguish a fresh object from one whose contexts were partially touched before failure.
+        CryptState _state;
 };
 #endif

--- a/src/shared/Auth/HMACSHA1.cpp
+++ b/src/shared/Auth/HMACSHA1.cpp
@@ -24,16 +24,25 @@
 
 #include "Auth/HMACSHA1.h"
 #include "BigNumber.h"
+#include <cstring>
 
-HMACSHA1::HMACSHA1(uint32 len, uint8 *seed)
+HMACSHA1::HMACSHA1(uint32 len, const uint8 *seed) : m_valid(false)
 {
+    memset(m_digest, 0, sizeof(m_digest));
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX_init(&m_ctx);
-    HMAC_Init_ex(&m_ctx, seed, len, EVP_sha1(), NULL);
+    if (HMAC_Init_ex(&m_ctx, seed, len, EVP_sha1(), NULL) != 1)
+    {
+        return;
+    }
 #else
     m_ctx = HMAC_CTX_new();
-    HMAC_Init_ex(m_ctx, seed, len, EVP_sha1(), NULL);
+    if (!m_ctx || HMAC_Init_ex(m_ctx, seed, len, EVP_sha1(), NULL) != 1)
+    {
+        return;
+    }
 #endif
+    m_valid = true;
 }
 
 HMACSHA1::~HMACSHA1()
@@ -52,11 +61,20 @@ void HMACSHA1::UpdateBigNumber(BigNumber *bn)
 
 void HMACSHA1::UpdateData(const uint8 *data, int length)
 {
+    if (!m_valid)
+    {
+        return;
+    }
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-    HMAC_Update(&m_ctx, data, length);
+    const int ok = HMAC_Update(&m_ctx, data, length);
 #else
-    HMAC_Update(m_ctx, data, length);
+    const int ok = HMAC_Update(m_ctx, data, length);
 #endif
+    if (ok != 1)
+    {
+        m_valid = false;
+        memset(m_digest, 0, sizeof(m_digest));
+    }
 }
 
 void HMACSHA1::UpdateData(const std::string &str)
@@ -66,22 +84,29 @@ void HMACSHA1::UpdateData(const std::string &str)
 
 void HMACSHA1::Finalize()
 {
+    if (!m_valid)
+    {
+        return;
+    }
+
     uint32 length = 0;
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-    HMAC_Final(&m_ctx, (uint8*)m_digest, &length);
+    const int ok = HMAC_Final(&m_ctx, (uint8*)m_digest, &length);
 #else
-    HMAC_Final(m_ctx, (uint8*)m_digest, &length);
+    const int ok = HMAC_Final(m_ctx, (uint8*)m_digest, &length);
 #endif
-    MANGOS_ASSERT(length == SHA_DIGEST_LENGTH);
+    // MANGOS_ASSERT is elided in RelWithDebInfo (/DNDEBUG), so a short digest would slip through it.
+    // A real if is the only guard that actually fails closed here.
+    if (ok != 1 || length != SHA_DIGEST_LENGTH)
+    {
+        m_valid = false;
+        memset(m_digest, 0, sizeof(m_digest));
+    }
 }
 
 uint8 *HMACSHA1::ComputeHash(BigNumber *bn)
 {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-    HMAC_Update(&m_ctx, bn->AsByteArray(), bn->GetNumBytes());
-#else
-    HMAC_Update(m_ctx, bn->AsByteArray(), bn->GetNumBytes());
-#endif
+    UpdateBigNumber(bn);
     Finalize();
     return (uint8*)m_digest;
 }

--- a/src/shared/Auth/HMACSHA1.h
+++ b/src/shared/Auth/HMACSHA1.h
@@ -48,7 +48,7 @@ public:
      * @param len Length of the seed
      * @param seed Pointer to seed data
      */
-    HMACSHA1(uint32 len, uint8 *seed);
+    HMACSHA1(uint32 len, const uint8 *seed);
     /**
      * @brief Destructor
      */
@@ -89,6 +89,8 @@ public:
      * @return SHA_DIGEST_LENGTH (20 bytes)
      */
     int GetLength() { return SHA_DIGEST_LENGTH; }
+    /// Whether the context exists and every HMAC call so far has succeeded.
+    bool IsValid() const { return m_valid; }
 private:
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     HMAC_CTX m_ctx; /**< OpenSSL HMAC context (pre-1.1.0) */
@@ -96,5 +98,6 @@ private:
     HMAC_CTX* m_ctx; /**< OpenSSL HMAC context (1.1.0+) */
 #endif
     uint8 m_digest[SHA_DIGEST_LENGTH]; /**< Computed hash digest */
+    bool m_valid; /**< true while the context and every HMAC call so far have succeeded */
 };
 #endif

--- a/src/shared/Auth/MopAuthKey.cpp
+++ b/src/shared/Auth/MopAuthKey.cpp
@@ -1,0 +1,53 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#include "MopAuthKey.h"
+#include "BigNumber.h"
+
+namespace MopAuth
+{
+    bool SessionKeyFromHex(const char* hex, uint8 out[SESSION_KEY_LEN])
+    {
+        if (!IsPlausibleSessionKeyHex(hex))
+        {
+            return false;
+        }
+
+        BigNumber k;
+        k.SetHexStr(hex);
+
+        // AsByteArray() is ALREADY LITTLE-ENDIAN and needs NO reversal: BN_bn2bin writes
+        // big-endian and AsByteArray then does std::reverse over the whole length
+        // (BigNumber.cpp:179-197). What it returns is exactly K's own byte order -- just SHORT,
+        // because BN_bn2hex dropped any leading zero bytes when realmd wrote the row.
+        //
+        //   DO NOT reverse it again. That was plan v2's defect: a double reversal yields a
+        //   big-endian K and every proof fails deterministically.
+        //   DO NOT pass minSize=40. AsByteArray(40) byte-ROTATES rather than pads (see the header).
+        //
+        // Copy immediately: BigNumber OWNS the returned buffer and frees it on the next call, so a
+        // unique_ptr around it would DOUBLE FREE and holding the pointer would dangle.
+        return Raw40FromLittleEndian(k.AsByteArray(), size_t(k.GetNumBytes()), out);
+    }
+}

--- a/src/shared/Auth/MopAuthKey.h
+++ b/src/shared/Auth/MopAuthKey.h
@@ -1,0 +1,124 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+#ifndef MANGOS_H_MOPAUTHKEY
+#define MANGOS_H_MOPAUTHKEY
+
+#include "Common/Common.h"
+#include <cstring>
+
+namespace MopAuth
+{
+    /// The client hashes EXACTLY 40 raw bytes [BINARY sub_140A6F050]. Anything else fails the proof
+    /// compare indistinguishably, as a generic AUTH_FAILED.
+    inline constexpr size_t SESSION_KEY_LEN = 40;
+
+    /**
+     * @brief Little-endian K bytes -> canonical raw-40 K, padding the TAIL.
+     *
+     * The input is ALREADY in K's own byte order; this only pads it out to 40. It does NOT reverse.
+     *
+     * WHY THE PAD IS AT THE TAIL, AND WHY BigNumber::AsByteArray(40) CANNOT BE USED:
+     *   AsByteArray(40) does not zero-pad, it BYTE-ROTATES (BigNumber.cpp:179-197). It memsets 40,
+     *   writes GetNumBytes() bytes at offset 0, then std::reverse()s the WHOLE 40 -- so the pad
+     *   lands at index 0 and every real byte shifts by one. realmd stores K via AsHexStr()
+     *   (= BN_bn2hex), which DROPS LEADING ZEROS, so a K whose most-significant raw byte is 0x00
+     *   comes back SHORT. K is regenerated per authentication (realmd AuthSocket.cpp:668), so that
+     *   is ~1/256 of LOGINS, not of accounts: auth succeeds 255 times and fails inexplicably on the
+     *   256th, and it will NOT reproduce on a retry. That is what makes it expensive.
+     *
+     * AND DO NOT "FIX" BigNumber: it is LINKED INTO REALMD (AuthSocket.cpp:488/492/494/645/882);
+     * changing its padding would alter realmd's SRP6 wire bytes. The fix is local, and this is it.
+     * (Sha1Hash is realmd-linked too -- AuthSocket.cpp:253/269/635 -- so its UpdateBigNumbers is
+     * equally off-limits; consumers pass raw bytes instead.)
+     *
+     * Prefer SessionKeyFromHex(): it owns the whole DB-hex -> K chain so no caller has to know
+     * which end is padded or which direction the bytes run. This primitive is exposed only so that
+     * rule can be unit-tested on its own.
+     *
+     * @param le    little-endian K bytes -- e.g. BigNumber::AsByteArray()'s return, which is
+     *              ALREADY little-endian (bn2bin writes big-endian, AsByteArray then reverses).
+     * @param leLen how many; 1..40. Zero is REJECTED, never zero-filled (spec 6.2a): an empty
+     *              sessionkey would otherwise become forty 0x00s -- a well-formed-looking K of
+     *              zeros, which is the stale/NULL-K confounder the guard exists to catch.
+     * @param out   receives the 40 raw bytes; untouched on failure.
+     * @return false if le is null, leLen == 0, or leLen > 40. Never truncates.
+     */
+    inline bool Raw40FromLittleEndian(const uint8* le, size_t leLen, uint8 out[SESSION_KEY_LEN])
+    {
+        if (!le || leLen == 0 || leLen > SESSION_KEY_LEN)
+        {
+            return false;
+        }
+
+        memset(out, 0, SESSION_KEY_LEN);
+        memcpy(out, le, leLen);                 // pad the TAIL -- never copy to out + (40 - leLen)
+
+        return true;
+    }
+
+    /// Structural plausibility of an account.sessionkey hex string: non-empty, hex-only, even
+    /// length, <= 80 chars (40 bytes). Deliberately does NOT enumerate lengths -- BN_bn2hex drops
+    /// leading zero bytes, so 78/76/74/... are all NORMAL, not corruption. This is a cheap
+    /// pre-filter for BN_hex2bn; the binding check is that the CONVERTED value is 1..40 bytes.
+    inline bool IsPlausibleSessionKeyHex(const char* hex)
+    {
+        if (!hex)
+        {
+            return false;
+        }
+
+        size_t len = 0;
+        for (const char* p = hex; *p; ++p, ++len)
+        {
+            const bool isHexDigit = (*p >= '0' && *p <= '9')
+                                 || (*p >= 'a' && *p <= 'f')
+                                 || (*p >= 'A' && *p <= 'F');
+            if (!isHexDigit)
+            {
+                return false;
+            }
+        }
+
+        return len != 0 && (len % 2) == 0 && len <= (SESSION_KEY_LEN * 2);
+    }
+
+    /**
+     * @brief account.sessionkey hex -> canonical raw-40 K. THE ONLY SANCTIONED WAY TO OBTAIN K.
+     *
+     * Owns the entire chain -- validate, convert, pad, re-check -- so that no caller has to reason
+     * about BigNumber's byte order. That encapsulation is the POINT, not a convenience: plan v2
+     * composed these steps at the call site, passed the already-little-endian AsByteArray() into a
+     * big-endian-taking helper, reversed K twice, and would have failed every proof
+     * deterministically. Both ends were individually "correct"; the SEAM between them was wrong,
+     * and no unit test of either end could see it. Do not re-open the seam.
+     *
+     * @param hex the account.sessionkey column. May be NULL or empty -- both are rejected.
+     * @param out receives the 40 raw bytes; untouched on failure.
+     * @return false if hex is NULL, empty, malformed, or converts outside 1..40 bytes.
+     */
+    bool SessionKeyFromHex(const char* hex, uint8 out[SESSION_KEY_LEN]);
+}
+
+#endif

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -28,6 +28,8 @@ set(SRC_GRP_AUTH
   Auth/BigNumber.h
   Auth/HMACSHA1.cpp
   Auth/HMACSHA1.h
+  Auth/MopAuthKey.cpp
+  Auth/MopAuthKey.h
   Auth/OpenSSLProvider.cpp
   Auth/OpenSSLProvider.h
   Auth/Sha1.cpp


### PR DESCRIPTION
## Summary

Phase 3 **Stage 2** of the MoP 5.4.8.18414 login port. On top of Stage 1's dormant restructure, this fills in the auth **semantics** — real world-crypt seeds, a canonical raw-40 session key, a spec-exact proof digest, one response serializer — and flips the single switch that makes the auth path reachable.

**A real 5.4.8.18414 client now authenticates against MaNGOS Four end-to-end and reaches the character-selection screen** (validated live — below).

Phase 3's scope ends at *auth accepted + `CMSG_CHAR_ENUM` dispatch*. Rendering the character **list** is Phase 4, so the client's "error retrieving character list" is expected and out of scope here.

## Result — live-validated (Gate 3b)

Against a real 5.4.8.18414 client, clean auth path (no `rejecting` / `malformed` / `illegal in state`):

```
HandleAuthSession: account 1 authenticated successfully from 127.0.0.1
HandleAuthSession: account 1 CONN_AUTHED (crypt activated, session enqueue published)
HandleCharEnumOpcode: CMSG_CHAR_ENUM dispatched for account 1
→ client reaches the character-select page
```

This confirms the full chain on the wire: the raw-40 K + the binary-recovered MoP world-crypt seeds + the spec-exact proof (auth succeeded), ARC4 in **both** directions, the post-crypt packed header (its first live run), and — the one modelled hypothesis in the design — the `SMSG_AUTH_RESPONSE` bit/field order (the client decrypted it, accepted auth, and proceeded).

## What's in it

The whole `WorldSocket::HandleAuthSession` path, previously dormant, is now correct and reachable:

- **`MopAuthKey`** — the single canonical `account.sessionkey`-hex → raw-40 K adapter (`SessionKeyFromHex`), removing the byte-order double-reversal and short-K hazards.
- **`AuthCrypt` / `ARC4` / `HMACSHA1`** — the binary-confirmed MoP seeds A/B; a two-phase, **observable** `Fresh → Prepared → Active` crypt (RC4/EVP failures now propagate, HMAC validity is checked, and there is no mid-stream `EVP_EncryptFinal_ex` on the continuous keystream).
- **`MopAuthProof`** — the spec-exact §3.2 five-chunk SHA1 over 40 raw bytes + a constant-time compare (`CRYPTO_memcmp`).
- **Read-only auth path** — drop `v`/`s` from the `account` SELECT (with the middle columns renumbered), remove the `(s,v)`/verifier leak and the `last_ip` write, and demote unbounded error-level rejection logs.
- **Decode** — add the missing leading `ReadBit()` before the 11-bit account-name length; the digest scatter is pinned entry-by-entry against the binary-derived map.
- **One canonical `SMSG_AUTH_RESPONSE` serializer** replacing six divergent construction sites; code 27 (`AUTH_WAIT_QUEUE`) is structurally unrepresentable and `hasAccountData` is enforced for `AUTH_OK`.
- **Queue-lock publication transaction** — crypt activation, `CONN_AUTHED`, and session enqueue are one atomic step (publication is the unlock), with UAF-safe cleanup for a post-allocation rejection.
- **The sole activation cutover** — `case CMSG_AUTH_SESSION: return HandleAuthSession(...)`.

## Verification

- **Offline:** `mangosd` builds clean (RelWithDebInfo); `mop_framing` + `mop_auth` ctest **2/2** (43 tests, every one registered); the digest scatter re-verified against the binary map.
- **Review:** each task reviewed clean, then a final **5-lens diverse review** (legacy-equivalence, over-correction, concurrency, test-integrity, comment-truth) + a completeness critic — **zero code Critical/Important**, all checked against primary sources rather than the plan.
- **Live:** Gate 3b (above).

## Security / constraints

- **realmd untouched** — no change to `src/realmd/` or the realmd-linked `BigNumber` / `Sha1Hash`; the short-K and salt-vs-key defects are fixed at the call sites, not in shared crypto.
- **No auth material logged** — never K, the proof, the salt, or the verifier; the two new markers are account-id only.

## Out of scope (Phase 4)

The MoP character-list response (`SMSG_CHAR_ENUM`), realm-split, and the account-data-times handshake. The gate log shows the client sending `CMSG_READY_FOR_ACCOUNT_DATA_TIMES` (`0x031C`) and `CMSG_BATTLE_PAY_GET_PURCHASE_LIST` (`0x18B2`) as "not handled" — expected, since only the 21-opcode login closure carries real 5.4.8 values so far (Phase 1b).

## Known follow-ups (non-blocking)

- The **queued** `SMSG_AUTH_RESPONSE` layout is confirmed by nothing offline; only a forced-queue (server-full) test exercises it.
- `SendPacket` advances the RC4 send-keystream before a droppable enqueue (OOM / backpressure) — harmless on the tiny login burst, but worth closing the socket on any post-`EncryptSend` failure now that the crypt is live.

## Commits

```
868ff22c7 docs(mop-auth): correct stale comments/citations + drop dead includes (final-review hygiene)
9bc0cc9ed feat(mop-auth): activate the auth handler (the sole Phase 3 cutover)
0129ebca2 feat(mop-auth): publish prepared crypt and session atomically
d269c4c95 feat(mop-auth): one canonical SMSG_AUTH_RESPONSE serializer (5 variants, 6 sites)
c032e8827 fix(mop-auth): read the name-length flag bit before the 11-bit length
5ce9e48a6 fix(mop-auth): honour read-only on the auth path and remove the auth-material leaks
a9393be93 feat(mop-auth): spec-exact proof digest over raw-40 K + constant-time compare
8a6d8f19c feat(mop-auth): migrate the session key to canonical raw 40 bytes with MoP seeds (atomic)
fc2f7c2ed feat(mop-auth): canonical raw-40 session-key helper
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/14)
<!-- Reviewable:end -->
