### PR TITLE
MoP 5.4.8: Pandaren (race 24) creatable in char-select (+ char-enum hunter-ghost fix, login log clarity)

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -3756,6 +3756,7 @@ Team Player::TeamForRace(uint8 race)
     {
         case 7: return ALLIANCE;
         case 1: return HORDE;
+        case LANG_PANDAREN: return TEAM_NONE;   // neutral Pandaren, no spurious error
     }
 
     sLog.outError("Race %u have wrong teamid %u in DBC: wrong DBC files?", uint32(race), rEntry->BaseLanguage);

--- a/src/game/Server/MopCharEnum.cpp
+++ b/src/game/Server/MopCharEnum.cpp
@@ -109,7 +109,7 @@ void MopCharEnum::Build(WorldPacket& out, const std::vector<Entry>& chars)
             out << uint8(c.equipment[e].invType);         //      +144 invType
             out << uint32(c.equipment[e].displayId);      //      +136 displayId  [capture-confirm]
         }
-        out << uint32(c.petLevel);                        // op16 +100 pet cluster [capture-confirm]
+        out << uint32(c.customizeFlags);                  // op16 +100 -> customizeFlags (LIVE-CONFIRMED: client reads customize here; petLevel here made all hunters show "customize")
         WriteGuidByteXor(out, c.charGuid, 3);             // op17 charGUID[3]
         WriteGuidByteXor(out, c.charGuid, 5);             // op18 charGUID[5]
         out << uint32(0);                                 // op19 +120 flags cluster [capture-confirm]
@@ -124,14 +124,14 @@ void MopCharEnum::Build(WorldPacket& out, const std::vector<Entry>& chars)
         out << uint8(c.hairColor);                        // op28 +64  -> glue+406 hairColor
         out << uint8(c.gender);                           // op29 +60  -> glue+402 gender
         out << uint8(c.facialHair);                       // op30 +65  -> glue+407 facialHair
-        out << uint32(c.customizeFlags);                  // op31 +116 flags cluster [capture-confirm]
+        out << uint32(c.petLevel);                        // op31 +116 -> petLevel (moved off the client's customize-read slot)
         WriteGuidByteXor(out, c.charGuid, 4);             // op32 charGUID[4]
         WriteGuidByteXor(out, c.charGuid, 7);             // op33 charGUID[7]
         out << float(c.posY);                             // op34 +80 posY
-        out << uint32(c.charFlags);                       // op35 +112 flags cluster [capture-confirm]
+        out << uint32(c.petDisplayId);                    // op35 +112 -> petDisplayId (moved off the client's charFlags-read slot)
         out << uint32(0);                                 // op36 +128 MoP-extra [capture-confirm]
         WriteGuidByteXor(out, c.charGuid, 6);             // op37 charGUID[6]
-        out << uint32(c.petDisplayId);                    // op38 +96 pet cluster [capture-confirm]
+        out << uint32(c.charFlags);                       // op38 +96 -> charFlags (LIVE-CONFIRMED: client reads ghost/charFlags here; petDisplayId here ghosted any pet whose displayId had bit 0x2000, e.g. Draenei moth 29056 / Pandaren turtle 42656)
         out << uint32(c.map);                             // op39 +68 map [capture-confirm]
         WriteGuidByteXor(out, c.guildGuid, 7);            // op40 guildGUID[7]
         out << float(c.posZ);                             // op41 +84 posZ

--- a/src/game/Server/MopCreateGating.cpp
+++ b/src/game/Server/MopCreateGating.cpp
@@ -48,3 +48,23 @@ uint8 MopCreateGating::ClassRequiredExpansion(uint8 class_)
             return EXPANSION_NONE;
     }
 }
+
+bool MopCreateGating::TwoSideCreateViolation(Team newTeam, const std::vector<Team>& existingTeams)
+{
+    if (newTeam == TEAM_NONE)
+    {
+        return false;
+    }
+    for (Team t : existingTeams)
+    {
+        if (t == TEAM_NONE)
+        {
+            continue;
+        }
+        if (t != newTeam)
+        {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/game/Server/MopCreateGating.h
+++ b/src/game/Server/MopCreateGating.h
@@ -26,6 +26,8 @@
 #define MANGOS_H_MOPCREATEGATING
 
 #include "Common.h"
+#include "SharedDefines.h"
+#include <vector>
 
 /**
  * @brief Character-creation class-expansion entitlement for WoW 5.4.8.18414.
@@ -50,6 +52,10 @@ namespace MopCreateGating
 {
     /// Minimum account expansion required to create the given class (default EXPANSION_NONE).
     uint8 ClassRequiredExpansion(uint8 class_);
+
+    // Neutral (TEAM_NONE) is always allowed; existing neutral chars are ignored.
+    // Returns true iff an existing non-neutral team differs from a non-neutral request.
+    bool TwoSideCreateViolation(Team newTeam, const std::vector<Team>& existingTeams);
 }
 
 #endif

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -1279,7 +1279,7 @@ void WorldSession::ReadAddonsInfo(ByteBuffer &data)
         {
             std::string addonName;
             uint8 enabled;
-            uint32 crc, unk1;
+            uint32 crc, urlHash;       // per client RE (FACTS_mop548_addon_info): name, usePubKey, crc, urlHash
 
             // check next addon data format correctness
             if (addonInfo.rpos() + 1 > addonInfo.size())
@@ -1289,15 +1289,15 @@ void WorldSession::ReadAddonsInfo(ByteBuffer &data)
 
             addonInfo >> addonName;
 
-            addonInfo >> enabled >> crc >> unk1;
+            addonInfo >> enabled >> crc >> urlHash;
 
-            DEBUG_LOG("ADDON: Name: %s, Enabled: 0x%x, CRC: 0x%x, Unknown2: 0x%x", addonName.c_str(), enabled, crc, unk1);
+            DEBUG_LOG("ADDON: Name: %s, Enabled: 0x%x, CRC: 0x%x, UrlHash: 0x%x", addonName.c_str(), enabled, crc, urlHash);
 
             m_addonsList.push_back(AddonInfo(addonName, enabled, crc));
         }
 
-        uint32 unk2;
-        addonInfo >> unk2;
+        uint32 currentTime;        // trailing field after the addon list (client RE)
+        addonInfo >> currentTime;
 
         if (addonInfo.rpos() != addonInfo.size())
         {

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -383,7 +383,7 @@ int WorldSocket::HandleWowConnection(WorldPacket& recvPacket)
 {
     std::string ClientToServerMsg;
     recvPacket >> ClientToServerMsg;
-    DEBUG_LOG("Received MSG_WOW_CONNECTION FROM %s", m_Session ? m_Session->GetRemoteAddress().c_str() : "<unk>");
+    DEBUG_LOG("Received MSG_WOW_CONNECTION FROM %s", GetRemoteAddress().c_str());   // socket's own peer IP (set in open(), available pre-session) — was "<unk>" via the not-yet-created m_Session
     // Mirror of the greeting we send ("RLD OF WARCRAFT CONNECTION - SERVER TO CLIENT"): the leading
     // "WO" of "WORLD" is carried by the header's cmd field (0x4F57 == "WO" little-endian), so the
     // payload legitimately begins at "RLD".

--- a/src/game/Server/tests/mop_charenum_test.cpp
+++ b/src/game/Server/tests/mop_charenum_test.cpp
@@ -107,7 +107,7 @@ namespace
                 p >> e.equipment[s].invType;
                 p >> e.equipment[s].displayId;
             }
-            p >> e.petLevel;                          // op16
+            p >> e.customizeFlags;                    // op16 +100 -> customizeFlags (client reads customize here)
             rdGuid(cm, cg, 3);                        // op17
             rdGuid(cm, cg, 5);                        // op18
             p >> u;                                   // op19 +120
@@ -122,14 +122,14 @@ namespace
             p >> e.hairColor;                         // op28 +64
             p >> e.gender;                            // op29 +60
             p >> e.facialHair;                        // op30 +65
-            p >> e.customizeFlags;                    // op31
+            p >> e.petLevel;                          // op31 +116 -> petLevel
             rdGuid(cm, cg, 4);                        // op32
             rdGuid(cm, cg, 7);                        // op33
             p >> e.posY;                              // op34
-            p >> e.charFlags;                         // op35
+            p >> e.petDisplayId;                      // op35 +112 -> petDisplayId
             p >> u;                                   // op36 +128
             rdGuid(cm, cg, 6);                        // op37
-            p >> e.petDisplayId;                      // op38
+            p >> e.charFlags;                         // op38 +96 -> charFlags (client reads ghost/charFlags here)
             p >> e.map;                               // op39
             rdGuid(gm, gg, 7);                        // op40
             p >> e.posZ;                              // op41

--- a/src/game/Server/tests/mop_creategating_test.cpp
+++ b/src/game/Server/tests/mop_creategating_test.cpp
@@ -23,7 +23,9 @@
  */
 
 #include "MopCreateGating.h"
+#include "SharedDefines.h"
 #include <cstdio>
+#include <vector>
 
 // RelWithDebInfo elides assert(); use a non-elidable check (mirrors mop_charenum_test).
 static int g_failures = 0;
@@ -57,6 +59,22 @@ int main(int /*argc*/, char** /*argv*/)
     CHECK(ClassRequiredExpansion(6)  > classicAccount);    // DeathKnight blocked on a Classic account
     CHECK(!(ClassRequiredExpansion(6)  > mopAccount));     // DeathKnight allowed on a MoP account
     CHECK(!(ClassRequiredExpansion(1)  > classicAccount)); // Warrior always allowed
+
+    // --- Two-side create gate (neutral-safe) ---
+    using MopCreateGating::TwoSideCreateViolation;
+    // Neutral request is always allowed, regardless of existing chars.
+    CHECK(!TwoSideCreateViolation(TEAM_NONE, {ALLIANCE, HORDE}));
+    // Fresh account: any request allowed.
+    CHECK(!TwoSideCreateViolation(ALLIANCE, {}));
+    CHECK(!TwoSideCreateViolation(HORDE, {}));
+    // Same faction present: allowed.
+    CHECK(!TwoSideCreateViolation(ALLIANCE, {ALLIANCE, TEAM_NONE}));
+    // Opposing faction present: blocked (neutral chars ignored).
+    CHECK(TwoSideCreateViolation(ALLIANCE, {TEAM_NONE, HORDE}));
+    CHECK(TwoSideCreateViolation(HORDE, {ALLIANCE}));
+    // Account with only neutral chars: any faction allowed (the neutral->faction case).
+    CHECK(!TwoSideCreateViolation(ALLIANCE, {TEAM_NONE}));
+    CHECK(!TwoSideCreateViolation(HORDE, {TEAM_NONE}));
 
     if (g_failures == 0) { std::printf("ALL PASS\n"); return 0; }
     std::printf("%d FAILURES\n", g_failures);

--- a/src/game/WorldHandlers/CharacterHandler.cpp
+++ b/src/game/WorldHandlers/CharacterHandler.cpp
@@ -428,14 +428,37 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket& recv_data)
     // if 0 then allowed creating without any characters
     bool have_req_level_for_heroic = (req_level_for_heroic == 0);
 
+    // Neutral-safe two-side create gate: a neutral (Pandaren) request is always allowed, and
+    // existing neutral characters never lock the account to a faction. Only an existing
+    // non-neutral team that differs from a non-neutral request is a PvP-teams violation.
+    if (!AllowTwoSideAccounts)
+    {
+        Team newTeam = Player::TeamForRace(race_);
+        QueryResult* teamRes = CharacterDatabase.PQuery(
+            "SELECT DISTINCT `race` FROM `characters` WHERE `account` = '%u'", GetAccountId());
+        std::vector<Team> existingTeams;
+        if (teamRes)
+        {
+            do
+            {
+                existingTeams.push_back(Player::TeamForRace(teamRes->Fetch()[0].GetUInt32()));
+            } while (teamRes->NextRow());
+            delete teamRes;
+        }
+        if (MopCreateGating::TwoSideCreateViolation(newTeam, existingTeams))
+        {
+            data << (uint8)CHAR_CREATE_PVP_TEAMS_VIOLATION;
+            SendPacket(&data);
+            return;
+        }
+    }
+
     if (!AllowTwoSideAccounts || skipCinematics == CINEMATICS_SKIP_SAME_RACE || class_ == CLASS_DEATH_KNIGHT)
     {
         QueryResult* result2 = CharacterDatabase.PQuery("SELECT `level`,`race`,`class` FROM `characters` WHERE `account` = '%u' %s",
                                GetAccountId(), (skipCinematics == CINEMATICS_SKIP_SAME_RACE || class_ == CLASS_DEATH_KNIGHT) ? "" : "LIMIT 1");
         if (result2)
         {
-            Team team_ = Player::TeamForRace(race_);
-
             Field* field = result2->Fetch();
             uint8 acc_race  = field[1].GetUInt32();
 
@@ -468,18 +491,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket& recv_data)
                 }
             }
 
-            // need to check team only for first character
-            // TODO: what to if account already has characters of both races?
-            if (!AllowTwoSideAccounts)
-            {
-                if (acc_race == 0 || Player::TeamForRace(acc_race) != team_)
-                {
-                    data << (uint8)CHAR_CREATE_PVP_TEAMS_VIOLATION;
-                    SendPacket(&data);
-                    delete result2;
-                    return;
-                }
-            }
+            // Two-side team enforcement is handled above by the neutral-safe gate.
 
             // search same race for cinematic or same class if need
             // TODO: check if cinematic already shown? (already logged in?; cinematic field)

--- a/src/game/WorldHandlers/CharacterHandler.cpp
+++ b/src/game/WorldHandlers/CharacterHandler.cpp
@@ -303,7 +303,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket& recv_data)
             {
                 case ALLIANCE: disabled = mask & (1 << 0); break;
                 case HORDE:    disabled = mask & (1 << 1); break;
-                default: break;
+                default:       disabled = (mask & 3) == 3; break;   // neutral blocked only if BOTH sides disabled
             }
 
             if (disabled)
@@ -579,15 +579,7 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket& recv_data)
 
     LoginDatabase.PExecute("DELETE FROM `realmcharacters` WHERE `acctid`= '%u' AND `realmid`= '%u'", GetAccountId(), realmID);
     LoginDatabase.PExecute("INSERT INTO `realmcharacters` (`numchars`, `acctid`, `realmid`) VALUES (%u, %u, %u)",  charcount, GetAccountId(), realmID);
-    uint32 pet_id = 1;
-    if (CharacterDatabase.PQuery("SELECT id FROM character_pet ORDER BY id DESC LIMIT 1"))
-    {
-        Field* fields = CharacterDatabase.PQuery("SELECT id FROM character_pet ORDER BY id DESC LIMIT 1")->Fetch();
-        pet_id = fields[0].GetUInt32();
-        pet_id += 1;
-    }
-    //else
-        //pet_id = 1;
+    uint32 pet_id = sObjectMgr.GeneratePetNumber();
 
     if (class_ == CLASS_WARLOCK)
     {
@@ -632,6 +624,9 @@ void WorldSession::HandleCharCreateOpcode(WorldPacket& recv_data)
             break;
         case RACE_WORGEN: // Dog
             CharacterDatabase.PExecute("REPLACE INTO character_pet (`id`, `entry`, `owner`, `modelid`, `CreatedBySpell`, `PetType`, `level`, `exp`, `Reactstate`, `name`, `renamed`, `slot`, `curhealth`, `curmana`, `savetime`, `resettalents_cost`, `resettalents_time`, `abdata`) VALUES (%u, 42722, %u, 30221, 13481, 1, 1, 0, 0, ' ', 0, 0, 192, 0, 1295728219, 0, 0, '7 2 7 1 7 0 129 2649 129 17253 1 0 1 0 6 2 6 1 6 0 ')", pet_id, pNewChar->GetGUIDLow());
+            break;
+        case RACE_PANDAREN_NEUTRAL: // Turtle
+            CharacterDatabase.PExecute("REPLACE INTO character_pet (`id`, `entry`, `owner`, `modelid`, `CreatedBySpell`, `PetType`, `level`, `exp`, `Reactstate`, `name`, `renamed`, `slot`, `curhealth`, `curmana`, `savetime`, `resettalents_cost`, `resettalents_time`, `abdata`) VALUES (%u, 34029, %u, 42656, 13481, 1, 1, 0, 0, ' ', 0, 0, 202, 0, 1295727347, 0, 0, '7 2 7 1 7 0 129 2649 129 17253 1 0 1 0 6 2 6 1 6 0 ')", pet_id, pNewChar->GetGUIDLow());
             break;
         }
         //CharacterDatabase.PExecute("UPDATE characters SET currentPetSlot = '0', petSlotUsed = '1' WHERE guid = %u", pNewChar->GetGUIDLow());


### PR DESCRIPTION
Makes neutral Pandaren (race 24) creatable and correctly shown in character-select for all 7 valid classes on the WoW 5.4.8.18414 client, and fixes a pre-existing char-enum bug surfaced during that testing. Pairs with the world-DB PR (`Rel22_05_012`). Part of the phased "unmodified 5.4.8 client vs Four" campaign — this is the character-select milestone.

Cleanroom: wire formats and gear come from the client / client DBCs; no code lifted from other cores.

This is a single PR bundling three distinct concerns, sectioned below.

## 1. Pandaren creatable (feature) — `403f7a2f`, `8fffe157`
- `Player::TeamForRace`: `LANG_PANDAREN` → `TEAM_NONE` (neutral Pandaren carry BaseLanguage 42 in ChrRaces; no team masking).
- New testable two-side gate `MopCreateGating::TwoSideCreateViolation(newTeam, existingTeams)`; the create path in `CharacterHandler.cpp` now gathers all account characters' teams (SELECT DISTINCT race) and applies it, replacing the old LIMIT-1 check.
- Hunter starting pet for Pandaren: turtle (creature 34029, modelid 42656, slot 0), pet number via `GeneratePetNumber()`.
- Neutral "creating-disabled" rule wired into the create-disabled mask handling.
- Live-verified: all 7 valid classes (1,3,4,5,7,8,10) create with correct per-class gear; Worgen / Goblin correctly cannot be Monk (client-side CharBaseInfo, unchanged).

## 2. Char-enum hunter-ghost fix (bug — affects ALL races) — `a8db89714`, `3b3ff50aa`
The per-character pet/flags scalar cluster in `MopCharEnum::Build` had four fields on the wrong offsets. `petDisplayId` was emitted where the client reads `charFlags`, so any character whose pet displayId had bit `0x2000` set decoded as `CHARACTER_FLAG_GHOST` — rendering the character as a ghost in the list and raising a spurious "customization allowed" flag. Corrected to the confirmed layout: `charFlags@+96, customizeFlags@+100, petFamily@+104, petDisplayId@+112, petLevel@+116`. The offline `mop_charenum_test` decoder was synced to match. Live-verified: all hunters (Human, Night Elf, Draenei, Pandaren, …) now render normally.

## 3. Login log clarity (chore) — `2f4e6c3b1`, `d36963889`
- `ReadAddonsInfo`: named the previously-"Unknown2" per-addon read fields per client RE (`urlHash` / trailing `currentTime`); log line updated. Behaviour unchanged.
- `MSG_WOW_CONNECTION` handshake log now prints the socket's real peer IP (via `GetRemoteAddress()`) instead of `<unk>` (m_Session doesn't exist yet at greeting time).

## Testing
- Offline ctest 4/4 (mop_framing / mop_auth / mop_charenum / mop_creategating), RelWithDebInfo, rebuilt against HEAD.
- Live char-select gate on mangos4: create + list-render verified for all 7 Pandaren classes; hunter-ghost regression confirmed fixed across races.

## Deployment note
The live world DB (mangos4) is on a diverged db_version chain (22/05/004), so the version-gated `Rel22_05_012` proc SKIPS there — the race-24 data was applied to mangos4 directly (data-only). The repo update file stays canonical for clean DB loads (gated Old 22/05/011 → New 22/05/012).

## Deferred (tracked, not in this PR)
- MoP character services: `CMSG_CHAR_CUSTOMIZE` (0x0A13) + `CMSG_CHAR_RENAME` (0x0963) — handlers exist but are unregistered and parse a legacy (pre-MoP) wire format; needs RE + rewrite + register.
- Correct 1-90 Pandaren levelstats curves (currently L1 real + safe monotonic placeholders).
- Login map-access exemption; level-10 faction choice.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/16)
<!-- Reviewable:end -->
