### PR TITLE
fix(mop): default Group::SetTargetIcon context arg so 3-arg callers compile

### DIFF
--- a/src/game/WorldHandlers/Group.h
+++ b/src/game/WorldHandlers/Group.h
@@ -1063,8 +1063,10 @@ class Group
             }
         }
 
+        // context defaults to 0 (a normal target-icon set) so pre-MoP 3-argument callers --
+        // notably Eluna's shared Group:SetTargetIcon binding -- stay source-compatible.
         void SetTargetIcon(uint8 id, ObjectGuid whoGuid, ObjectGuid targetGuid,
-            uint8 context);
+            uint8 context = 0);
 
         Difficulty GetDifficulty(bool isRaid) const { return isRaid ? m_raidDifficulty : m_dungeonDifficulty; }
         Difficulty GetDungeonDifficulty() const { return m_dungeonDifficulty; }


### PR DESCRIPTION
## Summary

The 5.4.8 raid-markers restore (`6b7978ec9`) gave `Group::SetTargetIcon` a new
**required** fourth parameter — `uint8 context` — so its signature became
`(uint8 id, ObjectGuid whoGuid, ObjectGuid targetGuid, uint8 context)`. That
broke every existing 3-argument caller, most importantly the **shared Eluna**
`Group:SetTargetIcon` binding, which fails to compile against the mangos-four
core with:

    error C2660: 'Group::SetTargetIcon': function does not take 3 arguments

Because `MangosServer/Eluna` is shared across all cores (Classic/TBC/WotLK/Cata/
MoP), it can't call the 4-arg overload unconditionally without breaking the
other cores. The clean fix is core-side: give the new parameter a default.

## Change

`src/game/WorldHandlers/Group.h` — default the new `context` argument to `0`:

    -  void SetTargetIcon(uint8 id, ObjectGuid whoGuid, ObjectGuid targetGuid, uint8 context);
    +  void SetTargetIcon(uint8 id, ObjectGuid whoGuid, ObjectGuid targetGuid, uint8 context = 0);

`context = 0` is a normal target-icon set (matching `GroupHandler`'s default
path). All existing 4-arg callers keep working and the pre-MoP 3-arg call is
source-compatible again — so **stock Eluna needs no change**.

## Testing

- Builds clean against stock Eluna (`fd0b208a`), no submodule change.
- 253/253 ctest pass.
- Live-verified: server boots and runs; raid markers function.

Supersedes MangosServer/Eluna#8 (close it) — the fix belongs in the core that
changed the signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/18)
<!-- Reviewable:end -->
