### PR TITLE
[Quests] Seed the quest log into the login self-values block

### DIFF
--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -115,7 +115,7 @@ add_test(NAME mop_initial_self_appearance_source
     COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_initial_self_appearance_source_test.cmake)
 
-foreach(mutation IN ITEMS visible_item_feed combined_builder skill_feed)
+foreach(mutation IN ITEMS visible_item_feed combined_builder skill_feed questlog_feed)
     add_test(NAME mop_initial_self_appearance_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/mop_initial_self_appearance_source_test.cmake
+++ b/src/game/Server/tests/mop_initial_self_appearance_source_test.cmake
@@ -10,6 +10,11 @@ elseif(MUTATION STREQUAL "combined_builder")
         "MopUpdateObject::AppendSelfPlayerValuesBlock"
         "MopUpdateObject::AppendSelfInventoryValuesBlock"
         map_source "${map_source}")
+elseif(MUTATION STREQUAL "questlog_feed")
+    string(REPLACE
+        "MopUpdateObject::SelfQuestLogSourceStart + i"
+        "MopUpdateObject::SelfInventorySourceStart + i"
+        map_source "${map_source}")
 elseif(MUTATION STREQUAL "skill_feed")
     string(REPLACE
         "MopUpdateObject::SelfSkillSourceStart + i"
@@ -44,6 +49,9 @@ require_once(
     "MopUpdateObject::SelfSkillSourceStart \\+ i"
     "initial self skill snapshot")
 require_once(
+    "MopUpdateObject::SelfQuestLogSourceStart"
+    "initial self quest-log snapshot")
+require_once(
     "MopUpdateObject::AppendSelfPlayerValuesBlock"
     "combined initial self VALUES builder")
 
@@ -52,4 +60,17 @@ string(FIND "${self_body}"
 if(NOT inventory_only EQUAL -1)
     message(FATAL_ERROR
         "initial self snapshot regressed to the inventory-only VALUES builder")
+endif()
+
+# AppendSelfPlayerValuesBlock asserts strictly ascending source indices. The
+# quest-log range is 166..415, below visible items at 916, so its loop must be
+# emitted first or the block is built out of order and trips that assert.
+string(FIND "${self_body}" "MopUpdateObject::SelfQuestLogSourceStart + i" questlog_pos)
+string(FIND "${self_body}" "MopUpdateObject::ObserverVisibleItemSourceStart + i" visible_pos)
+if(questlog_pos EQUAL -1 OR visible_pos EQUAL -1)
+    message(FATAL_ERROR "initial self snapshot is missing a required seed loop")
+endif()
+if(NOT questlog_pos LESS visible_pos)
+    message(FATAL_ERROR
+        "quest-log seed must precede the visible-item seed because AppendSelfPlayerValuesBlock requires ascending legacy indices")
 endif()

--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -1948,9 +1948,26 @@ void Map::SendInitSelf(Player* player)
     // first unequip sends a zero the client already assumes and leaves the
     // login-time model displayed until a later nonzero equip update.
     std::vector<MopUpdateObject::StaticField> selfFields;
-    selfFields.reserve(MopUpdateObject::ObserverVisibleItemFieldCount +
+    selfFields.reserve(MopUpdateObject::SelfQuestLogFieldCount +
+        MopUpdateObject::ObserverVisibleItemFieldCount +
         MopUpdateObject::SelfInventoryFieldCount +
         MopUpdateObject::SelfSkillFieldCount);
+    // Quests reach the client only through this seed and the incremental
+    // values path. Without it a character logs in with its quest log empty
+    // and the quest only appears if one of its fields happens to change
+    // later in the session. Emitted first because
+    // AppendSelfPlayerValuesBlock requires ascending legacy indices and
+    // this range (166..415) sorts below visible items at 916.
+    for (uint16 i = 0; i < MopUpdateObject::SelfQuestLogFieldCount; ++i)
+    {
+        const uint16 sourceIndex =
+            uint16(MopUpdateObject::SelfQuestLogSourceStart + i);
+        const uint32 value = player->GetUInt32Value(sourceIndex);
+        if (value != 0)
+        {
+            selfFields.push_back({ sourceIndex, value });
+        }
+    }
     for (uint16 i = 0; i < MopUpdateObject::ObserverVisibleItemFieldCount; ++i)
     {
         const uint16 sourceIndex =


### PR DESCRIPTION
## The bug

`Map::SendInitSelf` seeds the client's self-values at login from exactly three ranges — visible items, inventory, skill. The quest log is not among them.

That means the quest-log projection landed in `a61d113e7` lives **only** on the incremental path in `BuildValuesUpdateBlockForPlayer`. Quests reach the client only if one of their fields changes during the session. Log in holding an existing quest and the client is never told it exists.

This retroactively explains a symptom seen repeatedly during validation: a quest had to be abandoned and re-taken to appear. That forced a values update, which projected it. Inventory and skills survive a relog because they are in the seed list; quests are not.

Credit for the diagnosis goes to the operator, who traced it to the exact seed block.

## The fix

Adds the quest-log range to the seed loop, matching the three existing ones.

**It is emitted first, deliberately.** `AppendSelfPlayerValuesBlock` asserts strictly ascending legacy indices, and the quest-log range (166..415) sorts below visible items at 916. Appending it after the existing loops would build the values block out of order and trip that assert at runtime. No new translate arm is needed — the builder already re-strides via `TranslateSelfQuestLogIndex`.

The `value != 0` skip matches the existing loops and is correct here: at login there are no abandoned slots to clear, which is the only case where a zero must be preserved.

## Tests

The source test now requires the seed **and** asserts its ordering, because a wrong order fails only as a runtime assert that no offline check would otherwise catch. Adds a `questlog_feed` mutation. RED was confirmed before implementing.

- `ctest`: **1084/1084**
- Release `mangosd`: builds clean
- `git diff --check`: clean

## Note for follow-up

This generalises. Any self-only range on the values path needs adding here too, or it works in-session and vanishes on relog. **Buyback and coinage/XP are in the same position and are not fixed by this PR** — buyback matches an observed symptom (needing a vendor visit before it appears). Left out deliberately rather than bundled, since only the quest-log case has a live repro and staged test data.

Runtime validation: two quests are staged (26391 status 0, 28766 status 3). Relog and confirm both render without touching them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/25)
<!-- Reviewable:end -->
