### PR TITLE
[Quests] Project every word of a touched quest-log slot

### DIFF
--- a/src/game/Object/ObjectUpdate.cpp
+++ b/src/game/Object/ObjectUpdate.cpp
@@ -619,11 +619,31 @@ void Object::BuildValuesUpdateBlockForPlayer(UpdateData* data, Player* target) c
             // quest id, so an accepted quest never appears until these private
             // fields are projected. Ordered ahead of the visible-item feed
             // because the serializer requires ascending legacy indices.
-            for (uint16 i = MopUpdateObject::SelfQuestLogSourceStart;
-                 i < MopUpdateObject::SelfQuestLogSourceStart +
-                     MopUpdateObject::SelfQuestLogFieldCount; ++i)
+            //
+            // Fed a whole slot at a time. The serializer emits all fifteen
+            // 18414 words of any slot it sees, so supplying only the changed
+            // word would clear the rest of that slot on the client.
+            for (uint16 slot = 0; slot < MopUpdateObject::SelfQuestLogSlotCount; ++slot)
             {
-                addIfChanged(i);
+                const uint16 base = uint16(MopUpdateObject::SelfQuestLogSourceStart +
+                    slot * MopUpdateObject::SelfQuestLogSourceStride);
+                bool slotChanged = false;
+                for (uint16 word = 0; word < MopUpdateObject::SelfQuestLogSourceStride; ++word)
+                {
+                    if (m_changedValues[base + word])
+                    {
+                        slotChanged = true;
+                        break;
+                    }
+                }
+                if (!slotChanged)
+                {
+                    continue;
+                }
+                for (uint16 word = 0; word < MopUpdateObject::SelfQuestLogSourceStride; ++word)
+                {
+                    fields.push_back({ uint16(base + word), m_uint32Values[base + word] });
+                }
             }
 
             // Local equipment changes use the same public 18414 visible-item

--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -287,13 +287,51 @@ void MopUpdateObject::AppendSelfPlayerValuesBlock(ByteBuffer& out, uint64 guid,
         const uint32 value = sourceFields[i].value;
 
         // QuestLogFrame reads each slot at a fifteen-word stride, so Four's
-        // five-word slots have to be re-strided rather than shifted. Zero
-        // values are preserved: a cleared quest id is how the client is told
-        // a slot was abandoned.
+        // five-word slots have to be re-strided rather than shifted.
+        //
+        // 18414 writes EVERY word of a touched slot. Retail captures show the
+        // mask bit set for all fifteen words, with words 5..14 carried as
+        // explicit zeroes; leaving them unmasked never touches that client-side
+        // storage. Emit the whole slot so the client's view of it is fully
+        // defined. Zero values are significant throughout: a cleared quest id
+        // is how the client is told a slot was abandoned.
+        //
+        // Callers supply whole slots (see the quest-log feeds in
+        // ObjectUpdate.cpp and Map.cpp). Any word the caller omits is emitted
+        // as zero, so a partial slot would clear the rest of it.
         if (sourceIndex >= SelfQuestLogSourceStart &&
             sourceIndex < SelfQuestLogSourceStart + SelfQuestLogFieldCount)
         {
-            fields.push_back({ TranslateSelfQuestLogIndex(sourceIndex), value });
+            const uint16 slot = uint16((sourceIndex - SelfQuestLogSourceStart) /
+                SelfQuestLogSourceStride);
+            uint32 slotWords[SelfQuestLogSourceStride] = { 0 };
+            uint32 next = i;
+            for (; next < fieldCount; ++next)
+            {
+                const uint16 candidate = sourceFields[next].index;
+                if (candidate < SelfQuestLogSourceStart ||
+                    candidate >= SelfQuestLogSourceStart + SelfQuestLogFieldCount)
+                {
+                    break;
+                }
+                if (uint16((candidate - SelfQuestLogSourceStart) /
+                    SelfQuestLogSourceStride) != slot)
+                {
+                    break;
+                }
+                slotWords[(candidate - SelfQuestLogSourceStart) %
+                    SelfQuestLogSourceStride] = sourceFields[next].value;
+            }
+
+            const uint16 targetBase =
+                uint16(SelfQuestLogTargetStart + slot * SelfQuestLogTargetStride);
+            for (uint16 word = 0; word < SelfQuestLogTargetStride; ++word)
+            {
+                fields.push_back({ uint16(targetBase + word),
+                    word < SelfQuestLogSourceStride ? slotWords[word] : 0u });
+            }
+
+            i = next - 1;   // the loop's ++i steps past the consumed slot
             continue;
         }
 

--- a/src/game/Server/tests/mop_initial_self_appearance_source_test.cmake
+++ b/src/game/Server/tests/mop_initial_self_appearance_source_test.cmake
@@ -12,8 +12,8 @@ elseif(MUTATION STREQUAL "combined_builder")
         map_source "${map_source}")
 elseif(MUTATION STREQUAL "questlog_feed")
     string(REPLACE
-        "MopUpdateObject::SelfQuestLogSourceStart + i"
-        "MopUpdateObject::SelfInventorySourceStart + i"
+        "MopUpdateObject::SelfQuestLogSlotCount"
+        "MopUpdateObject::SelfInventoryFieldCount"
         map_source "${map_source}")
 elseif(MUTATION STREQUAL "skill_feed")
     string(REPLACE
@@ -65,7 +65,7 @@ endif()
 # AppendSelfPlayerValuesBlock asserts strictly ascending source indices. The
 # quest-log range is 166..415, below visible items at 916, so its loop must be
 # emitted first or the block is built out of order and trips that assert.
-string(FIND "${self_body}" "MopUpdateObject::SelfQuestLogSourceStart + i" questlog_pos)
+string(FIND "${self_body}" "MopUpdateObject::SelfQuestLogSlotCount" questlog_pos)
 string(FIND "${self_body}" "MopUpdateObject::ObserverVisibleItemSourceStart + i" visible_pos)
 if(questlog_pos EQUAL -1 OR visible_pos EQUAL -1)
     message(FATAL_ERROR "initial self snapshot is missing a required seed loop")

--- a/src/game/Server/tests/mop_self_values_source_test.cmake
+++ b/src/game/Server/tests/mop_self_values_source_test.cmake
@@ -29,8 +29,8 @@ elseif(MUTATION STREQUAL "buyback_feed")
         object_update "${object_update}")
 elseif(MUTATION STREQUAL "questlog_feed")
     string(REPLACE
-        "for (uint16 i = MopUpdateObject::SelfQuestLogSourceStart;"
-        "for (uint16 i = 0; /* removed self quest-log feed */"
+        "for (uint16 slot = 0; slot < MopUpdateObject::SelfQuestLogSlotCount; ++slot)"
+        "for (uint16 slot = 0; false; ++slot) /* removed self quest-log feed */"
         object_update "${object_update}")
 endif()
 
@@ -75,7 +75,7 @@ require_once("for \\(uint16 i = MopUpdateObject::SelfSkillSourceStart"
     "self skill feed")
 require_once("for \\(uint16 i = MopUpdateObject::SelfBuybackSourceStart"
     "self buyback price/timestamp feed")
-require_once("for \\(uint16 i = MopUpdateObject::SelfQuestLogSourceStart"
+require_once("MopUpdateObject::SelfQuestLogSlotCount"
     "self quest-log feed")
 require_once("addIfChanged\\(PLAYER_FIELD_COINAGE\\)"
     "self coinage low-word feed")

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -453,17 +453,22 @@ int main(int /*argc*/, char** /*argv*/)
     // The quest log is the one self range whose slot stride differs between
     // Four and 18414. Four stores fifty five-word slots at 166..415; the
     // client's CGPlayerData::questLog is fifty FIFTEEN-word slots at
-    // 171..920 (750 fields, binary-confirmed). Only the leading five words of
-    // each client slot carry Four's id/state/counts/timer, so the projection
-    // must re-stride per slot rather than copy the range flat. A flat copy
-    // would land legacy slot 1 on 176 instead of 186, inside client slot 0.
+    // 171..920. Retail captures show 18414 setting the mask bit for all
+    // fifteen words of a touched slot, carrying words 5..14 as explicit
+    // zeroes, so the serializer expands each five-word slot to fifteen.
     {
         const MopUpdateObject::StaticField sourceFields[] =
         {
-            { 166, 0x000004D2u },        // slot 0 quest id     -> 171
-            { 170, 0x00000E10u },        // slot 0 timer        -> 175
-            { 171, 0x000004D3u },        // slot 1 quest id     -> 186
-            { 415, 0u },                 // slot 49 timer       -> 910
+            { 166, 0x000004D2u },   // slot 0  quest id
+            { 167, 0x00000001u },   // slot 0  state
+            { 168, 0x00010000u },   // slot 0  counts
+            { 169, 0x00000017u },   // slot 0  counts
+            { 170, 0x00000E10u },   // slot 0  timer
+            { 411, 0x000004D3u },   // slot 49 quest id
+            { 412, 0u },
+            { 413, 0u },
+            { 414, 0u },
+            { 415, 0u },
         };
         ByteBuffer values;
         MopUpdateObject::AppendSelfPlayerValuesBlock(values, 0x10, sourceFields,
@@ -478,16 +483,30 @@ int main(int /*argc*/, char** /*argv*/)
         {
             return (masks[index / 32] & (uint32(1) << (index % 32))) != 0;
         };
-        for (uint16 index : { uint16(171), uint16(175), uint16(186), uint16(910) })
-            CHECK(hasBit(index));
-        // the flat-copy targets, which must NOT be produced
-        CHECK(!hasBit(176));
+        // every word of both touched slots, including the ten zero words
+        for (uint16 index = 171; index <= 185; ++index) CHECK(hasBit(index));
+        for (uint16 index = 906; index <= 920; ++index) CHECK(hasBit(index));
+        // untouched neighbouring slots stay absent
+        CHECK(!hasBit(186));
+        CHECK(!hasBit(905));
+        // A flat range copy would land slot 49 at 416..420 instead of
+        // 906..920, so the positive checks above already exclude it; 420 is
+        // asserted absent as the direct flat-copy target of source 415.
+        // (176 is NOT a valid guard any more: it is slot 0 word 5, which the
+        // serializer now legitimately writes as an explicit zero.)
         CHECK(!hasBit(420));
         // and the untranslated legacy indices
         CHECK(!hasBit(166));
         CHECK(!hasBit(415));
 
-        for (uint32 expectedValue : { 0x000004D2u, 0x00000E10u, 0x000004D3u, 0u })
+        const uint32 expected[] =
+        {
+            0x000004D2u, 0x00000001u, 0x00010000u, 0x00000017u, 0x00000E10u,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,      // slot 0  words 5..14
+            0x000004D3u, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0,      // slot 49 words 5..14
+        };
+        for (uint32 expectedValue : expected)
         {
             uint32 actualValue;
             values >> actualValue;

--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -1958,14 +1958,21 @@ void Map::SendInitSelf(Player* player)
     // later in the session. Emitted first because
     // AppendSelfPlayerValuesBlock requires ascending legacy indices and
     // this range (166..415) sorts below visible items at 916.
-    for (uint16 i = 0; i < MopUpdateObject::SelfQuestLogFieldCount; ++i)
+    // Seeded a whole slot at a time: the serializer emits all fifteen 18414
+    // words of any slot it sees, so a partial slot would clear the remainder
+    // client-side. A slot is seeded when its quest id is set.
+    for (uint16 slot = 0; slot < MopUpdateObject::SelfQuestLogSlotCount; ++slot)
     {
-        const uint16 sourceIndex =
-            uint16(MopUpdateObject::SelfQuestLogSourceStart + i);
-        const uint32 value = player->GetUInt32Value(sourceIndex);
-        if (value != 0)
+        const uint16 base = uint16(MopUpdateObject::SelfQuestLogSourceStart +
+            slot * MopUpdateObject::SelfQuestLogSourceStride);
+        if (player->GetUInt32Value(base) == 0)
         {
-            selfFields.push_back({ sourceIndex, value });
+            continue;
+        }
+        for (uint16 word = 0; word < MopUpdateObject::SelfQuestLogSourceStride; ++word)
+        {
+            selfFields.push_back({ uint16(base + word),
+                player->GetUInt32Value(base + word) });
         }
     }
     for (uint16 i = 0; i < MopUpdateObject::ObserverVisibleItemFieldCount; ++i)


### PR DESCRIPTION
## Evidence

18414 writes **all fifteen words** of a quest slot. Decoded from the retail 18414 corpus — 150 slot observations across values updates:

| word | non-zero | meaning |
|---|---:|---|
| 0 | 30 | quest id |
| 1 | 1 | state |
| 2 | 7 | counts (`0x10000` = packed uint16 pair) |
| 3 | 2 | counts |
| 4–14 | **0** | always zero, but always **present in the mask** |

Words 0–3 match Four's semantic layout exactly, which independently confirms the mapping landed in `a61d113e7`. Words 5–14 are carried as explicit zeroes.

We set mask bits only for words 0–4, so words 5–14 of every slot were never written and the client kept whatever that storage previously held.

## Observed downstream

`QUEST_ACCEPTED` fired with `arg1=8` — a quest-log index one past the end of a 7-entry log — and `arg2=0`, never a valid questID. `AddQuestWatch(arg1)` therefore no-opped and auto-watch never engaged. Manual *Track Quest* worked because that path resolves the index from the UI list rather than from the event argument.

## Change

The serializer expands each five-word source slot to the full fifteen 18414 words, zero-filling 5–14.

Both feeds became slot-granular as a direct consequence: now that a slot is emitted whole, supplying a partial slot would **clear the remainder client-side**. So a slot is fed whole whenever any of its words changed (incremental path) or its quest id is set (login seed).

## Correction to an earlier commit

`a61d113e7` described words 5–14 as "MoP objective storage Four does not populate". The evidence says retail zeroes them. Comment corrected in this change.

## Tests

- `ctest`: **1084/1084**
- Release `mangosd`: builds clean
- `git diff --check`: clean

The byte-exact test now covers both ends of the block (slot 0 and slot 49) and asserts all fifteen words of each touched slot are present, plus that untouched neighbouring slots stay absent. One stale assertion was removed and replaced: `!hasBit(176)` was a valid flat-copy guard before, but 176 is slot 0 word 5, which the serializer now legitimately writes as an explicit zero. The flat-copy case is still excluded — a flat copy could never produce slot 49 at 906..920.

## Honest limit

The causal link from the unwritten words to the bad event arguments is the **leading hypothesis, not proven**. If the client zero-initialises that storage at create, `arg2=0` is consistent with either explanation and `arg1=8` needs a separate account. The divergence from retail is proven and worth closing regardless; the relog retest will settle sufficiency.

Sample bound: 150 slot observations from values packets under 8 KB. "Words 5–14 always zero" is well supported for ordinary quests but does not prove they are never used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/26)
<!-- Reviewable:end -->
