### PR TITLE
[Player] Project XP, coinage, explored zones and the rested pool

### DIFF
--- a/src/game/Object/ObjectUpdate.cpp
+++ b/src/game/Object/ObjectUpdate.cpp
@@ -110,6 +110,9 @@ namespace
         PLAYER_FIELD_BUYBACK_TIMESTAMP_1 + 12 ==
             MopUpdateObject::SelfBuybackSourceStart + MopUpdateObject::SelfBuybackFieldCount,
         "self buyback translation must cover the legacy price and timestamp arrays");
+    static_assert(PLAYER_EXPLORED_ZONES_1 == MopUpdateObject::SelfExploredSourceStart &&
+        PLAYER_REST_STATE_EXPERIENCE == MopUpdateObject::SelfExploredSourceEnd,
+        "explored-zone and rested-pool projection must stay contiguous and anchored");
     static_assert(PLAYER_QUEST_LOG_1_1 == MopUpdateObject::SelfQuestLogSourceStart &&
         PLAYER_QUEST_LOG_50_5 + 1 ==
             MopUpdateObject::SelfQuestLogSourceStart + MopUpdateObject::SelfQuestLogFieldCount,
@@ -672,6 +675,13 @@ void Object::BuildValuesUpdateBlockForPlayer(UpdateData* data, Player* target) c
             for (uint16 i = MopUpdateObject::SelfSkillSourceStart;
                  i < MopUpdateObject::SelfSkillSourceStart +
                      MopUpdateObject::SelfSkillFieldCount; ++i)
+            {
+                addIfChanged(i);
+            }
+            // Explored zones and the rested-XP pool. Ordered after the skill
+            // block and before buyback to keep legacy indices ascending.
+            for (uint16 i = MopUpdateObject::SelfExploredSourceStart;
+                 i <= MopUpdateObject::SelfExploredSourceEnd; ++i)
             {
                 addIfChanged(i);
             }

--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -358,6 +358,17 @@ void MopUpdateObject::AppendSelfPlayerValuesBlock(ByteBuffer& out, uint64 guid,
             fields.push_back({ uint16(sourceIndex + 7), value });
             continue;
         }
+        // 18414 CGPlayerData::local.exploredZones is 1627..1826 and
+        // local.restStateBonusPool 1827; Four stores the same two ranges
+        // contiguously at 1619..1818 and 1819. Both shift by eight. Without
+        // this the rested-XP pool never reaches the client at all, and
+        // MainMenuBar.lua compares a nil exhaustion threshold.
+        if (sourceIndex >= SelfExploredSourceStart &&
+            sourceIndex <= SelfExploredSourceEnd)
+        {
+            fields.push_back({ uint16(sourceIndex + SelfExploredTargetShift), value });
+            continue;
+        }
         // IDA 9.4 18414 CGPlayerData metadata places local.skill at
         // 1153..1600 (448 fields). Four stores the same seven parallel
         // 64-word arrays at 1146..1593.

--- a/src/game/Server/MopUpdateObject.h
+++ b/src/game/Server/MopUpdateObject.h
@@ -51,6 +51,12 @@ namespace MopUpdateObject
     // is fifty fifteen-word slots. The extra ten words per client slot are
     // MoP objective storage Four does not populate, so this range is the only
     // self projection that re-strides instead of shifting by a constant.
+    // Explored zones and the rested-XP pool are contiguous in both layouts:
+    // Four holds 1619..1818 then 1819, 18414 holds local.exploredZones
+    // 1627..1826 then local.restStateBonusPool 1827. One +8 shift covers both.
+    static constexpr uint16 SelfExploredSourceStart = 1619;
+    static constexpr uint16 SelfExploredSourceEnd = 1819;   // inclusive, rest pool
+    static constexpr uint16 SelfExploredTargetShift = 8;
     static constexpr uint16 SelfQuestLogSourceStart = 166;
     static constexpr uint16 SelfQuestLogTargetStart = 171;
     static constexpr uint16 SelfQuestLogSlotCount = 50;

--- a/src/game/Server/tests/mop_initial_self_appearance_source_test.cmake
+++ b/src/game/Server/tests/mop_initial_self_appearance_source_test.cmake
@@ -49,6 +49,12 @@ require_once(
     "MopUpdateObject::SelfSkillSourceStart \\+ i"
     "initial self skill snapshot")
 require_once(
+    "MopUpdateObject::SelfExploredSourceStart"
+    "initial self explored-zone and rested-pool snapshot")
+require_once(
+    "PLAYER_FIELD_COINAGE"
+    "initial self coinage/XP snapshot")
+require_once(
     "MopUpdateObject::SelfQuestLogSourceStart"
     "initial self quest-log snapshot")
 require_once(

--- a/src/game/Server/tests/mop_self_values_source_test.cmake
+++ b/src/game/Server/tests/mop_self_values_source_test.cmake
@@ -75,6 +75,8 @@ require_once("for \\(uint16 i = MopUpdateObject::SelfSkillSourceStart"
     "self skill feed")
 require_once("for \\(uint16 i = MopUpdateObject::SelfBuybackSourceStart"
     "self buyback price/timestamp feed")
+require_once("MopUpdateObject::SelfExploredSourceStart"
+    "self explored-zone and rested-pool feed")
 require_once("MopUpdateObject::SelfQuestLogSlotCount"
     "self quest-log feed")
 require_once("addIfChanged\\(PLAYER_FIELD_COINAGE\\)"

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -518,6 +518,50 @@ int main(int /*argc*/, char** /*argv*/)
         CHECK(values.rpos() == values.size());
     }
 
+    // Explored zones and the rested-XP pool shift by eight, not seven.
+    // 18414 holds local.exploredZones at 1627..1826 and
+    // local.restStateBonusPool at 1827; Four holds 1619..1818 and 1819.
+    {
+        const MopUpdateObject::StaticField sourceFields[] =
+        {
+            { 1619, 0xA1A2A3A4u },   // first explored-zone word -> 1627
+            { 1818, 0xB1B2B3B4u },   // last explored-zone word  -> 1826
+            { 1819, 0xC1C2C3C4u },   // rested-XP pool           -> 1827
+        };
+        ByteBuffer values;
+        MopUpdateObject::AppendSelfPlayerValuesBlock(values, 0x10, sourceFields,
+            sizeof(sourceFields) / sizeof(sourceFields[0]));
+        values.rpos(3);
+        uint8 blockCount;
+        values >> blockCount;
+        CHECK(blockCount == 58);
+        uint32 masks[58];
+        for (uint32& mask : masks) values >> mask;
+        auto hasBit = [&masks](uint16 index)
+        {
+            return (masks[index / 32] & (uint32(1) << (index % 32))) != 0;
+        };
+        CHECK(hasBit(1627));
+        CHECK(hasBit(1826));
+        CHECK(hasBit(1827));
+        // a seven-shift, as used by the coinage/XP range, must not be applied
+        CHECK(!hasBit(1626));
+        CHECK(!hasBit(1825));
+        // and the untranslated legacy indices
+        CHECK(!hasBit(1619));
+        CHECK(!hasBit(1819));
+        for (uint32 expectedValue : { 0xA1A2A3A4u, 0xB1B2B3B4u, 0xC1C2C3C4u })
+        {
+            uint32 actualValue;
+            values >> actualValue;
+            CHECK(actualValue == expectedValue);
+        }
+        uint8 dynamicCount;
+        values >> dynamicCount;
+        CHECK(dynamicCount == 0);
+        CHECK(values.rpos() == values.size());
+    }
+
     // Per-slot re-striding, checked directly at both ends of the block.
     CHECK(MopUpdateObject::TranslateSelfQuestLogIndex(166) == 171);
     CHECK(MopUpdateObject::TranslateSelfQuestLogIndex(170) == 175);

--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -1994,6 +1994,18 @@ void Map::SendInitSelf(Player* player)
             selfFields.push_back({ sourceIndex, value });
         }
     }
+    // Coinage, XP and next-level XP. Without these MainMenuBar.lua compares
+    // a nil exhaustion threshold against a zero max XP on PLAYER_XP_UPDATE and
+    // the XP bar is broken from login. Ordered before the skill block to keep
+    // legacy indices ascending.
+    for (uint16 i = PLAYER_FIELD_COINAGE; i <= PLAYER_NEXT_LEVEL_XP; ++i)
+    {
+        const uint32 value = player->GetUInt32Value(i);
+        if (value != 0)
+        {
+            selfFields.push_back({ i, value });
+        }
+    }
     // The client authorizes selectable chat languages from its local skill
     // block. SMSG_INITIAL_SPELLS alone does not populate that state.
     for (uint16 i = 0; i < MopUpdateObject::SelfSkillFieldCount; ++i)
@@ -2005,6 +2017,18 @@ void Map::SendInitSelf(Player* player)
             selfFields.push_back({ sourceIndex, value });
         }
     }
+    // Explored zones and the rested-XP pool; highest legacy indices in the
+    // seed, so they close the ascending run.
+    for (uint16 i = MopUpdateObject::SelfExploredSourceStart;
+         i <= MopUpdateObject::SelfExploredSourceEnd; ++i)
+    {
+        const uint32 value = player->GetUInt32Value(i);
+        if (value != 0)
+        {
+            selfFields.push_back({ i, value });
+        }
+    }
+
     if (!selfFields.empty())
     {
         MopUpdateObject::AppendSelfPlayerValuesBlock(inventoryData.GetBuffer(), sp.guid,


### PR DESCRIPTION
Fifth and sixth instances of the login-seed gap, client-proved.

`MainMenuBar.lua:119` throws *attempt to compare number with nil* on `PLAYER_XP_UPDATE`, with `playerMaxXP = 0` and `exhaustionThreshold = nil`. The XP bar and rested state are broken from login until something happens to change those fields.

## Two different failures

**Fed but never seeded** — `PLAYER_FIELD_COINAGE`, `PLAYER_XP`, `PLAYER_NEXT_LEVEL_XP` existed only in `ObjectUpdate.cpp`'s `addIfChanged` calls.

**Never sent at all** — `PLAYER_REST_STATE_EXPERIENCE` and the 200 `PLAYER_EXPLORED_ZONES_1` words were in *neither* path **and had no translate arm**, so they could not have reached the client even if fed. That second part is worse than the report and is why the rested threshold was nil rather than stale.

## Mapping, from the 18414 descriptor extraction

| Four | index | client | index | shift |
|---|---:|---|---:|---:|
| `PLAYER_FIELD_COINAGE` | 1142–1143 | `local.coinage` | 1149–1150 | +7 |
| `PLAYER_XP` | 1144 | `local.XP` | 1151 | +7 |
| `PLAYER_NEXT_LEVEL_XP` | 1145 | `local.nextLevelXP` | 1152 | +7 |
| `PLAYER_EXPLORED_ZONES_1` | 1619–1818 | `local.exploredZones` | 1627–1826 | **+8** |
| `PLAYER_REST_STATE_EXPERIENCE` | 1819 | `local.restStateBonusPool` | 1827 | **+8** |

Explored zones and the rested pool are contiguous in **both** layouts, so one `+8` arm covers both. Note the shift differs from the immediately adjacent coinage/XP range — that is why it could not simply be folded into the existing arm, and it is the kind of thing that would have been silently wrong if assumed rather than read from the binary.

## Change

Adds the `+8` translate arm, plus the missing entries in both the incremental feed and the login seed, ordered to keep legacy indices ascending as `AppendSelfPlayerValuesBlock` requires. A `static_assert` binds the new constants to `PLAYER_EXPLORED_ZONES_1` and `PLAYER_REST_STATE_EXPERIENCE` so the two layouts cannot drift.

## Tests

- `ctest`: **1084/1084**
- Release `mangosd`: builds clean
- `git diff --check`: clean

Byte-exact test covers both ends of the explored range plus the rested pool, and asserts a `+7` shift is **not** applied — the specific way this could be got wrong given the neighbouring range uses seven.

## Scope note

Explored zones were not in the reported symptom. They are included because they share the range and the shift with the rested pool, are equally unsent, and would otherwise have been the seventh instance of this same bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/27)
<!-- Reviewable:end -->
