### PR TITLE
[Movement] Register the teleport acknowledgements

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -580,6 +580,15 @@ void InitializeOpcodes()
     DefS(SMSG_PLAYED_TIME, "SMSG_PLAYED_TIME");
 
     // Wave 10 core 5.4.8 player movement and server relay.
+    // Teleport acknowledgements. Both handlers already existed but were never
+    // registered, so the acks from the client reached nothing and the teleport
+    // semaphore was never cleared. Player::Update skips the visibility observer
+    // sweep while IsBeingTeleported(), so one same-map teleport stopped all
+    // object creation for the rest of the session while movement and combat
+    // broadcasts kept flowing. Retail 18414 captures pair SMSG_MOVE_TELEPORT
+    // 1:1 with CMSG_MOVE_TELEPORT_ACK, 1,522 of each, so the ack always comes.
+    DefC(CMSG_MOVE_TELEPORT_ACK, "CMSG_MOVE_TELEPORT_ACK", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMoveTeleportAckOpcode);
+    DefC(MSG_MOVE_WORLDPORT_ACK, "MSG_MOVE_WORLDPORT_ACK", STATUS_TRANSFER, PROCESS_THREADUNSAFE, &WorldSession::HandleMoveWorldportAckOpcode);
     DefC(MSG_MOVE_HEARTBEAT, "MSG_MOVE_HEARTBEAT", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);
     DefC(CMSG_MOVE_START_FORWARD, "CMSG_MOVE_START_FORWARD", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);
     DefC(CMSG_MOVE_START_BACKWARD, "CMSG_MOVE_START_BACKWARD", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);

--- a/src/game/Server/Opcodes.h
+++ b/src/game/Server/Opcodes.h
@@ -264,7 +264,7 @@ enum OpcodesList
     MSG_MOVE_TOGGLE_COLLISION_CHEAT              = 0x0BC8,    // 5.4.1 17538 (no client leaf)
     CMSG_MOVE_SET_FACING                         = 0x1050, // 5.4.8 18414
     CMSG_MOVE_SET_PITCH                          = 0x0261, // not in 5.4.8 (legacy; handler retained)
-    MSG_MOVE_WORLDPORT_ACK                       = 0x00E0,    // 5.4.1 17538 (no client leaf)
+    MSG_MOVE_WORLDPORT_ACK                       = 0x00E0,    // 5.4.8 18414 (480 retail CMSG observations, zero-length)
     SMSG_MONSTER_MOVE                            = 0x1A07,    // 5.4.8 18414 (Wow.exe leaf; name single-source fork)
     SMSG_MOVE_WATER_WALK                         = 0x1F9A,    // 5.4.8 18414 (Wow.exe leaf; name reference-consensus)
     SMSG_MOVE_LAND_WALK                          = 0x086A,    // 5.4.8 18414 (Wow.exe leaf; name reference-consensus)

--- a/src/game/Server/Opcodes_reference.h
+++ b/src/game/Server/Opcodes_reference.h
@@ -175,9 +175,9 @@
  *   TOTAL SMSG rows                   925
  *
  * SUBSYSTEM CONFIDENCE: high=365, low=221, medium=182, none=157
- * STATUS TOTALS: ACTIVE=399, DOC=437, DORMANT=684
+ * STATUS TOTALS: ACTIVE=400, DOC=437, DORMANT=683
  *   SMSG: ACTIVE=258, DOC=271, DORMANT=396
- *   CMSG: ACTIVE=141, DOC=166, DORMANT=288
+ *   CMSG: ACTIVE=142, DOC=166, DORMANT=287
  */
 
 // CAVEATS -- read before trusting any single row:
@@ -1321,7 +1321,7 @@ typedef uint16_t uint16;
  *   CMSG_UNKNOWN_0x0069                            0x0069  DOC     
  *   CMSG_LFD_LOCK_INFO_REQUEST                     0x006B  ACTIVE   server-binding=CMSG_LFG_LOCK_INFO_REQUEST
  *   CMSG_UNKNOWN_0x0071                            0x0071  DOC     
- *   CMSG_MOVE_TELEPORT_ACK                         0x0078  DORMANT 
+ *   CMSG_MOVE_TELEPORT_ACK                         0x0078  ACTIVE
  *   CMSG_MOVE_STOP_PITCH                           0x007A  DORMANT 
  *   CMSG_MOUNTSPECIAL_ANIM                         0x0082  DORMANT 
  *   CMSG_SCENE_COMPLETED                           0x0087  DOC     

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -1197,7 +1197,7 @@ foreach(mutation IN ITEMS inbound_sequence movement_gap_sequence player_move_seq
         force_swim_sequence force_swim_flags2_width flags2_width inbound_registration movement_gap_registration force_swim_registration
         force_swim_handler_order output_metadata heartbeat_framing mover_guid_validation
         spline_state_builder spline_state_registration monster_move_writer monster_move_registration
-        monster_move_integration monster_move_gate)
+        monster_move_integration monster_move_gate teleport_ack_registration worldport_ack_registration)
     add_test(NAME mop_movement_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/mop_movement_source_test.cmake
+++ b/src/game/Server/tests/mop_movement_source_test.cmake
@@ -81,6 +81,16 @@ elseif(MUTATION STREQUAL "monster_move_integration")
 elseif(MUTATION STREQUAL "monster_move_gate")
     string(REPLACE "case SMSG_MONSTER_MOVE:" "case SMSG_MONSTER_MOVE_REMOVED:"
         world_session_source "${world_session_source}")
+elseif(MUTATION STREQUAL "teleport_ack_registration")
+    string(REPLACE
+        "DefC(CMSG_MOVE_TELEPORT_ACK, \"CMSG_MOVE_TELEPORT_ACK\""
+        "DefC(0xFFFF, \"removed teleport ack\""
+        opcode_registry "${opcode_registry}")
+elseif(MUTATION STREQUAL "worldport_ack_registration")
+    string(REPLACE
+        "DefC(MSG_MOVE_WORLDPORT_ACK, \"MSG_MOVE_WORLDPORT_ACK\""
+        "DefC(0xFFFF, \"removed worldport ack\""
+        opcode_registry "${opcode_registry}")
 endif()
 
 function(strip_cpp_comments output source)
@@ -338,3 +348,18 @@ foreach(required IN ITEMS "recv_data >> movementInfo" "VerifyMovementInfo(moveme
         message(FATAL_ERROR "movement handler integration missing: ${required}")
     endif()
 endforeach()
+
+# Both teleport acknowledgements have had working handlers since before the
+# 18414 work, but neither was registered, so the client acks reached nothing
+# and the teleport semaphore never cleared. Player::Update skips the
+# visibility observer sweep while IsBeingTeleported(), so a single same-map
+# teleport silently stopped all object creation for the rest of the session.
+require_once("${opcode_registry}"
+    "DefC(CMSG_MOVE_TELEPORT_ACK, \"CMSG_MOVE_TELEPORT_ACK\""
+    "CMSG_MOVE_TELEPORT_ACK inbound registration")
+require_once("${opcode_registry}"
+    "DefC(MSG_MOVE_WORLDPORT_ACK, \"MSG_MOVE_WORLDPORT_ACK\""
+    "MSG_MOVE_WORLDPORT_ACK inbound registration")
+require_once("${movement_handler}"
+    "plMover->SetSemaphoreTeleportNear(false)"
+    "near-teleport semaphore release")


### PR DESCRIPTION
A single same-map teleport stopped **all object creation for the rest of the session**.

Operator capture:

```
before 1st teleport:  236  SMSG_UPDATE_OBJECT
between teleports:      0
after 2nd teleport:     0     (15,000 further log lines)

meanwhile:           1155  SMSG_MONSTER_MOVE
                       94  SMSG_ATTACKERSTATEUPDATE
                       76  SMSG_THREAT_UPDATE
```

Creatures moved, attacked the player and generated threat against a client that had never been told they existed.

## Cause

`CMSG_MOVE_TELEPORT_ACK 0x0078` and `MSG_MOVE_WORLDPORT_ACK 0x00E0` both have complete handlers — `HandleMoveTeleportAckOpcode` at `MovementHandler.cpp:326`, which clears the near-teleport semaphore at line 353 — but **neither was ever registered** in `Opcodes.cpp`.

So the client's acks went to the unhandled-opcode log, `mSemaphoreTeleport_Near` was never cleared, and `Player.cpp:1024`:

```cpp
if (World::GetVisibilityObserverSweepEnabled() && !IsBeingTeleported())
```

skips the visibility observer sweep forever. No sweep, no creates. Broadcasts kept flowing because they do not go through visibility, which is why the world stayed alive but invisible.

The operator's log shows the acks arriving exactly as predicted: `2 × UNKNOWN (0x0078)`, one per teleport.

## The acks are not optional

Retail 18414 captures pair them 1:1:

```
SMSG_MOVE_TELEPORT      0x0B39   1,522 occurrences   len 27-29
CMSG_MOVE_TELEPORT_ACK  0x0078   1,522 occurrences   len 14-16
MSG_MOVE_WORLDPORT_ACK  0x00E0     480 occurrences   len 0
```

Exactly 1,522 of each — every teleport the server sends, the client acks. The 480 zero-length observations also confirm `0x00E0` for 18414; its `Opcodes.h` comment claimed *"5.4.1 17538 (no client leaf)"* and is corrected here.

## Relationship to the visibility gate

Same visible symptom as the create-eligibility gate, different mechanism. That bug **rejected** creates inside `BuildCreateUpdateBlockForPlayer`; this one stops that function being reached at all. Both are needed.

It also explains an earlier report of `.tele stormwind` hanging on the loading screen — the far-teleport equivalent, `MSG_MOVE_WORLDPORT_ACK`.

## Test

Asserts both registrations and the semaphore release, with mutations removing each.

Worth stating why this needed a new test rather than an existing one catching it: **a correct, fully-implemented handler that is simply never wired to an opcode is invisible to every other test we have.** Nothing compiles differently, nothing fails, the code just never runs. That is a defect class, not a one-off.

- `ctest`: **1086/1086**
- Release `mangosd`: builds clean
- reference overlay: ACTIVE=400, DOC=437, DORMANT=683, idempotent
- `git diff --check`: clean

## Runtime validation

Teleport within a map twice and confirm object updates continue; confirm `.tele` to another map completes rather than hanging on the loading screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/28)
<!-- Reviewable:end -->
