### PR TITLE
[Movement] Do not register MSG_MOVE_WORLDPORT_ACK: 0x00E0 is CMSG_CHAR_ENUM

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -587,8 +587,11 @@ void InitializeOpcodes()
     // object creation for the rest of the session while movement and combat
     // broadcasts kept flowing. Retail 18414 captures pair SMSG_MOVE_TELEPORT
     // 1:1 with CMSG_MOVE_TELEPORT_ACK, 1,522 of each, so the ack always comes.
+    // MSG_MOVE_WORLDPORT_ACK is deliberately NOT registered: its inherited
+    // value 0x00E0 belongs to CMSG_CHAR_ENUM in 18414. Registering it there
+    // overwrote the char-enum slot and hung every client on "Retrieving
+    // character list". Its real 18414 value is unknown.
     DefC(CMSG_MOVE_TELEPORT_ACK, "CMSG_MOVE_TELEPORT_ACK", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMoveTeleportAckOpcode);
-    DefC(MSG_MOVE_WORLDPORT_ACK, "MSG_MOVE_WORLDPORT_ACK", STATUS_TRANSFER, PROCESS_THREADUNSAFE, &WorldSession::HandleMoveWorldportAckOpcode);
     DefC(MSG_MOVE_HEARTBEAT, "MSG_MOVE_HEARTBEAT", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);
     DefC(CMSG_MOVE_START_FORWARD, "CMSG_MOVE_START_FORWARD", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);
     DefC(CMSG_MOVE_START_BACKWARD, "CMSG_MOVE_START_BACKWARD", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);

--- a/src/game/Server/Opcodes.h
+++ b/src/game/Server/Opcodes.h
@@ -264,7 +264,7 @@ enum OpcodesList
     MSG_MOVE_TOGGLE_COLLISION_CHEAT              = 0x0BC8,    // 5.4.1 17538 (no client leaf)
     CMSG_MOVE_SET_FACING                         = 0x1050, // 5.4.8 18414
     CMSG_MOVE_SET_PITCH                          = 0x0261, // not in 5.4.8 (legacy; handler retained)
-    MSG_MOVE_WORLDPORT_ACK                       = 0x00E0,    // 5.4.8 18414 (480 retail CMSG observations, zero-length)
+    MSG_MOVE_WORLDPORT_ACK                       = 0x00E0,    // WRONG for 18414: 0x00E0 is CMSG_CHAR_ENUM. Value unverified, do not register.
     SMSG_MONSTER_MOVE                            = 0x1A07,    // 5.4.8 18414 (Wow.exe leaf; name single-source fork)
     SMSG_MOVE_WATER_WALK                         = 0x1F9A,    // 5.4.8 18414 (Wow.exe leaf; name reference-consensus)
     SMSG_MOVE_LAND_WALK                          = 0x086A,    // 5.4.8 18414 (Wow.exe leaf; name reference-consensus)

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -1197,7 +1197,7 @@ foreach(mutation IN ITEMS inbound_sequence movement_gap_sequence player_move_seq
         force_swim_sequence force_swim_flags2_width flags2_width inbound_registration movement_gap_registration force_swim_registration
         force_swim_handler_order output_metadata heartbeat_framing mover_guid_validation
         spline_state_builder spline_state_registration monster_move_writer monster_move_registration
-        monster_move_integration monster_move_gate teleport_ack_registration worldport_ack_registration)
+        monster_move_integration monster_move_gate teleport_ack_registration)
     add_test(NAME mop_movement_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/mop_movement_source_test.cmake
+++ b/src/game/Server/tests/mop_movement_source_test.cmake
@@ -86,11 +86,6 @@ elseif(MUTATION STREQUAL "teleport_ack_registration")
         "DefC(CMSG_MOVE_TELEPORT_ACK, \"CMSG_MOVE_TELEPORT_ACK\""
         "DefC(0xFFFF, \"removed teleport ack\""
         opcode_registry "${opcode_registry}")
-elseif(MUTATION STREQUAL "worldport_ack_registration")
-    string(REPLACE
-        "DefC(MSG_MOVE_WORLDPORT_ACK, \"MSG_MOVE_WORLDPORT_ACK\""
-        "DefC(0xFFFF, \"removed worldport ack\""
-        opcode_registry "${opcode_registry}")
 endif()
 
 function(strip_cpp_comments output source)
@@ -357,9 +352,6 @@ endforeach()
 require_once("${opcode_registry}"
     "DefC(CMSG_MOVE_TELEPORT_ACK, \"CMSG_MOVE_TELEPORT_ACK\""
     "CMSG_MOVE_TELEPORT_ACK inbound registration")
-require_once("${opcode_registry}"
-    "DefC(MSG_MOVE_WORLDPORT_ACK, \"MSG_MOVE_WORLDPORT_ACK\""
-    "MSG_MOVE_WORLDPORT_ACK inbound registration")
 require_once("${movement_handler}"
     "plMover->SetSemaphoreTeleportNear(false)"
     "near-teleport semaphore release")


### PR DESCRIPTION
**Fixes a login-breaking regression introduced by `bef38f2be` (PR #28).**

`MSG_MOVE_WORLDPORT_ACK` carries the inherited value `0x00E0`, which in 18414 is `CMSG_CHAR_ENUM` — already registered at `opcode_register.inc:4` with `STATUS_AUTHED`. Registering the worldport ack overwrote that dispatch slot, so the character-list request was dispatched as a worldport ack and rejected with *"the player has not logged in yet"*. Every client hung on **"Retrieving character list"**.

```
previous build:  0x00E0 -> CMSG_CHAR_ENUM          -> SMSG_CHAR_ENUM sent   OK
bef38f2be:       0x00E0 -> MSG_MOVE_WORLDPORT_ACK  -> rejected, no response BROKEN
```

## Why I got it wrong

I read **480 zero-length CMSG observations of `0x00E0`** in the retail corpus as confirming the worldport ack. They confirm only that `0x00E0` is a zero-length client message. `CMSG_CHAR_ENUM` is *also* zero-length, and 480 character-list requests across a sniff corpus is entirely ordinary — one every time a player reaches the character screen.

Frequency and shape matched. Identity did not. Wire observation can confirm that a value is *used*, and in which direction, but it cannot by itself say *which message* it is — the same distinction I had written into the evidence-tier note earlier and then failed to apply.

`Opcodes.h` had already flagged the value as inherited from 5.4.1 17538 *"(no client leaf)"*. I upgraded that caveat to "confirmed" on the strength of the observation count instead of heeding it.

## What stays

`CMSG_MOVE_TELEPORT_ACK 0x0078` is unaffected and correct: no collision, binary-confirmed for 18414, handler present, and paired 1:1 with `SMSG_MOVE_TELEPORT` across 1,522 retail observations each. That half fixes same-map teleport killing all object creation and should not be reverted.

## What is now open again

The far-teleport ack has **no known 18414 value**, so the cross-map `.tele` loading-screen hang is unexplained again. `Opcodes.h` now records `0x00E0` as wrong for this build rather than as confirmed, so the next person does not repeat this.

## Follow-up worth doing

Nothing in the build catches two opcodes sharing a value — the second `DefC` silently wins. A duplicate-registration guard would have caught this at test time rather than at login. Not included here to keep the fix minimal and fast.

- `ctest`: **1085/1085**
- Release `mangosd`: builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/29)
<!-- Reviewable:end -->
