### PR TITLE
[Quests] Send the quest's objectives, and its own id, in the query response

### DIFF
--- a/src/game/Server/tests/mop_questgiver_acquisition_packets_test.cpp
+++ b/src/game/Server/tests/mop_questgiver_acquisition_packets_test.cpp
@@ -480,7 +480,7 @@ static void TestQuestQueryResponseFixedOrder()
     response.rewardHonorAddition = 2205;
     response.obsoleteArenaPoints = 2206;
     response.suggestedPlayers = 2207;
-    response.repObjectiveFaction = 2208;
+    response.innerQuestId = 2208;
     response.minLevel = 2209;
     response.rewardReputationMask = 2210;
     response.pointOpt = 2211;
@@ -612,6 +612,92 @@ static void TestQuestQueryResponseStringsAndObjective()
     CHECK(visual == objective.visualEffects[0]);
 }
 
+// Reproduces a real retail 18414 response byte-for-byte in size and layout.
+//
+// Quest 27353 "Blessings of the Elements" was captured from live traffic: a
+// 1121-byte response with three item objectives and strings of 58/98/493/25
+// bytes. The retail packet places its strings at 235, 301, 451 and 980, and
+// repeats the quest id at offset 411. Our builder must land on all of it.
+//
+// Before the objectives block was populated this produced 1056 bytes with
+// every string 65 bytes early, which is what stopped the client auto-watching
+// an accepted quest.
+static void TestQuestQueryResponseMatchesRetail27353()
+{
+    MopQuestQueryPackets::Response response;
+    response.questId = 27353;
+    response.innerQuestId = 27353;
+    response.completedText = std::string(58, 'c');
+    response.objectivesText = std::string(98, 'o');
+    response.details = std::string(493, 'd');
+    response.title = std::string(25, 't');
+
+    uint32_t const objectIds[3] = { 60881, 60873, 60875 };
+    int32_t const amounts[3] = { 1, 1, 5 };
+    for (uint32_t i = 0; i < 3; ++i)
+    {
+        MopQuestQueryPackets::Objective objective;
+        objective.id = 27353 * 16 + i;
+        objective.type = MopQuestQueryPackets::OBJECTIVE_ITEM;
+        objective.index = uint8_t(i);
+        objective.objectId = objectIds[i];
+        objective.amount = amounts[i];
+        response.objectives.push_back(objective);
+    }
+
+    WorldPacket packet;
+    CHECK(MopQuestQueryPackets::BuildResponse(packet, response));
+    CHECK(packet.size() == 1121);
+
+    // 4 + ceil((109 + 30*3)/8) == 4 + 25, then three 18-byte objectives.
+    CHECK(std::memcmp(&packet[29 + 0 * 18], "\x01\x00\x00\x00", 4) == 0);
+    CHECK(packet[29 + 0 * 18 + 12] == 0);       // index
+    CHECK(packet[29 + 0 * 18 + 13] == 1);       // type: item
+    CHECK(packet[29 + 2 * 18 + 12] == 2);
+    CHECK(std::memcmp(&packet[29 + 2 * 18 + 14], "\xcb\xed\x00\x00", 4) == 0);
+
+    // String offsets, straight off the retail capture.
+    CHECK(std::memcmp(&packet[235], std::string(58, 'c').data(), 58) == 0);
+    CHECK(std::memcmp(&packet[301], std::string(98, 'o').data(), 98) == 0);
+    CHECK(std::memcmp(&packet[451], std::string(493, 'd').data(), 493) == 0);
+    CHECK(std::memcmp(&packet[980], std::string(25, 't').data(), 25) == 0);
+
+    // Retail repeats the quest id here. Feeding this slot from
+    // RepObjectiveFaction left it zero, which made the client compute
+    // QUEST_ACCEPTED's arguments from a missing cache entry.
+    uint32_t inner = 0;
+    std::memcpy(&inner, &packet[411], 4);
+    CHECK(inner == 27353);
+}
+
+// A reputation requirement has to survive as its own objective now that the
+// scalar it used to travel in is known to carry the quest id. Retail marks it
+// untracked: type 6, index 255, faction in objectId, standing in amount.
+static void TestQuestQueryResponseReputationObjective()
+{
+    MopQuestQueryPackets::Response response;
+    response.questId = 32374;
+    response.innerQuestId = 32374;
+
+    MopQuestQueryPackets::Objective objective;
+    objective.id = 32374 * 16;
+    objective.type = MopQuestQueryPackets::OBJECTIVE_REPUTATION;
+    objective.index = MopQuestQueryPackets::ObjectiveIndexUntracked;
+    objective.objectId = 1359;
+    objective.amount = 21000;
+    response.objectives.push_back(objective);
+
+    WorldPacket packet;
+    CHECK(MopQuestQueryPackets::BuildResponse(packet, response));
+
+    size_t const base = 4 + 18;                 // 4 + ceil((109 + 30)/8)
+    CHECK(packet[base + 12] == 255);
+    CHECK(packet[base + 13] == 6);
+    uint32_t faction = 0;
+    std::memcpy(&faction, &packet[base + 14], 4);
+    CHECK(faction == 1359);
+}
+
 static void TestOpcodeValues()
 {
     CHECK(uint32_t(CMSG_QUESTGIVER_HELLO) == 0x02DBu);
@@ -636,6 +722,8 @@ int main(int /*argc*/, char** /*argv*/)
     TestQuestQueryAbsentResponse();
     TestQuestQueryResponseFixedOrder();
     TestQuestQueryResponseStringsAndObjective();
+    TestQuestQueryResponseMatchesRetail27353();
+    TestQuestQueryResponseReputationObjective();
     TestOpcodeValues();
 
     if (g_fail != 0)

--- a/src/game/WorldHandlers/GossipDef.cpp
+++ b/src/game/WorldHandlers/GossipDef.cpp
@@ -620,6 +620,11 @@ void PlayerMenu::SendQuestQueryResponse(uint32 questId,
     std::string Title, Details, Objectives, EndText, CompletedText;
     std::string PortraitGiverText, PortraitGiverName;
     std::string PortraitTurnInText, PortraitTurnInName;
+    std::string ObjectiveText[QUEST_OBJECTIVES_COUNT];
+    for (uint32 slot = 0; slot < QUEST_OBJECTIVES_COUNT; ++slot)
+    {
+        ObjectiveText[slot] = pQuest->ObjectiveText[slot];
+    }
     Title = pQuest->GetTitle();
     Details = pQuest->GetDetails();
     Objectives = pQuest->GetObjectives();
@@ -673,6 +678,14 @@ void PlayerMenu::SendQuestQueryResponse(uint32 questId,
             {
                 PortraitTurnInText = ql->PortraitTurnInText[loc_idx];
             }
+            for (uint32 slot = 0; slot < QUEST_OBJECTIVES_COUNT; ++slot)
+            {
+                if (ql->ObjectiveText[slot].size() > (size_t)loc_idx &&
+                    !ql->ObjectiveText[slot][loc_idx].empty())
+                {
+                    ObjectiveText[slot] = ql->ObjectiveText[slot][loc_idx];
+                }
+            }
         }
     }
 
@@ -684,7 +697,7 @@ void PlayerMenu::SendQuestQueryResponse(uint32 questId,
     response.rewardMoneyMaxLevel = pQuest->GetRewMoneyMaxLevel();
     response.rewardHonorAddition = pQuest->GetRewHonorAddition();
     response.suggestedPlayers = pQuest->GetSuggestedPlayers();
-    response.repObjectiveFaction = pQuest->GetRepObjectiveFaction();
+    response.innerQuestId = pQuest->GetQuestId();
     response.minLevel = int32(pQuest->GetMinLevel());
     response.pointOpt = pQuest->GetPointOpt();
     response.questLevel = pQuest->GetQuestLevel();
@@ -709,6 +722,84 @@ void PlayerMenu::SendQuestQueryResponse(uint32 questId,
     response.title = Title;
     response.details = Details;
     response.objectivesText = Objectives;
+
+    // 18414 carries the quest's objectives as a structured block. The client
+    // builds its tracker from these, not from the objectives display string,
+    // so a quest sent without them renders its text correctly but is never
+    // watched. The block was absent entirely until now.
+    //
+    // An objective's index selects which 16-bit counter lane of the quest log
+    // the client reads. SetQuestSlotCounter() writes lane creatureOrGO_idx and
+    // nothing else, so creature and gameobject objectives must keep their
+    // array position or they would display another objective's progress.
+    // Items are free to take any spare lane. Our counter words only span lanes
+    // 0-3, so an item that finds none left is marked untracked rather than
+    // pointing past them at the quest timer.
+    bool laneUsed[QUEST_OBJECTIVES_COUNT] = {};
+    uint32 objectiveSerial = 0;
+
+    for (uint32 slot = 0; slot < QUEST_OBJECTIVES_COUNT; ++slot)
+    {
+        int32 const entry = pQuest->ReqCreatureOrGOId[slot];
+        if (!entry || !pQuest->ReqCreatureOrGOCount[slot])
+        {
+            continue;
+        }
+
+        MopQuestQueryPackets::Objective objective;
+        // Retail sends global QuestObjective record ids, which the world
+        // database has no column for. A quest-scoped sequence preserves the
+        // one property the client can depend on: uniqueness.
+        objective.id = pQuest->GetQuestId() * 16 + objectiveSerial++;
+        objective.type = entry > 0
+            ? uint8(MopQuestQueryPackets::OBJECTIVE_CREATURE)
+            : uint8(MopQuestQueryPackets::OBJECTIVE_GAMEOBJECT);
+        objective.objectId = uint32(entry > 0 ? entry : -entry);
+        objective.amount = int32(pQuest->ReqCreatureOrGOCount[slot]);
+        objective.index = uint8(slot);
+        objective.text = ObjectiveText[slot];
+        laneUsed[slot] = true;
+        response.objectives.push_back(objective);
+    }
+
+    for (uint32 slot = 0; slot < QUEST_ITEM_OBJECTIVES_COUNT; ++slot)
+    {
+        if (!pQuest->ReqItemId[slot] || !pQuest->ReqItemCount[slot])
+        {
+            continue;
+        }
+
+        MopQuestQueryPackets::Objective objective;
+        objective.id = pQuest->GetQuestId() * 16 + objectiveSerial++;
+        objective.type = uint8(MopQuestQueryPackets::OBJECTIVE_ITEM);
+        objective.objectId = pQuest->ReqItemId[slot];
+        objective.amount = int32(pQuest->ReqItemCount[slot]);
+        objective.index = MopQuestQueryPackets::ObjectiveIndexUntracked;
+        for (uint32 lane = 0; lane < QUEST_OBJECTIVES_COUNT; ++lane)
+        {
+            if (!laneUsed[lane])
+            {
+                laneUsed[lane] = true;
+                objective.index = uint8(lane);
+                break;
+            }
+        }
+        response.objectives.push_back(objective);
+    }
+
+    // A reputation requirement is an objective of its own on the wire. It used
+    // to reach the client only as the scalar that actually carries the quest
+    // id, so moving that scalar would otherwise drop the requirement.
+    if (pQuest->GetRepObjectiveFaction() && pQuest->GetRepObjectiveValue())
+    {
+        MopQuestQueryPackets::Objective objective;
+        objective.id = pQuest->GetQuestId() * 16 + objectiveSerial++;
+        objective.type = uint8(MopQuestQueryPackets::OBJECTIVE_REPUTATION);
+        objective.objectId = pQuest->GetRepObjectiveFaction();
+        objective.amount = pQuest->GetRepObjectiveValue();
+        objective.index = MopQuestQueryPackets::ObjectiveIndexUntracked;
+        response.objectives.push_back(objective);
+    }
     response.endText = EndText;
     response.completedText = CompletedText;
     response.portraitGiverText = PortraitGiverText;

--- a/src/game/WorldHandlers/GossipDef.h
+++ b/src/game/WorldHandlers/GossipDef.h
@@ -953,6 +953,27 @@ namespace MopQuestQueryPackets
         uint64 sourceGuid = 0;
     };
 
+    // Objective kinds recovered from real 18414 traffic. The counts are
+    // occurrences over 3,189 responses that decoded with zero residual, and
+    // each kind was identified from the range its objectId falls in:
+    // creatures and items sit in their usual entry ranges, and the type-2
+    // objectIds observed (210890-215762) are gameobject entries.
+    enum ObjectiveType : uint8
+    {
+        OBJECTIVE_CREATURE   = 0,       // n=2011
+        OBJECTIVE_ITEM       = 1,       // n=1233
+        OBJECTIVE_GAMEOBJECT = 2,       // n=98
+        OBJECTIVE_CURRENCY   = 4,       // n=50, always untracked
+        OBJECTIVE_REPUTATION = 6,       // n=50, always untracked
+        OBJECTIVE_MONEY      = 8,       // n=4,  always untracked
+    };
+
+    // An objective's index selects which 16-bit counter lane of the quest log
+    // the client reads. Retail marks objectives that occupy no lane with this
+    // sentinel; every currency, reputation and money objective in the corpus
+    // carries it, and no tracked objective does.
+    static constexpr uint8 ObjectiveIndexUntracked = 255;
+
     struct Objective
     {
         int32 amount = 0;
@@ -996,7 +1017,11 @@ namespace MopQuestQueryPackets
         uint32 rewardHonorAddition = 0;
         uint32 obsoleteArenaPoints = 0;
         uint32 suggestedPlayers = 0;
-        uint32 repObjectiveFaction = 0;
+        // The record repeats its own quest id here. This slot was previously
+        // fed from RepObjectiveFaction; every one of 4,564 retail 18414
+        // responses carries the quest id in it instead, and the client reads
+        // it as QuestInfo field 0 when it raises QUEST_ACCEPTED.
+        uint32 innerQuestId = 0;
         int32 minLevel = 0;
         uint32 rewardReputationMask = 0;
         uint32 pointOpt = 0;
@@ -1213,7 +1238,7 @@ namespace MopQuestQueryPackets
         built << response.obsoleteArenaPoints;
         built << response.rewardChoiceItemIds[5];
         built << response.suggestedPlayers;
-        built << response.repObjectiveFaction;
+        built << response.innerQuestId;
         built << response.requiredSourceItemIds[1];
         built << response.rewardItemIds[1];
         built << response.minLevel;


### PR DESCRIPTION
Fixes quest auto-watch. Two defects in `SMSG_QUEST_QUERY_RESPONSE`, both found by
decoding real 18414 retail captures.

## 1. The objectives block was never populated

`Response::objectives` had no producer anywhere in production code — the only
`push_back` calls in the tree are in tests. The handler set `objectivesText`
(the display string), which is why quest text always looked right while the
client had nothing to build a tracker from.

Our response for quest 27353 was 1056 bytes against retail's 1121, with all four
strings displaced by a **constant** 65 bytes and **identical declared lengths**,
so none of the gap was content drift:

```
header      ceil(30*3/8) = 11
objectives        3 x 18 = 54
                    total = 65
```

## 2. One scalar is the record's own quest id, not RepObjectiveFaction

The slot fed from `GetRepObjectiveFaction()` holds the quest id in **all 4,564**
retail responses examined — including the **29** that carry a reputation
objective, which are exactly the quests where a real `RepObjectiveFaction` would
have shown itself. It never does.

Leaving it zero is what broke auto-watch: `payload[0] == 0` sends `sub_97B060`
past the display list to return `count+1`, which matches the observed
`arg1 = entries+1, arg2 = 0`.

Reputation requirements now travel as their own `type-6` objective the way retail
sends them, so moving the scalar doesn't drop them.

## Evidence

A walker built from our field order consumes **3,189 retail responses with zero
residual**, fixing the objective layout as
`amount, id, text, flags, index (uint8), type (uint8), objectId` (18 bytes + text).
Objective kinds were identified from the entry range each `objectId` falls in.

## The index constraint

`index` selects which 16-bit counter lane the client reads.
`SetQuestSlotCounter()` writes lane `creatureOrGO_idx` and nothing else, so
creature/GO objectives must keep their array position. Items take spare lanes;
our counter words only cover lanes 0-3, so an item with none left is marked
untracked (255, retail's sentinel) rather than addressing the quest timer past
them.

## Tests

New cases reproduce the retail packet exactly: 1121 bytes, strings at 235, 301,
451, 980, quest id repeated at 411. Suite is 1085/1085 (three unrelated tests
need `OPENSSL_MODULES` and `libmariadb.dll`/`lua52.dll` on PATH; all three pass
once set).

## Not covered by unit tests

The population path itself needs a live `Quest` and session, so it is verified by
the retail-layout test on the builder plus live testing. Worth watching on first
live run: an item objective showing a nonsense count would mean the client reads
a lane for items past our two counter words.

Reviewed read-only by Codex; its two valid findings (gameobject sign handling,
dropped reputation objectives) are both fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/30)
<!-- Reviewable:end -->
