### PR TITLE
[Movement] Register the far-teleport ack at its real 18414 value, 0x1FAD

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -47,6 +47,8 @@
 #include "Opcodes.h"
 #include "WorldSession.h"
 
+#include <cstring>
+
 /**
  * @brief Static integrity metadata for the Phase 1a login closure.
  *
@@ -58,12 +60,34 @@
 OpcodeHandler clientOpcodeTable[OPCODE_TABLE_SIZE];
 OpcodeHandler serverOpcodeTable[OPCODE_TABLE_SIZE];
 
+/// Which table slots a registration has already claimed, so that a second
+/// claim on the same value is caught instead of silently replacing the first.
+static bool clientOpcodeClaimed[OPCODE_TABLE_SIZE];
+static bool serverOpcodeClaimed[OPCODE_TABLE_SIZE];
+
 /**
  * @brief Register a client-received (inbound) opcode with its real handler.
+ *
+ * Two symbols sharing a value is a data error, not a runtime condition: the
+ * second registration replaces the first and the displaced opcode simply stops
+ * being dispatched. That happened with MSG_MOVE_WORLDPORT_ACK, whose inherited
+ * 0x00E0 is CMSG_CHAR_ENUM in 18414 -- registering it hung every client on
+ * "Retrieving character list", and nothing reported why. Fail loudly instead.
  */
 static void DefC(uint16 v, char const* name, SessionStatus s, PacketProcessing p, void (WorldSession::*h)(WorldPacket&))
 {
     MANGOS_ASSERT(v < OPCODE_TABLE_SIZE);
+    if (clientOpcodeClaimed[v])
+    {
+        // Registering the same symbol twice is redundant but harmless; the
+        // generated login closure and the manual block below it can overlap.
+        // Two *different* symbols on one value is the bug this guards against.
+        MANGOS_ASSERT(std::strcmp(name, clientOpcodeTable[v].name) == 0 &&
+            "two client opcodes share one value: the second would silently "
+            "displace the first from the dispatch table");
+        sLog.outDetail("Opcodes: client opcode 0x%04X ('%s') registered twice", v, name);
+    }
+    clientOpcodeClaimed[v] = true;
     clientOpcodeTable[v] = OpcodeHandler{ name, s, p, h };
 }
 
@@ -73,6 +97,14 @@ static void DefC(uint16 v, char const* name, SessionStatus s, PacketProcessing p
 static void DefS(uint16 v, char const* name)
 {
     MANGOS_ASSERT(v < OPCODE_TABLE_SIZE);
+    if (serverOpcodeClaimed[v])
+    {
+        MANGOS_ASSERT(std::strcmp(name, serverOpcodeTable[v].name) == 0 &&
+            "two server opcodes share one value: the second would silently "
+            "displace the first from the name table");
+        sLog.outDetail("Opcodes: server opcode 0x%04X ('%s') registered twice", v, name);
+    }
+    serverOpcodeClaimed[v] = true;
     serverOpcodeTable[v] = OpcodeHandler{ name, STATUS_NEVER, PROCESS_INPLACE, &WorldSession::Handle_ServerSide };
 }
 
@@ -151,6 +183,8 @@ void InitializeOpcodes()
     {
         clientOpcodeTable[i] = OpcodeHandler{ "UNKNOWN", STATUS_UNHANDLED, PROCESS_INPLACE, &WorldSession::Handle_NULL };
         serverOpcodeTable[i] = OpcodeHandler{ "UNKNOWN", STATUS_NEVER, PROCESS_INPLACE, &WorldSession::Handle_ServerSide };
+        clientOpcodeClaimed[i] = false;
+        serverOpcodeClaimed[i] = false;
     }
 #include "opcode_register.inc"     // login closure only (Phase 1a); greeting NOT registered
     AssertLoginClosureIntegrity();
@@ -587,11 +621,17 @@ void InitializeOpcodes()
     // object creation for the rest of the session while movement and combat
     // broadcasts kept flowing. Retail 18414 captures pair SMSG_MOVE_TELEPORT
     // 1:1 with CMSG_MOVE_TELEPORT_ACK, 1,522 of each, so the ack always comes.
-    // MSG_MOVE_WORLDPORT_ACK is deliberately NOT registered: its inherited
-    // value 0x00E0 belongs to CMSG_CHAR_ENUM in 18414. Registering it there
-    // overwrote the char-enum slot and hung every client on "Retrieving
-    // character list". Its real 18414 value is unknown.
     DefC(CMSG_MOVE_TELEPORT_ACK, "CMSG_MOVE_TELEPORT_ACK", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMoveTeleportAckOpcode);
+    // The worldport ack is 0x1FAD in 18414, not the inherited 0x00E0 -- that
+    // value is CMSG_CHAR_ENUM here, and registering it there overwrote the
+    // char-enum slot and hung every client on "Retrieving character list".
+    // 0x1FAD was taken from a live cross-map teleport that hung on the loading
+    // screen, then checked against the corpus before being registered: it
+    // occurs 2,022 times, always CMSG, always zero-length, against 2,022
+    // SMSG_NEW_WORLD -- an exact 1:1 pairing, 1,968 of them four or five
+    // records after the NEW_WORLD. It is claimed by nothing else, so unlike
+    // 0x00E0 this cannot displace an existing handler.
+    DefC(MSG_MOVE_WORLDPORT_ACK, "MSG_MOVE_WORLDPORT_ACK", STATUS_TRANSFER, PROCESS_THREADUNSAFE, &WorldSession::HandleMoveWorldportAckOpcode);
     DefC(MSG_MOVE_HEARTBEAT, "MSG_MOVE_HEARTBEAT", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);
     DefC(CMSG_MOVE_START_FORWARD, "CMSG_MOVE_START_FORWARD", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);
     DefC(CMSG_MOVE_START_BACKWARD, "CMSG_MOVE_START_BACKWARD", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMovementOpcodes);

--- a/src/game/Server/Opcodes.h
+++ b/src/game/Server/Opcodes.h
@@ -264,7 +264,7 @@ enum OpcodesList
     MSG_MOVE_TOGGLE_COLLISION_CHEAT              = 0x0BC8,    // 5.4.1 17538 (no client leaf)
     CMSG_MOVE_SET_FACING                         = 0x1050, // 5.4.8 18414
     CMSG_MOVE_SET_PITCH                          = 0x0261, // not in 5.4.8 (legacy; handler retained)
-    MSG_MOVE_WORLDPORT_ACK                       = 0x00E0,    // WRONG for 18414: 0x00E0 is CMSG_CHAR_ENUM. Value unverified, do not register.
+    MSG_MOVE_WORLDPORT_ACK                       = 0x1FAD,    // 5.4.8 18414 (retail: 2022 zero-length CMSG, one per SMSG_NEW_WORLD)
     SMSG_MONSTER_MOVE                            = 0x1A07,    // 5.4.8 18414 (Wow.exe leaf; name single-source fork)
     SMSG_MOVE_WATER_WALK                         = 0x1F9A,    // 5.4.8 18414 (Wow.exe leaf; name reference-consensus)
     SMSG_MOVE_LAND_WALK                          = 0x086A,    // 5.4.8 18414 (Wow.exe leaf; name reference-consensus)

--- a/src/game/Server/Opcodes_reference.h
+++ b/src/game/Server/Opcodes_reference.h
@@ -175,9 +175,9 @@
  *   TOTAL SMSG rows                   925
  *
  * SUBSYSTEM CONFIDENCE: high=365, low=221, medium=182, none=157
- * STATUS TOTALS: ACTIVE=400, DOC=437, DORMANT=683
+ * STATUS TOTALS: ACTIVE=401, DOC=436, DORMANT=683
  *   SMSG: ACTIVE=258, DOC=271, DORMANT=396
- *   CMSG: ACTIVE=142, DOC=166, DORMANT=287
+ *   CMSG: ACTIVE=143, DOC=165, DORMANT=287
  */
 
 // CAVEATS -- read before trusting any single row:
@@ -1897,7 +1897,7 @@ typedef uint16_t uint16;
  *   CMSG_BATTLEFIELD_STATUS                        0x1F9E  ACTIVE
  *   CMSG_CALENDAR_GET_CALENDAR                     0x1F9F  ACTIVE
  *   CMSG_MAIL_RETURN_TO_SENDER                     0x1FA8  DORMANT 
- *   CMSG_UNKNOWN_0x1FAD                            0x1FAD  DOC     
+ *   CMSG_UNKNOWN_0x1FAD                            0x1FAD  ACTIVE   server-binding=MSG_MOVE_WORLDPORT_ACK     
  *   CMSG_CALENDAR_EVENT_RSVP                       0x1FB8  DORMANT 
  *   CMSG_UNKNOWN_0x1FB9                            0x1FB9  DOC     
  *   CMSG_CORPSE_TRANSPORT_QUERY                    0x1FBE  ACTIVE   server-binding=CMSG_CORPSE_QUERY

--- a/src/game/Server/tests/mop_opcode_foundation_test.cpp
+++ b/src/game/Server/tests/mop_opcode_foundation_test.cpp
@@ -50,6 +50,16 @@ int main(int /*argc*/, char** /*argv*/)
     CheckOpcode(std::uint32_t(SMSG_RANDOM_ROLL), 0x141Au);
     CheckOpcode(std::uint32_t(SMSG_INSPECT_RATED_BG_STATS), 0x041Fu);
 
+    // The far-teleport ack. Its inherited value was 0x00E0, which is
+    // CMSG_CHAR_ENUM in 18414; registering it there displaced char-enum from
+    // the dispatch table and hung every client on "Retrieving character list".
+    // 0x1FAD comes from a live cross-map teleport and holds up in the corpus:
+    // 2,022 occurrences, always CMSG, always zero-length, one per
+    // SMSG_NEW_WORLD.
+    CheckOpcode(std::uint32_t(MSG_MOVE_WORLDPORT_ACK), 0x1FADu);
+    CheckOpcode(std::uint32_t(CMSG_CHAR_ENUM), 0x00E0u);
+    CHECK(std::uint32_t(MSG_MOVE_WORLDPORT_ACK) != std::uint32_t(CMSG_CHAR_ENUM));
+
     if (g_fail)
     {
         std::fprintf(stderr, "%d check(s) failed\n", g_fail);


### PR DESCRIPTION
Far teleports never completed: the client sits on the loading screen after
`SMSG_NEW_WORLD` because the ack that finishes the transfer was unregistered.

`MSG_MOVE_WORLDPORT_ACK` carried the inherited value **0x00E0**, which is
`CMSG_CHAR_ENUM` in 18414. Registering it there displaced char-enum from the
dispatch table and hung every client on "Retrieving character list" (#28/#29),
so it was correctly left unregistered — but its real value was unknown.

## 0x1FAD, verified before registering rather than after

Taken from a live cross-map teleport that hung, then checked against the corpus:

```
112,881,343 records scanned
SMSG_NEW_WORLD 0x1C3B : 2022
CMSG 0x1FAD           : 2022      <- exact 1:1 pairing
SMSG 0x1FAD           : 0         <- direction confirmed
body lengths          : {0: 2022} <- every occurrence zero-length
gap after NEW_WORLD   : 4 (746), 5 (1222)
```

Every `NEW_WORLD` gets exactly one zero-length `CMSG 0x1FAD`, four or five
records later. Nothing else claims 0x1FAD, so unlike 0x00E0 this **cannot
displace an existing handler**. The handler already exists and ignores its
payload, consistent with a zero-length body.

## Guard for the 0x00E0 class of bug

That mistake was expensive because it was *silent*: registration overwrote
whatever occupied the slot, and the displaced opcode simply stopped dispatching
with no diagnostic. `DefC`/`DefS` now assert when a second registration would
replace a **different** symbol.

An identical re-registration stays legal and is only logged — the generated
login closure and the manual block below it legitimately overlap, and
`SMSG_LOGIN_SETTIMESPEED` is registered by both today. The guard found that on
its first run.

## Tests

`mop_opcode_foundation` now pins `MSG_MOVE_WORLDPORT_ACK == 0x1FAD`,
`CMSG_CHAR_ENUM == 0x00E0`, and that they differ. Reference-header status
overlay updated (CMSG ACTIVE 142 -> 143).

Suite **1085/1085**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/31)
<!-- Reviewable:end -->
