### PR TITLE
[Objects] Create units that are moving or in combat

### DIFF
--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -156,10 +156,23 @@ uint32 MopUpdateObject::TranslateGameObjectDynamic(uint32 legacyDynamic)
 
 bool MopUpdateObject::CanUseSimpleUnitMovement(SimpleUnitEligibility const& eligibility)
 {
-    return !eligibility.isVehicle && !eligibility.isBoarded && !eligibility.hasTransport &&
-        !eligibility.hasSpline && (eligibility.movementFlags & ~SimpleLivingWalkModeFlag) == 0 &&
-        eligibility.movementFlags2 == 0 &&
-        !eligibility.hasOptionalMovement && !eligibility.hasAttackingTarget;
+    // Only reject states the encoder cannot represent. AppendSimpleLivingMovement
+    // emits a state-invariant layout: it declares every optional block absent
+    // (attacking target 0, spline 0, fall data 0, movement flags omitted, extra
+    // movement flags omitted, forces 0) and then writes position plus all nine
+    // speeds unconditionally. So a moving or fighting unit encodes to exactly the
+    // same structure as an idle one - the client is simply told "stationary
+    // snapshot here", and the SMSG_MONSTER_MOVE stream animates it from there.
+    //
+    // Rejecting those states instead made Object::BuildCreateUpdateBlockForPlayer
+    // return without emitting anything, so any creature that was moving or in
+    // combat when it entered view was never created client-side and stayed
+    // invisible while still dealing damage.
+    //
+    // Transport and vehicle states are still rejected: those change what the
+    // position means (transport-relative rather than world), so a stationary
+    // snapshot would place the unit somewhere wrong rather than merely stale.
+    return !eligibility.isVehicle && !eligibility.isBoarded && !eligibility.hasTransport;
 }
 
 bool MopUpdateObject::CanUseStationaryGameObjectMovement(StationaryGameObjectEligibility const& eligibility)

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -597,22 +597,37 @@ int main(int /*argc*/, char** /*argv*/)
     CHECK(MopUpdateObject::TranslateGameObjectDynamic(0xFFFF0009u) == 0xFFFF0012u);
     CHECK(MopUpdateObject::TranslateGameObjectDynamic(0x123400F3u) == 0x12340006u);
 
+    // Only transport-relative states are rejected. AppendSimpleLivingMovement
+    // emits a state-invariant layout - every optional block is declared absent
+    // and position plus all nine speeds are written unconditionally - so a
+    // moving or fighting unit encodes to the same structure as an idle one.
+    // Rejecting those states made BuildCreateUpdateBlockForPlayer emit nothing,
+    // leaving creatures that were moving or in combat permanently invisible.
     MopUpdateObject::SimpleUnitEligibility eligibility{};
     CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
     eligibility.isVehicle = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.isVehicle = false;
     eligibility.isBoarded = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.isBoarded = false;
     eligibility.hasTransport = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.hasTransport = false;
-    eligibility.hasSpline = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.hasSpline = false;
+
+    // States the encoder represents as a stationary snapshot: the unit is still
+    // created, and the SMSG_MONSTER_MOVE stream animates it from there.
+    eligibility.hasSpline = true; CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.hasSpline = false;
     eligibility.movementFlags = MopUpdateObject::SimpleLivingWalkModeFlag;
     CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
     eligibility.movementFlags = 1;
-    CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
+    CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
     eligibility.movementFlags = MopUpdateObject::SimpleLivingWalkModeFlag | 1;
-    CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
+    CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
     eligibility.movementFlags = 0;
-    eligibility.movementFlags2 = 1; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.movementFlags2 = 0;
-    eligibility.hasOptionalMovement = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.hasOptionalMovement = false;
-    eligibility.hasAttackingTarget = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
+    eligibility.movementFlags2 = 1; CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.movementFlags2 = 0;
+    eligibility.hasOptionalMovement = true; CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.hasOptionalMovement = false;
+    eligibility.hasAttackingTarget = true; CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.hasAttackingTarget = false;
+
+    // Transport rejection must survive any combination of the snapshot states.
+    eligibility.hasSpline = true;
+    eligibility.hasAttackingTarget = true;
+    eligibility.hasTransport = true;
+    CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
 
     MopUpdateObject::StationaryGameObjectEligibility gameObjectEligibility{};
     gameObjectEligibility.hasTemplate = true;


### PR DESCRIPTION
Creatures that were moving or in combat when they entered view were never
created client-side: permanently invisible while still dealing damage.

`CanUseSimpleUnitMovement()` rejected units with a spline, non-walk movement
flags, `movementFlags2`, optional movement, or an attacking target. When it
returned false, `Object::BuildCreateUpdateBlockForPlayer` emitted nothing at
all — so the unit simply never existed for the client.

## Why those rejections were never needed

`AppendSimpleLivingMovement` writes a **state-invariant** layout. Every optional
block is hardcoded absent regardless of the unit's actual state:

```cpp
out.WriteBit(0);        // attacking target             (553)
out.WriteBits(0, 22);   // forces                       (574)
out.WriteBit(1);        // movement flags omitted       (575)
out.WriteBit(0);        // fall data                    (577)
out.WriteBit(0);        // spline                       (579)
out.WriteBit(1);        // extra movement flags omitted (584)
```

Only the GUID bytes and `self` vary the output. A moving or fighting unit
encodes to exactly the same structure as an idle one — the client is told
"stationary snapshot here" and `SMSG_MONSTER_MOVE` animates it from there. The
eligibility check was gating on conditions the encoder does not consult.

## What is still rejected, and why

Vehicle, boarded and transport states remain rejected. Lines 546/565 declare no
transport while the position written is `movement.x` directly, so a
transport-relative coordinate would place the unit somewhere **wrong** rather
than merely stale. That is a different failure from being one tick behind.

## Tests

`mop_updateobject_test` inverts the assertions for the snapshot states and adds
a case proving transport rejection survives any combination of them.

Suite **1085/1085**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/32)
<!-- Reviewable:end -->
