### PR TITLE
[NPC] Serve BroadcastText records over the hotfix channel

### DIFF
--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -1171,8 +1171,15 @@ enum AccountDataType
 #define GLOBAL_CACHE_MASK           0x15
 #define PER_CHARACTER_CACHE_MASK    0xEA
 
+// A hotfix type is the DB2's own table hash, taken from the WDB2 header of the
+// extracted file. Confirmed against the two already served: 1344507586 is
+// 0x50238EC2, the table hash of Item.db2, and 2442913102 is 0x919BE54E, that of
+// Item-sparse.db2.
 #define DB2_REPLY_ITEM 1344507586
 #define DB2_REPLY_SPARSE 2442913102
+// 0x021826BB, the table hash of BroadcastText.db2. The live client requests
+// this the moment it is handed a BroadcastText id it cannot resolve locally.
+#define DB2_REPLY_BROADCAST_TEXT 35137211
 
 struct AccountData
 {
@@ -2179,6 +2186,7 @@ class WorldSession
         void HandleRequestHotfix(WorldPacket& recv_data);
         void SendItemDb2Reply(uint32 entry);
         void SendItemSparseDb2Reply(uint32 entry);
+        void SendBroadcastTextDb2Reply(uint32 entry);
 
         void HandleObjectUpdateFailedOpcode(WorldPacket& recv_data);
 

--- a/src/game/Server/tests/mop_world_quest_interaction_packets_test.cpp
+++ b/src/game/Server/tests/mop_world_quest_interaction_packets_test.cpp
@@ -247,8 +247,104 @@ static void TestOpcodeValues()
     CHECK(uint32_t(SMSG_QUESTGIVER_STATUS_MULTIPLE) == 0x06CEu);
 }
 
+// Invented BroadcastText ids must never land on a record the client already
+// ships, or it renders its own text for our row and nothing reports an error.
+// Measured on the 18414 client: 936 records spanning 1..77161.
+static void TestSynthesisedBroadcastTextIdsAvoidTheClientRange()
+{
+    CHECK(MopNpcTextPackets::SynthesiseBroadcastTextId(0, 0) >
+        MopNpcTextPackets::ClientHighestShippedBroadcastTextId);
+
+    // npc_text ids run to 16777215 in our world database; the whole span has
+    // to stay clear of the client's range and inside uint32.
+    uint32 const lowest = MopNpcTextPackets::SynthesiseBroadcastTextId(0, 0);
+    uint32 const highest =
+        MopNpcTextPackets::SynthesiseBroadcastTextId(16777215u, 7);
+    CHECK(lowest > 77161u);
+    CHECK(highest > lowest);
+
+    // Distinct rows and options never share an id, and the mapping inverts.
+    uint32 const cases[][2] = {
+        { 0, 0 }, { 0, 7 }, { 1, 0 }, { 4938, 0 }, { 4938, 3 },
+        { 8363, 7 }, { 16777215u, 7 }
+    };
+    for (auto const& c : cases)
+    {
+        uint32 const id =
+            MopNpcTextPackets::SynthesiseBroadcastTextId(c[0], c[1]);
+        uint32 textId = 0xFFFFFFFFu;
+        uint32 option = 0xFFFFFFFFu;
+        CHECK(MopNpcTextPackets::DecodeSynthesisedBroadcastTextId(id, textId,
+            option));
+        CHECK(textId == c[0]);
+        CHECK(option == c[1]);
+    }
+
+    CHECK(MopNpcTextPackets::SynthesiseBroadcastTextId(4938, 0) !=
+        MopNpcTextPackets::SynthesiseBroadcastTextId(4938, 1));
+    CHECK(MopNpcTextPackets::SynthesiseBroadcastTextId(4938, 7) !=
+        MopNpcTextPackets::SynthesiseBroadcastTextId(4939, 0));
+
+    // An id the client shipped is not ours to decode.
+    uint32 textId = 0;
+    uint32 option = 0;
+    CHECK(!MopNpcTextPackets::DecodeSynthesisedBroadcastTextId(62792, textId,
+        option));
+    CHECK(!MopNpcTextPackets::DecodeSynthesisedBroadcastTextId(3397, textId,
+        option));
+}
+
+// npc_text 4938 (Marshal McBride) carries text but no retail mapping. Before
+// this it produced recordSize 0 and the client refused to open the window.
+static void TestUnmappedNpcTextStillGetsAnId()
+{
+    GossipText gossip;
+    for (auto& option : gossip.Options)
+    {
+        option.BroadcastTextId = 0;
+        option.Language = 0;
+        option.Probability = 0.0f;
+        for (auto& emote : option.Emotes)
+        {
+            emote._Emote = 0;
+            emote._Delay = 0;
+        }
+    }
+    gossip.Options[0].Text_0 = "Hey, citizen!";
+    gossip.Options[0].Probability = 1.0f;
+
+    MopNpcTextPackets::Response const response =
+        MopNpcTextPackets::MakeResponse(4938, &gossip);
+    CHECK(response.found);
+    CHECK(response.broadcastTextIds[0] ==
+        MopNpcTextPackets::SynthesiseBroadcastTextId(4938, 0));
+    CHECK(response.probabilities[0] == 1.0f);
+
+    // Options with nothing behind them stay silent, so the client cannot
+    // select a blank alternative.
+    for (size_t index = 1; index < MAX_GOSSIP_TEXT_OPTIONS; ++index)
+    {
+        CHECK(response.broadcastTextIds[index] == 0);
+        CHECK(response.probabilities[index] == 0.0f);
+    }
+
+    // A row the world database does map keeps its retail id: the client may
+    // already hold that record, and it needs no hotfix from us.
+    gossip.Options[0].BroadcastTextId = 62792;
+    MopNpcTextPackets::Response const mapped =
+        MopNpcTextPackets::MakeResponse(4938, &gossip);
+    CHECK(mapped.broadcastTextIds[0] == 62792);
+
+    // No row at all remains absent rather than inventing one.
+    MopNpcTextPackets::Response const absent =
+        MopNpcTextPackets::MakeResponse(4938, nullptr);
+    CHECK(!absent.found);
+}
+
 int main(int /*argc*/, char** /*argv*/)
 {
+    TestSynthesisedBroadcastTextIdsAvoidTheClientRange();
+    TestUnmappedNpcTextStillGetsAnId();
     TestAreaTriggerRequest();
     TestAreaTriggerNoCorpse();
     TestExplorationExperience();

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -1898,6 +1898,9 @@ void WorldSession::HandleRequestHotfix(WorldPacket& recv_data)
             case DB2_REPLY_SPARSE:
                 SendItemSparseDb2Reply(record.entry);
                 break;
+            case DB2_REPLY_BROADCAST_TEXT:
+                SendBroadcastTextDb2Reply(record.entry);
+                break;
             default:
                 sLog.outError("CMSG_REQUEST_HOTFIX: Received unknown hotfix type: %u", request.type);
                 recv_data.rfinish();

--- a/src/game/WorldHandlers/NPCHandler.h
+++ b/src/game/WorldHandlers/NPCHandler.h
@@ -174,6 +174,50 @@ struct GossipText
 
 namespace MopNpcTextPackets
 {
+    // The 18414 client resolves a BroadcastText id against its own
+    // BroadcastText.db2 and, when that fails, asks the server for the record
+    // over CMSG_REQUEST_HOTFIX. That second route is how retail delivered text
+    // the client never shipped: the client carries 936 records, while retail
+    // captures reference 1,707 distinct ids, only 4 of which the client has.
+    //
+    // Measured on the live client, the id decides everything. Zero is refused,
+    // an id the client cannot resolve is refused once the hotfix goes
+    // unanswered, and an id it can resolve opens the window. So an unmapped
+    // row needs an id we invent and then serve ourselves.
+    //
+    // Inventing one makes collision the hazard: the client's own records span
+    // 1..77161, and landing on one would silently render its Mists text for a
+    // Classic npc_text row -- wrong text, no error, very hard to trace. The
+    // base clears that range entirely, and the static_assert keeps it cleared
+    // if anyone revisits the scheme.
+    static constexpr uint32 ClientHighestShippedBroadcastTextId = 77161;
+    static constexpr uint32 SynthesisedBroadcastTextBase = 100000;
+    static_assert(SynthesisedBroadcastTextBase >
+        ClientHighestShippedBroadcastTextId,
+        "synthesised BroadcastText ids must not collide with the records the "
+        "client ships, or it renders its own text instead of ours");
+
+    // One id per option, so a row's eight alternatives stay distinguishable,
+    // and the mapping inverts for debugging.
+    inline uint32 SynthesiseBroadcastTextId(uint32 textId, uint32 option)
+    {
+        return SynthesisedBroadcastTextBase +
+            textId * MAX_GOSSIP_TEXT_OPTIONS + option;
+    }
+
+    inline bool DecodeSynthesisedBroadcastTextId(uint32 id, uint32& textId,
+        uint32& option)
+    {
+        if (id < SynthesisedBroadcastTextBase)
+        {
+            return false;
+        }
+        uint32 const packed = id - SynthesisedBroadcastTextBase;
+        textId = packed / MAX_GOSSIP_TEXT_OPTIONS;
+        option = packed % MAX_GOSSIP_TEXT_OPTIONS;
+        return true;
+    }
+
     inline Response MakeResponse(uint32 textId, GossipText const* gossip)
     {
         Response response;
@@ -185,14 +229,26 @@ namespace MopNpcTextPackets
 
         for (size_t index = 0; index < MAX_GOSSIP_TEXT_OPTIONS; ++index)
         {
-            uint32 const broadcastTextId =
-                gossip->Options[index].BroadcastTextId;
+            GossipTextOption const& option = gossip->Options[index];
+            uint32 broadcastTextId = option.BroadcastTextId;
+
+            // A real mapping is kept as-is: where the world database knows the
+            // retail id, the client may already hold that record and needs no
+            // hotfix. Otherwise an option that carries text gets an invented
+            // id, which SendBroadcastTextDb2Reply answers.
+            if (!broadcastTextId &&
+                (!option.Text_0.empty() || !option.Text_1.empty()))
+            {
+                broadcastTextId = SynthesiseBroadcastTextId(textId,
+                    uint32(index));
+            }
+
             response.broadcastTextIds[index] = broadcastTextId;
 
-            // A probability without a resolvable ID lets the client select a
-            // blank record, so unmapped alternatives must not participate.
+            // A probability without an id lets the client select a blank
+            // record, so an option with nothing behind it must not participate.
             response.probabilities[index] = broadcastTextId
-                ? gossip->Options[index].Probability
+                ? option.Probability
                 : 0.0f;
             response.found = response.found || broadcastTextId != 0;
         }

--- a/src/game/WorldHandlers/QueryHandler.cpp
+++ b/src/game/WorldHandlers/QueryHandler.cpp
@@ -455,6 +455,120 @@ void WorldSession::HandleNpcTextQueryOpcode(WorldPacket& recv_data)
 }
 
 /**
+ * @brief Serves a BroadcastText record the client could not resolve locally.
+ *
+ * The 18414 client ships 936 BroadcastText records. When SMSG_NPC_TEXT_UPDATE
+ * hands it an id outside that set it does not give up -- it asks for the record
+ * with CMSG_REQUEST_HOTFIX, and renders the text once the server answers. That
+ * is how retail delivered the 1,703 ids in our capture corpus that no client
+ * ever contained, and it is why an unanswered request leaves the quest window
+ * shut rather than merely blank.
+ *
+ * The ids we answer here are the ones MakeResponse invents for npc_text rows
+ * the world database has no retail mapping for, so the record is rebuilt from
+ * the npc_text row that produced the id.
+ */
+void WorldSession::SendBroadcastTextDb2Reply(uint32 entry)
+{
+    WorldPacket data(SMSG_DB_REPLY, 128);
+
+    uint32 textId = 0;
+    uint32 optionIndex = 0;
+    GossipText const* gossip = nullptr;
+    if (MopNpcTextPackets::DecodeSynthesisedBroadcastTextId(entry, textId,
+        optionIndex) && optionIndex < MAX_GOSSIP_TEXT_OPTIONS)
+    {
+        gossip = sObjectMgr.GetGossipText(textId);
+    }
+
+    if (!gossip)
+    {
+        // Answer anyway. A silent drop is what kept the window shut, and the
+        // client repeats the request rather than proceeding without a reply.
+        ByteBuffer empty;
+        MopHotfixPackets::BuildDbReply(data, uint32(-1), uint32(time(NULL)),
+            DB2_REPLY_BROADCAST_TEXT, empty);
+        SendPacket(&data);
+        DEBUG_LOG("WORLD: SMSG_DB_REPLY BroadcastText %u -> no source row", entry);
+        return;
+    }
+
+    GossipTextOption const& option = gossip->Options[optionIndex];
+    std::string text0 = option.Text_0;
+    std::string text1 = option.Text_1;
+
+    int loc_idx = GetSessionDbLocaleIndex();
+    if (loc_idx >= 0)
+    {
+        if (NpcTextLocale const* locale = sObjectMgr.GetNpcTextLocale(textId))
+        {
+            if (locale->Text_0.size() > optionIndex &&
+                locale->Text_0[optionIndex].size() > size_t(loc_idx) &&
+                !locale->Text_0[optionIndex][loc_idx].empty())
+            {
+                text0 = locale->Text_0[optionIndex][loc_idx];
+            }
+            if (locale->Text_1.size() > optionIndex &&
+                locale->Text_1[optionIndex].size() > size_t(loc_idx) &&
+                !locale->Text_1[optionIndex][loc_idx].empty())
+            {
+                text1 = locale->Text_1[optionIndex][loc_idx];
+            }
+        }
+    }
+
+    // A row may carry only one of the two genders; the client shows whichever
+    // it needs, so an empty side is sent as the other rather than as nothing.
+    if (text0.empty())
+    {
+        text0 = text1;
+    }
+    if (text1.empty())
+    {
+        text1 = text0;
+    }
+
+    // Field order is BroadcastText.db2's own: ID, LanguageID, Text_lang,
+    // Text1_lang, EmoteID[3], EmoteDelay[3], SoundEntriesID, EmotesID, Flags.
+    ByteBuffer buff;
+    buff << uint32(entry);
+    buff << uint32(option.Language);
+
+    buff << uint16(text0.length());
+    if (text0.length())
+    {
+        buff << text0;
+    }
+
+    buff << uint16(text1.length());
+    if (text1.length())
+    {
+        buff << text1;
+    }
+
+    for (uint32 i = 0; i < 3; ++i)
+    {
+        buff << uint32(option.Emotes[i]._Emote);
+    }
+    for (uint32 i = 0; i < 3; ++i)
+    {
+        buff << uint32(option.Emotes[i]._Delay);
+    }
+
+    buff << uint32(0);                      // SoundEntriesID
+    buff << uint32(0);                      // EmotesID
+    buff << uint32(0);                      // Flags
+
+    MopHotfixPackets::BuildDbReply(data, entry,
+        sObjectMgr.GetHotfixDate(entry, DB2_REPLY_BROADCAST_TEXT),
+        DB2_REPLY_BROADCAST_TEXT, buff);
+    SendPacket(&data);
+
+    DEBUG_LOG("WORLD: Sent SMSG_DB_REPLY BroadcastText %u (npc_text %u option %u, %u bytes)",
+        entry, textId, optionIndex, uint32(buff.size()));
+}
+
+/**
  * @brief Handles an item page text query and sends all linked pages.
  *
  * @param recv_data The incoming page text query packet.


### PR DESCRIPTION
Fixes the Northshire starting chain. Marshal McBride's quest window would not
open at all, because npc_text 4938 has no BroadcastTextId.

## Two failed diagnostics narrowed it

Both run on the live client with `npccache.wdb` cleared:

| BroadcastTextId | in client's table | window opens |
|---|---|---|
| 0 | — | no |
| 3397 (real retail id) | no | **no** |
| 62792 | yes | **yes** |

Sending the record anyway with real probabilities and zero ids also failed —
structurally valid, `probability[0] = 1.0`, still refused. So neither
"send the record" nor "send a non-zero id" is sufficient. **Resolvability is
the variable.**

## The client says what it wants

```
Sent SMSG_NPC_TEXT_UPDATE ID '4938' mapped=1
CMSG_REQUEST_HOTFIX: Received unknown hotfix type: 35137211
```

On an id it cannot resolve, the client **asks the server for the record**, and
`HandleRequestHotfix` dropped it on `default:`.

`35137211` is `0x021826BB` — the table hash in `BroadcastText.db2`'s WDB2
header. The two types already served confirm the rule:

```
DB2_REPLY_ITEM   = 1344507586 = 0x50238EC2 = Item.db2        table_hash
DB2_REPLY_SPARSE = 2442913102 = 0x919BE54E = Item-sparse.db2 table_hash
```

This is how retail delivered text no client ever contained: the capture corpus
references **1,707** distinct BroadcastText ids, of which this client holds **4**.

## Which makes retail's id values unnecessary

We serve the record, so we choose the id, and the text is already in `npc_text`.
Unmapped options carrying text get `100000 + textId * 8 + option`.

Collision is the hazard — the client's own records span `1..77161`, and landing
on one renders its Mists text for a Classic row **with no error anywhere**. So
the constraint is asserted, not commented:

```cpp
static_assert(SynthesisedBroadcastTextBase > ClientHighestShippedBroadcastTextId,
    "synthesised BroadcastText ids must not collide with the records the "
    "client ships, or it renders its own text instead of ours");
```

Options with a real mapping keep it untouched — the client may already hold that
record, so the 4 accidental overlaps need no carve-out.

## Tests

Collision clearance across the full npc_text id range, round-trip inversion,
distinctness across rows and options, refusal to decode client-shipped ids
(62792, 3397), and that an unmapped row with text now yields `found` plus a
synthesised id while empty options stay silent.

Suite **1085/1085**.

## Not yet validated

**The window actually opening is untested.** Two prior models of this bug were
refuted by live testing, so this one should be too before it is trusted. Test
with the client closed, `Cache\WDB\enGB\npccache.wdb` deleted, and npc_text 4938
reverted to `BroadcastTextID0 = 0` — a leftover diagnostic value takes the
"real mapping" path and skips the synthesis entirely.

Paired log lines to watch:

```
Sent SMSG_NPC_TEXT_UPDATE ID '4938' mapped=1
Sent SMSG_DB_REPLY BroadcastText 139504 (npc_text 4938 option 0, N bytes)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/33)
<!-- Reviewable:end -->
