### PR TITLE
[Player] Project PLAYER_FLAGS to self, so death and rest state reach the client

### DIFF
--- a/src/game/Object/ObjectUpdate.cpp
+++ b/src/game/Object/ObjectUpdate.cpp
@@ -628,6 +628,14 @@ void Object::BuildValuesUpdateBlockForPlayer(UpdateData* data, Player* target) c
             addIfChanged(UNIT_FIELD_COMBATREACH);
             addIfChanged(UNIT_FIELD_DISPLAYID);
             addIfChanged(UNIT_FIELD_NATIVEDISPLAYID);
+            // PLAYER_FLAGS_GHOST lives here. Until this was projected the
+            // client was never told the character had died, so nothing
+            // downstream of death worked: no release dialog, therefore no
+            // CMSG_REPOP_REQUEST at all, and both release and .revive had no
+            // state to act on. Ordered after the native display id and ahead
+            // of the quest log because the serializer requires ascending
+            // legacy indices.
+            addIfChanged(PLAYER_FLAGS);
 
             // QuestLogFrame renders a slot only once the client holds its
             // quest id, so an accepted quest never appears until these private

--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -436,6 +436,22 @@ void MopUpdateObject::AppendSelfPlayerValuesBlock(ByteBuffer& out, uint64 guid,
             case 62: fields.push_back({ 68, value }); break;
             case 63: fields.push_back({ 69, value }); break;
             case 64: fields.push_back({ 70, value }); break;
+            // PLAYER_FLAGS, which carries PLAYER_FLAGS_GHOST. Without it the
+            // client is never told the character died: no release dialog, so
+            // no CMSG_REPOP_REQUEST, so release and .revive have nothing to
+            // act on and the corpse outlives a state the client never entered.
+            // The giveaway is a character sitting at 1 HP that will not
+            // regenerate, because the server is correctly withholding regen
+            // from a corpse while the client renders someone alive.
+            //
+            // 18414 index from the client's own field descriptors:
+            // CGPlayerData's table is a 12-byte stride from dword_10F52B8, and
+            // CGPlayerData::playerFlags writes at dword_10F52D0, so it sits at
+            // relative index 2 -- the same relative position Four gives it.
+            // CGPlayerData::questLog writes at dword_10F533C, relative index
+            // 11, and its absolute 18414 index is already pinned at 171 by the
+            // quest-log projection, which puts the block base at 160.
+            case 157: fields.push_back({ 162, value }); break;
             default:
                 MANGOS_ASSERT(false && "unsupported legacy self-player field");
                 break;

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -562,6 +562,46 @@ int main(int /*argc*/, char** /*argv*/)
         CHECK(values.rpos() == values.size());
     }
 
+    // PLAYER_FLAGS. Nothing projected it, and two unrelated-looking failures
+    // came out of that single gap: PLAYER_FLAGS_GHOST (0x10) never reached the
+    // client, so death did nothing at all -- no release dialog, therefore no
+    // CMSG_REPOP_REQUEST, therefore nothing for release or .revive to act on --
+    // and PLAYER_FLAGS_RESTING (0x20), one bit away, left GetRestState()
+    // returning nil so MainMenuBar.lua:119 threw on every XP update and login.
+    //
+    // The 18414 index comes from the client's own field descriptors rather
+    // than by extrapolating a neighbouring shift: CGPlayerData's descriptor
+    // table runs at a 12-byte stride from dword_10F52B8, playerFlags writes at
+    // dword_10F52D0 (relative index 2) and questLog at dword_10F533C (relative
+    // index 11). questLog's absolute index is pinned at 171 below, which puts
+    // the block base at 160 and playerFlags at 162.
+    {
+        ByteBuffer values;
+        const MopUpdateObject::StaticField sourceFields[] =
+        {
+            { 157, 0x00000030u },   // GHOST | RESTING
+        };
+        MopUpdateObject::AppendSelfPlayerValuesBlock(values, 0x10, sourceFields,
+            sizeof(sourceFields) / sizeof(sourceFields[0]));
+        values.rpos(3);
+        uint8 blockCount;
+        values >> blockCount;
+        uint32 masks[6];
+        CHECK(blockCount == 6);
+        for (uint32& mask : masks) values >> mask;
+        auto hasBit = [&masks](uint16 index)
+        {
+            return (masks[index / 32] & (uint32(1) << (index % 32))) != 0;
+        };
+        CHECK(hasBit(162));
+        CHECK(!hasBit(157));    // the legacy index must not be sent verbatim
+        CHECK(!hasBit(161));
+        CHECK(!hasBit(163));
+        uint32 value = 0;
+        values >> value;
+        CHECK(value == 0x00000030u);
+    }
+
     // Per-slot re-striding, checked directly at both ends of the block.
     CHECK(MopUpdateObject::TranslateSelfQuestLogIndex(166) == 171);
     CHECK(MopUpdateObject::TranslateSelfQuestLogIndex(170) == 175);

--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -1952,6 +1952,16 @@ void Map::SendInitSelf(Player* player)
         MopUpdateObject::ObserverVisibleItemFieldCount +
         MopUpdateObject::SelfInventoryFieldCount +
         MopUpdateObject::SelfSkillFieldCount);
+    // A character that logged out dead comes back with PLAYER_FLAGS_GHOST
+    // already set, so the flag never changes during the session and the
+    // incremental path has nothing to report. Seeded here or the client
+    // renders a living character over a corpse it will not let go of.
+    // Sorts below the quest log at 166, so it opens the ascending run.
+    if (player->GetUInt32Value(PLAYER_FLAGS) != 0)
+    {
+        selfFields.push_back({ PLAYER_FLAGS, player->GetUInt32Value(PLAYER_FLAGS) });
+    }
+
     // Quests reach the client only through this seed and the incremental
     // values path. Without it a character logs in with its quest log empty
     // and the quest only appears if one of its fields happens to change


### PR DESCRIPTION
Death was **completely non-functional** client-side and the XP bar threw on every kill. Both come out of **one field** the self-values path never gathered.

## One gap, two symptoms

`PLAYER_FLAGS` carries `PLAYER_FLAGS_GHOST (0x10)` and `PLAYER_FLAGS_RESTING (0x20)`, one bit apart.

**Death.** Server state was correct — `characters.playerFlags = 16`, `health = 1` — but the client was never told, so it rendered a living character over a corpse. Nothing downstream worked: no release dialog, therefore **zero `CMSG_REPOP_REQUEST` in an entire session**, therefore release and `.revive` had no state to act on. The clean tell is a character stuck at 1 HP that won't regenerate — the server correctly withholding regen from a corpse while the client shows someone alive. Character-select read the DB directly and showed the ghost all along.

**Rest state.** `GetRestState()` returned nil, so `MainMenuBar.lua:119` compared a number with nil on `PLAYER_ENTERING_WORLD`, `PLAYER_XP_UPDATE`, `UPDATE_EXHAUSTION` and `PLAYER_LEVEL_UP`. One kill produced **13 error panels**, because Blizzard's own DebugTools throws while displaying an error and recurses.

## The index came from descriptors, not extrapolation

18414 index is **162**, derived from the client's own field table:

```
CGPlayerData descriptors: 12-byte stride from dword_10F52B8
  playerFlags -> dword_10F52D0   relative index 2
  questLog    -> dword_10F533C   relative index 11
questLog absolute index is already pinned at 171 -> block base 160 -> playerFlags 162
```

The neighbouring unit fields shift by `+6`, and extrapolating that would have written **163** — an unrelated field, silently.

## Deliberately not included

Dynamic flags. `OBJECT_FIELD_DYNAMICFLAGS` has **zero uses** anywhere in the server and `UNIT_DYNAMIC_FLAGS` is only touched by creature GM commands, so projecting either would ship a field nothing writes.

## Tests

New case pins index 162 with both bits set, and asserts the legacy index 157 and its neighbours 161/163 are *not* emitted. Login seed added too — a character that logged out dead returns with the flag already set, so it never changes and the incremental path has nothing to report.

Suite **1085/1085**. Live validation of the death cycle still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/36)
<!-- Reviewable:end -->
