### PR TITLE
[Death] Register the corpse-reclaim and resurrection opcodes

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -573,6 +573,33 @@ void InitializeOpcodes()
     // Wave 34 corpse location and transport map-position queries.
     DefC(CMSG_CORPSE_QUERY, "CMSG_CORPSE_QUERY", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleCorpseQueryOpcode);
     DefS(SMSG_CORPSE_QUERY_RESPONSE, "SMSG_CORPSE_QUERY_RESPONSE");
+
+    // Coming back from death. Every handler below already existed; only the
+    // registrations were missing, so a character could die and become a ghost
+    // -- once PLAYER_FLAGS reached the client -- and then had no way back. The
+    // client asked for its corpse and fell silent, because the reply to that
+    // is a reclaim it could not send.
+    //
+    // Release, then reclaim at the corpse, then the two assisted paths: a
+    // resurrection offered by another player, and a spirit healer.
+    DefC(CMSG_REPOP_REQUEST, "CMSG_REPOP_REQUEST", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleRepopRequestOpcode);
+    DefC(CMSG_RECLAIM_CORPSE, "CMSG_RECLAIM_CORPSE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleReclaimCorpseOpcode);
+    DefC(CMSG_RESURRECT_RESPONSE, "CMSG_RESURRECT_RESPONSE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleResurrectResponseOpcode);
+    DefS(SMSG_RESURRECT_REQUEST, "SMSG_RESURRECT_REQUEST");
+    DefC(CMSG_SPIRIT_HEALER_ACTIVATE, "CMSG_SPIRIT_HEALER_ACTIVATE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSpiritHealerActivateOpcode);
+    DefS(SMSG_SPIRIT_HEALER_CONFIRM, "SMSG_SPIRIT_HEALER_CONFIRM");
+
+    // Two members of this flow are deliberately left dormant.
+    //
+    // CMSG_SELF_RES and CMSG_HEARTH_AND_RESURRECT are both recorded as 0x0360
+    // with binary provenance, so one of those names is wrong. Registering
+    // either would claim a slot that may belong to the other, which is the
+    // mistake that put MSG_MOVE_WORLDPORT_ACK on top of CMSG_CHAR_ENUM and hung
+    // every client on the character list. HandleSelfResOpcode is written and
+    // waiting; it needs the value settled first.
+    //
+    // SMSG_RESURRECT_FAILED (0x1253) carries no client leaf, so its value is
+    // inherited rather than confirmed. Same reason.
     DefC(CMSG_CORPSE_MAP_POSITION_QUERY, "CMSG_CORPSE_MAP_POSITION_QUERY", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleCorpseMapPositionQueryOpcode);
     DefS(SMSG_CORPSE_MAP_POSITION_QUERY_RESPONSE, "SMSG_CORPSE_MAP_POSITION_QUERY_RESPONSE");
 

--- a/src/game/Server/Opcodes_reference.h
+++ b/src/game/Server/Opcodes_reference.h
@@ -175,9 +175,9 @@
  *   TOTAL SMSG rows                   925
  *
  * SUBSYSTEM CONFIDENCE: high=365, low=221, medium=182, none=157
- * STATUS TOTALS: ACTIVE=401, DOC=436, DORMANT=683
- *   SMSG: ACTIVE=258, DOC=271, DORMANT=396
- *   CMSG: ACTIVE=143, DOC=165, DORMANT=287
+ * STATUS TOTALS: ACTIVE=407, DOC=436, DORMANT=677
+ *   SMSG: ACTIVE=260, DOC=271, DORMANT=394
+ *   CMSG: ACTIVE=147, DOC=165, DORMANT=283
  */
 
 // CAVEATS -- read before trusting any single row:
@@ -794,7 +794,7 @@ typedef uint16_t uint16;
  *   SMSG_GUILD_RECIPES                             0x0FF1  DORMANT
  *   SMSG_BUY_ITEM                                  0x101A  ACTIVE
  *   SMSG_UNKNOWN_0x1023                            0x1023  DOC     
- *   SMSG_RESURRECT_REQUEST                         0x1062  DORMANT 
+ *   SMSG_RESURRECT_REQUEST                         0x1062  ACTIVE
  *   SMSG_DEATH_RELEASE_LOC                         0x1063  ACTIVE   [medium-conf]
  *   SMSG_CHAT_PLAYER_NOT_FOUND                     0x1082  ACTIVE   [medium-conf]
  *   SMSG_UNKNOWN_0x108A                            0x108A  DOC      [medium-conf]
@@ -852,7 +852,7 @@ typedef uint16_t uint16;
  *   SMSG_SHOWTAXINODES                             0x1E1A  DORMANT  [medium-conf]
  *   SMSG_BATTLEGROUND_INFO_THROTTLED               0x1E1E  DORMANT  [medium-conf]
  *   SMSG_CROSSED_INEBRIATION_THRESHOLD             0x1E9E  DORMANT 
- *   SMSG_SPIRIT_HEALER_CONFIRM                     0x1EAA  DORMANT  [medium-conf]
+ *   SMSG_SPIRIT_HEALER_CONFIRM                     0x1EAA  ACTIVE   [medium-conf]
  *
  *  -- QuestCache.cpp (1) --
  *   SMSG_SET_PHASE_SHIFT                           0x02A2  DORMANT  [low-conf]
@@ -1425,7 +1425,7 @@ typedef uint16_t uint16;
  *   CMSG_GROUP_RAID_CONVERT                        0x032C  DORMANT 
  *   CMSG_LFG_GET_STATUS                            0x032D  ACTIVE
  *   CMSG_GM_RESPONSE_RESOLVE                       0x033D  DOC     
- *   CMSG_SPIRIT_HEALER_ACTIVATE                    0x0340  DORMANT 
+ *   CMSG_SPIRIT_HEALER_ACTIVATE                    0x0340  ACTIVE
  *   CMSG_BATTLEFIELD_MGR_EXIT_REQUEST              0x0343  DOC     
  *   CMSG_ATTACKSTOP                                0x0345  ACTIVE
  *   CMSG_TRAINER_LIST                              0x034B  DORMANT 
@@ -1451,7 +1451,7 @@ typedef uint16_t uint16;
  *   CMSG_AUCTION_PLACE_BID                         0x03C8  DORMANT 
  *   CMSG_ACTIVATETAXI                              0x03C9  DORMANT 
  *   CMSG_PUSHQUESTTOPARTY                          0x03D2  ACTIVE
- *   CMSG_RECLAIM_CORPSE                            0x03D3  DORMANT 
+ *   CMSG_RECLAIM_CORPSE                            0x03D3  ACTIVE
  *   CMSG_SET_TRADE_ITEM                            0x03D5  DORMANT 
  *   CMSG_SWAP_INV_ITEM                             0x03DF  ACTIVE
  *   CMSG_DUEL_RESPONSE                             0x03E2  DOC     
@@ -1631,7 +1631,7 @@ typedef uint16_t uint16;
  *   CMSG_UNKNOWN_0x0AB6                            0x0AB6  DOC     
  *   CMSG_UNKNOWN_0x0ABA                            0x0ABA  DOC     
  *   CMSG_MESSAGECHAT_OFFICER                       0x0ABF  DORMANT 
- *   CMSG_RESURRECT_RESPONSE                        0x0B0C  DORMANT 
+ *   CMSG_RESURRECT_RESPONSE                        0x0B0C  ACTIVE
  *   CMSG_GENERATE_RANDOM_CHARACTER_NAME            0x0B1C  DOC     
  *   CMSG_BATTLE_PAY_ACK_FAILED_RESPONSE            0x0B38  DOC     
  *   CMSG_CONTACT_LIST                              0x0BB4  DORMANT 
@@ -1746,7 +1746,7 @@ typedef uint16_t uint16;
  *   CMSG_GOSSIP_HELLO                              0x12F3  ACTIVE
  *   CMSG_FAR_SIGHT                                 0x1341  DORMANT 
  *   CMSG_LOGOUT_REQUEST                            0x1349  ACTIVE   server-binding=CMSG_LOGOUT_REQUEST_IDLE
- *   CMSG_REPOP_REQUEST                             0x134A  DORMANT 
+ *   CMSG_REPOP_REQUEST                             0x134A  ACTIVE
  *   CMSG_SELL_ITEM                                 0x1358  ACTIVE
  *   CMSG_REQUEST_PET_INFO                          0x135B  DORMANT 
  *   CMSG_COMPLETE_MOVIE                            0x1362  DORMANT 


### PR DESCRIPTION
Once `PLAYER_FLAGS` reached the client (#36) a character could die and become a ghost — and then had **no way back**.

The client ran the corpse-run flow correctly and went unanswered:

```
CMSG_CORPSE_QUERY (0x1FBE)           client knows it is a ghost
SMSG_CORPSE_QUERY_RESPONSE (0x0E0B)  we answer
CMSG_REQUEST_CEMETERY_LIST           corpse-run flow proceeds
UNKNOWN (0x03D3) x 10                every resurrect click, dropped
```

Every handler already existed — only the registrations were missing, the same shape as `CMSG_MOVE_TELEPORT_ACK`. Registered as the flow is actually used: release, reclaim at the corpse, then the two assisted paths.

```
CMSG_REPOP_REQUEST          0x134A  HandleRepopRequestOpcode
CMSG_RECLAIM_CORPSE         0x03D3  HandleReclaimCorpseOpcode
CMSG_RESURRECT_RESPONSE     0x0B0C  HandleResurrectResponseOpcode
CMSG_SPIRIT_HEALER_ACTIVATE 0x0340  HandleSpiritHealerActivateOpcode
SMSG_RESURRECT_REQUEST      0x1062  send side
SMSG_SPIRIT_HEALER_CONFIRM  0x1EAA  send side
```

## Two are deliberately left dormant

**`CMSG_SELF_RES` and `CMSG_HEARTH_AND_RESURRECT` are both recorded as `0x0360`**, both with binary provenance — so one of those names is wrong. Registering either would claim a slot that may belong to the other, which is precisely what put `MSG_MOVE_WORLDPORT_ACK` on top of `CMSG_CHAR_ENUM` and hung every client on the character list this morning. `HandleSelfResOpcode` is written and waiting on the value being settled.

**`SMSG_RESURRECT_FAILED`** carries `(legacy; no client leaf)` — inherited, not confirmed. Same reason.

## Separately identified, not in this PR

`UNKNOWN (0x0CAE)` in the same capture is **`CMSG_MESSAGECHAT_GUILD`**, not a resurrection opcode — the operator's typed commands leaving on an unregistered chat channel, which is why `.revive` appeared to do nothing. Only 2 of 20 chat variants are registered against a handler that already switches on 13. Following as its own PR.

Reference overlay updated: six opcodes DORMANT → ACTIVE, CMSG 143→147, SMSG 258→260.

Suite **1085/1085**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/37)
<!-- Reviewable:end -->
