### PR TITLE
[Death] Unregister the three GUID-bearing death CMSGs until their bodies decode

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -582,12 +582,30 @@ void InitializeOpcodes()
     //
     // Release, then reclaim at the corpse, then the two assisted paths: a
     // resurrection offered by another player, and a spirit healer.
+    // Only the release step is registered. Its handler reads a single byte
+    // and the 18414 client sends exactly one, so it needs no conversion.
     DefC(CMSG_REPOP_REQUEST, "CMSG_REPOP_REQUEST", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleRepopRequestOpcode);
-    DefC(CMSG_RECLAIM_CORPSE, "CMSG_RECLAIM_CORPSE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleReclaimCorpseOpcode);
-    DefC(CMSG_RESURRECT_RESPONSE, "CMSG_RESURRECT_RESPONSE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleResurrectResponseOpcode);
     DefS(SMSG_RESURRECT_REQUEST, "SMSG_RESURRECT_REQUEST");
-    DefC(CMSG_SPIRIT_HEALER_ACTIVATE, "CMSG_SPIRIT_HEALER_ACTIVATE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleSpiritHealerActivateOpcode);
     DefS(SMSG_SPIRIT_HEALER_CONFIRM, "SMSG_SPIRIT_HEALER_CONFIRM");
+
+    // The three GUID-bearing members of this flow stay unregistered until
+    // their bodies are decoded, because their handlers predate 18414 and parse
+    // a raw uint64 where the client sends a bit-packed GUID. Retail capture
+    // gives the real sizes, and none of them fit:
+    //
+    //   CMSG_RECLAIM_CORPSE          86 observed, body  1-5 bytes
+    //   CMSG_SPIRIT_HEALER_ACTIVATE   7 observed, body    7 bytes
+    //   CMSG_RESURRECT_RESPONSE     218 observed, body 9-12 bytes
+    //
+    // recv_data >> guid demands eight. Reclaim and spirit-healer therefore
+    // throw ByteBufferException on every real packet, which disconnects the
+    // player where bad-packet kicking is enabled; resurrect-response survives
+    // the read but decodes a packed GUID as a raw one. Registering them turned
+    // a silent drop into a worse failure.
+    //
+    // CMSG_MOVE_TELEPORT_ACK is the converted comparison: 14-16 bytes on the
+    // wire, read with ReadGuidMask/ReadGuidBytes. These three need the same
+    // treatment before they can be exposed.
 
     // Two members of this flow are deliberately left dormant.
     //

--- a/src/game/Server/Opcodes_reference.h
+++ b/src/game/Server/Opcodes_reference.h
@@ -175,9 +175,9 @@
  *   TOTAL SMSG rows                   925
  *
  * SUBSYSTEM CONFIDENCE: high=365, low=221, medium=182, none=157
- * STATUS TOTALS: ACTIVE=407, DOC=436, DORMANT=677
+ * STATUS TOTALS: ACTIVE=404, DOC=436, DORMANT=680
  *   SMSG: ACTIVE=260, DOC=271, DORMANT=394
- *   CMSG: ACTIVE=147, DOC=165, DORMANT=283
+ *   CMSG: ACTIVE=144, DOC=165, DORMANT=286
  */
 
 // CAVEATS -- read before trusting any single row:
@@ -1425,7 +1425,7 @@ typedef uint16_t uint16;
  *   CMSG_GROUP_RAID_CONVERT                        0x032C  DORMANT 
  *   CMSG_LFG_GET_STATUS                            0x032D  ACTIVE
  *   CMSG_GM_RESPONSE_RESOLVE                       0x033D  DOC     
- *   CMSG_SPIRIT_HEALER_ACTIVATE                    0x0340  ACTIVE
+ *   CMSG_SPIRIT_HEALER_ACTIVATE                    0x0340  DORMANT
  *   CMSG_BATTLEFIELD_MGR_EXIT_REQUEST              0x0343  DOC     
  *   CMSG_ATTACKSTOP                                0x0345  ACTIVE
  *   CMSG_TRAINER_LIST                              0x034B  DORMANT 
@@ -1451,7 +1451,7 @@ typedef uint16_t uint16;
  *   CMSG_AUCTION_PLACE_BID                         0x03C8  DORMANT 
  *   CMSG_ACTIVATETAXI                              0x03C9  DORMANT 
  *   CMSG_PUSHQUESTTOPARTY                          0x03D2  ACTIVE
- *   CMSG_RECLAIM_CORPSE                            0x03D3  ACTIVE
+ *   CMSG_RECLAIM_CORPSE                            0x03D3  DORMANT
  *   CMSG_SET_TRADE_ITEM                            0x03D5  DORMANT 
  *   CMSG_SWAP_INV_ITEM                             0x03DF  ACTIVE
  *   CMSG_DUEL_RESPONSE                             0x03E2  DOC     
@@ -1631,7 +1631,7 @@ typedef uint16_t uint16;
  *   CMSG_UNKNOWN_0x0AB6                            0x0AB6  DOC     
  *   CMSG_UNKNOWN_0x0ABA                            0x0ABA  DOC     
  *   CMSG_MESSAGECHAT_OFFICER                       0x0ABF  DORMANT 
- *   CMSG_RESURRECT_RESPONSE                        0x0B0C  ACTIVE
+ *   CMSG_RESURRECT_RESPONSE                        0x0B0C  DORMANT
  *   CMSG_GENERATE_RANDOM_CHARACTER_NAME            0x0B1C  DOC     
  *   CMSG_BATTLE_PAY_ACK_FAILED_RESPONSE            0x0B38  DOC     
  *   CMSG_CONTACT_LIST                              0x0BB4  DORMANT 


### PR DESCRIPTION
[Death] Unregister the three GUID-bearing death CMSGs until their bodies decode

Registering these in c228b64c6 turned a silent drop into a worse failure. Their
handlers predate 18414 and read a raw uint64 where the client sends a bit-packed
GUID, and retail capture shows none of the real bodies is large enough:

    CMSG_RECLAIM_CORPSE          86 observed, body  1-5 bytes
    CMSG_SPIRIT_HEALER_ACTIVATE   7 observed, body    7 bytes
    CMSG_RESURRECT_RESPONSE     218 observed, body 9-12 bytes

recv_data >> guid demands eight, so reclaim and spirit-healer throw
ByteBufferException on every real packet, which disconnects the player wherever
bad-packet kicking is enabled. Resurrect-response survives the read at nine
bytes but decodes a packed GUID as a raw one. CMSG_MOVE_TELEPORT_ACK is the
converted comparison: 14-16 bytes, read with ReadGuidMask/ReadGuidBytes.

CMSG_REPOP_REQUEST stays registered. Its handler reads a single byte with
read_skip<uint8>() and the client sends exactly one, so release works and needs
no conversion. The two DefS entries stay: they are outbound name metadata and do
not affect dispatch.

The lesson generalises past this flow. An opcode value being binary-confirmed
says nothing about whether its handler parses the 18414 body, and most of these
handlers were last exercised against 4.3.4, which was not bit-packed. Body size
from the capture corpus is a cheap check and should gate any further
registration.

Reference overlay reverted for the three: CMSG ACTIVE 147 back to 144.

Suite is 1085/1085.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/38)
<!-- Reviewable:end -->
