### PR TITLE
[Chat] Register the eighteen unregistered chat opcodes

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -287,6 +287,48 @@ void InitializeOpcodes()
     // 18414 /say requests carry a uint32 language followed by the bit-packed message body.
     DefC(CMSG_MESSAGECHAT_SAY, "CMSG_MESSAGECHAT_SAY", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
     DefC(CMSG_MESSAGECHAT_AFK, "CMSG_MESSAGECHAT_AFK", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+
+    // The rest of the chat channels. Only say and afk were registered, so
+    // everything else a player types was dropped without a trace -- including
+    // GM commands, which ride the chat opcode, and which is why a typed
+    // .revive appeared to do nothing at all.
+    //
+    // HandleMessagechatOpcode already switches on all thirteen types, and its
+    // reads are 18414 shaped rather than inherited: a uint32 language followed
+    // by ReadString(ReadBits(9)). Retail body sizes agree exactly -- guild,
+    // raid, party and instance all bottom out at six bytes, four for the
+    // language and two for the nine-bit length, the same minimum as say, which
+    // is registered and works.
+    DefC(CMSG_MESSAGECHAT_YELL, "CMSG_MESSAGECHAT_YELL", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_EMOTE, "CMSG_MESSAGECHAT_EMOTE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_DND, "CMSG_MESSAGECHAT_DND", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_WHISPER, "CMSG_MESSAGECHAT_WHISPER", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_CHANNEL, "CMSG_MESSAGECHAT_CHANNEL", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_GUILD, "CMSG_MESSAGECHAT_GUILD", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_OFFICER, "CMSG_MESSAGECHAT_OFFICER", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_PARTY, "CMSG_MESSAGECHAT_PARTY", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_RAID, "CMSG_MESSAGECHAT_RAID", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_RAID_WARNING, "CMSG_MESSAGECHAT_RAID_WARNING", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_INSTANCE, "CMSG_MESSAGECHAT_INSTANCE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleMessagechatOpcode);
+
+    // Addon traffic rides its own six opcodes and its own handler, which reads
+    // a nine-bit message length and a five-bit prefix length. Also 18414
+    // shaped, and the observed minimum of six bytes matches.
+    DefC(CMSG_MESSAGECHAT_ADDON_RAID, "CMSG_MESSAGECHAT_ADDON_RAID", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleAddonMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_ADDON_PARTY, "CMSG_MESSAGECHAT_ADDON_PARTY", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleAddonMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_ADDON_INSTANCE, "CMSG_MESSAGECHAT_ADDON_INSTANCE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleAddonMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_ADDON_GUILD, "CMSG_MESSAGECHAT_ADDON_GUILD", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleAddonMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_ADDON_OFFICER, "CMSG_MESSAGECHAT_ADDON_OFFICER", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleAddonMessagechatOpcode);
+    DefC(CMSG_MESSAGECHAT_ADDON_WHISPER, "CMSG_MESSAGECHAT_ADDON_WHISPER", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleAddonMessagechatOpcode);
+
+    // Reporting a message as spam. Its handler already decodes the 18414 guid
+    // with ReadGuidMask/ReadGuidBytes rather than a raw read.
+    DefC(CMSG_CHAT_IGNORED, "CMSG_CHAT_IGNORED", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleChatIgnoredOpcode);
+
+    // CMSG_MESSAGECHAT_BATTLEGROUND stays dormant: its value is inherited from
+    // 4.3.4 and unverified for 5.4.8, and at 0x2156 it exceeds the thirteen
+    // bits the 18414 header gives an opcode, so it cannot be what the client
+    // sends. HandleMessagechatOpcode has no case for it either.
     DefC(CMSG_TEXT_EMOTE, "CMSG_TEXT_EMOTE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleTextEmoteOpcode);
     DefC(CMSG_EMOTE, "CMSG_EMOTE", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleEmoteOpcode);
     DefS(SMSG_TEXT_EMOTE, "SMSG_TEXT_EMOTE");

--- a/src/game/Server/Opcodes_reference.h
+++ b/src/game/Server/Opcodes_reference.h
@@ -175,9 +175,9 @@
  *   TOTAL SMSG rows                   925
  *
  * SUBSYSTEM CONFIDENCE: high=365, low=221, medium=182, none=157
- * STATUS TOTALS: ACTIVE=404, DOC=436, DORMANT=680
+ * STATUS TOTALS: ACTIVE=422, DOC=436, DORMANT=662
  *   SMSG: ACTIVE=260, DOC=271, DORMANT=394
- *   CMSG: ACTIVE=144, DOC=165, DORMANT=286
+ *   CMSG: ACTIVE=162, DOC=165, DORMANT=268
  */
 
 // CAVEATS -- read before trusting any single row:
@@ -1312,7 +1312,7 @@ typedef uint16_t uint16;
  *   CMSG_UNACCEPT_TRADE                            0x0023  DORMANT 
  *   CMSG_DESTROY_ITEM                              0x0026  ACTIVE
  *   CMSG_NEUTRAL_PLAYER_SELECT_FACTION             0x0027  DOC     
- *   CMSG_MESSAGECHAT_DND                           0x002E  DORMANT 
+ *   CMSG_MESSAGECHAT_DND                           0x002E  ACTIVE
  *   CMSG_VIOLENCE_LEVEL                            0x0040  ACTIVE
  *   CMSG_TIME_SYNC_RESPONSE_FAILED                 0x0058  ACTIVE
  *   CMSG_UNKNOWN_0x0060                            0x0060  DOC     
@@ -1325,13 +1325,13 @@ typedef uint16_t uint16;
  *   CMSG_MOVE_STOP_PITCH                           0x007A  DORMANT 
  *   CMSG_MOUNTSPECIAL_ANIM                         0x0082  DORMANT 
  *   CMSG_SCENE_COMPLETED                           0x0087  DOC     
- *   CMSG_MESSAGECHAT_ADDON_RAID                    0x009A  DORMANT 
+ *   CMSG_MESSAGECHAT_ADDON_RAID                    0x009A  ACTIVE
  *   CMSG_CLEAR_TRADE_ITEM                          0x00A7  DORMANT 
  *   CMSG_CHANNEL_MODERATOR                         0x00AE  DORMANT 
  *   CMSG_CHANNEL_OWNER                             0x00AF  DORMANT 
  *   CMSG_AUTH_SESSION                              0x00B2  ACTIVE  
  *   CMSG_UNKNOWN_0x00B3                            0x00B3  DOC     
- *   CMSG_MESSAGECHAT_CHANNEL                       0x00BB  DORMANT 
+ *   CMSG_MESSAGECHAT_CHANNEL                       0x00BB  ACTIVE
  *   CMSG_MOVE_START_PITCH_UP                       0x00D8  DORMANT 
  *   CMSG_MOVE_FALL_RESET                           0x00D9  DORMANT 
  *   CMSG_FORCE_WALK_SPEED_CHANGE_ACK               0x00DB  DORMANT 
@@ -1382,7 +1382,7 @@ typedef uint16_t uint16;
  *   CMSG_RIDE_VEHICLE_INTERACT                     0x0277  DORMANT 
  *   CMSG_SET_FACTION_ATWAR                         0x027B  DORMANT 
  *   CMSG_NPC_TEXT_QUERY                            0x0287  ACTIVE   [high-conf]
- *   CMSG_MESSAGECHAT_ADDON_PARTY                   0x028E  DORMANT 
+ *   CMSG_MESSAGECHAT_ADDON_PARTY                   0x028E  ACTIVE
  *   CMSG_SUSPEND_TOKEN_RESPONSE                    0x0292  DOC     
  *   CMSG_UNREGISTER_ALL_ADDON_PREFIXES             0x029F  ACTIVE
  *   CMSG_GET_MIRRORIMAGE_DATA                      0x02A3  DORMANT 
@@ -1470,9 +1470,9 @@ typedef uint16_t uint16;
  *   CMSG_LFG_JOIN                                  0x046B  DORMANT 
  *   CMSG_QUERY_GUILD_RECIPES                       0x0478  DORMANT 
  *   CMSG_GUILD_ADD_RANK                            0x047A  DORMANT 
- *   CMSG_CHAT_IGNORED                              0x048A  DORMANT 
+ *   CMSG_CHAT_IGNORED                              0x048A  ACTIVE
  *   CMSG_UNKNOWN_0x049B                            0x049B  DOC     
- *   CMSG_MESSAGECHAT_YELL                          0x04AA  DORMANT 
+ *   CMSG_MESSAGECHAT_YELL                          0x04AA  ACTIVE
  *   CMSG_GUILD_NEWS_UPDATE_STICKY                  0x04D1  DOC     
  *   CMSG_GUILD_LEAVE                               0x04D8  DORMANT 
  *   CMSG_GUILD_BANK_NOTE                           0x04D9  DOC     
@@ -1563,7 +1563,7 @@ typedef uint16_t uint16;
  *   CMSG_CHANNEL_UNBAN                             0x081F  DORMANT 
  *   CMSG_REQUEST_RATED_BG_STATS                    0x0826  ACTIVE
  *   CMSG_MINIMAP_PING                              0x0837  ACTIVE
- *   CMSG_MESSAGECHAT_RAID                          0x083E  DORMANT 
+ *   CMSG_MESSAGECHAT_RAID                          0x083E  ACTIVE
  *   CMSG_LOOT_RELEASE                              0x0840  ACTIVE
  *   CMSG_CREATURE_QUERY                            0x0842  ACTIVE
  *   CMSG_MOVE_HOVER_ACK                            0x0858  DORMANT 
@@ -1578,7 +1578,7 @@ typedef uint16_t uint16;
  *   CMSG_LFG_SET_ROLES                             0x08A2  DORMANT 
  *   CMSG_RANDOM_ROLL                               0x08A3  DOC     
  *   CMSG_REORDER_CHARACTERS                        0x08A7  DORMANT 
- *   CMSG_MESSAGECHAT_ADDON_INSTANCE                0x08AF  DORMANT 
+ *   CMSG_MESSAGECHAT_ADDON_INSTANCE                0x08AF  ACTIVE
  *   CMSG_BATTLEFIELD_MANAGER_EXIT_REQUEST          0x08B3  DORMANT 
  *   CMSG_CHANNEL_BAN                               0x08BF  DORMANT 
  *   CMSG_CANCEL_CHANNELLING                        0x08C0  DORMANT 
@@ -1630,7 +1630,7 @@ typedef uint16_t uint16;
  *   CMSG_UNKNOWN_0x0AB2                            0x0AB2  DOC     
  *   CMSG_UNKNOWN_0x0AB6                            0x0AB6  DOC     
  *   CMSG_UNKNOWN_0x0ABA                            0x0ABA  DOC     
- *   CMSG_MESSAGECHAT_OFFICER                       0x0ABF  DORMANT 
+ *   CMSG_MESSAGECHAT_OFFICER                       0x0ABF  ACTIVE
  *   CMSG_RESURRECT_RESPONSE                        0x0B0C  DORMANT
  *   CMSG_GENERATE_RANDOM_CHARACTER_NAME            0x0B1C  DOC     
  *   CMSG_BATTLE_PAY_ACK_FAILED_RESPONSE            0x0B38  DOC     
@@ -1647,7 +1647,7 @@ typedef uint16_t uint16;
  *   CMSG_GUILD_INFO_TEXT                           0x0C70  DORMANT 
  *   CMSG_UNKNOWN_0x0C79                            0x0C79  DOC     
  *   CMSG_GUILD_SET_RANK                            0x0C7A  DORMANT 
- *   CMSG_MESSAGECHAT_GUILD                         0x0CAE  DORMANT 
+ *   CMSG_MESSAGECHAT_GUILD                         0x0CAE  ACTIVE
  *   CMSG_GUILD_REPLACE_GUILD_MASTER                0x0CD0  DOC     
  *   CMSG_GUILD_SWITCH_RANK                         0x0CD1  DORMANT 
  *   CMSG_GUILD_BANK_LOG_QUERY                      0x0CD3  DORMANT 
@@ -1665,14 +1665,14 @@ typedef uint16_t uint16;
  *   CMSG_LOOT_METHOD                               0x0DE1  DORMANT 
  *   CMSG_CHANNEL_KICK                              0x0E0B  DORMANT 
  *   CMSG_UNKNOWN_0x0E0E                            0x0E0E  DOC     
- *   CMSG_MESSAGECHAT_ADDON_GUILD                   0x0E3B  DORMANT 
+ *   CMSG_MESSAGECHAT_ADDON_GUILD                   0x0E3B  ACTIVE
  *   CMSG_MESSAGECHAT_AFK                           0x0EAB  ACTIVE
- *   CMSG_MESSAGECHAT_ADDON_WHISPER                 0x0EBB  DORMANT 
+ *   CMSG_MESSAGECHAT_ADDON_WHISPER                 0x0EBB  ACTIVE
  *   CMSG_CHAR_CREATE                               0x0F1D  ACTIVE  
  *   CMSG_TUTORIAL_CLEAR                            0x0F23  ACTIVE
  *   CMSG_AUTH_CONTINUED_SESSION                    0x0F49  DORMANT 
  *   CMSG_PAGE_TEXT_QUERY                           0x1022  ACTIVE   [high-conf]
- *   CMSG_MESSAGECHAT_EMOTE                         0x103E  DORMANT 
+ *   CMSG_MESSAGECHAT_EMOTE                         0x103E  ACTIVE
  *   CMSG_ITEM_UPGRADE                              0x1042  DOC     
  *   CMSG_MOVE_SET_FACING                           0x1050  ACTIVE
  *   CMSG_FORCE_MOVE_UNROOT_ACK                     0x1051  DORMANT 
@@ -1686,7 +1686,7 @@ typedef uint16_t uint16;
  *   CMSG_MOVE_START_TURN_RIGHT                     0x107B  ACTIVE
  *   CMSG_SCENE_PLAYBACK_CANCELED                   0x1087  DOC     
  *   CMSG_QUEUED_MESSAGES_END                       0x1093  DOC     
- *   CMSG_MESSAGECHAT_PARTY                         0x109A  DORMANT 
+ *   CMSG_MESSAGECHAT_PARTY                         0x109A  ACTIVE
  *   CMSG_UNKNOWN_0x10A2                            0x10A2  DOC     
  *   CMSG_SET_PET_SLOT                              0x10A7  DORMANT 
  *   CMSG_CHANNEL_INVITE                            0x10AB  DORMANT 
@@ -1717,7 +1717,7 @@ typedef uint16_t uint16;
  *   CMSG_MOVE_START_ASCEND                         0x11FA  DORMANT 
  *   CMSG_REQUEST_CATEGORY_COOLDOWNS                0x1203  ACTIVE   [high-conf]
  *   CMSG_UNKNOWN_0x1207                            0x1207  DOC     
- *   CMSG_MESSAGECHAT_WHISPER                       0x123E  DORMANT 
+ *   CMSG_MESSAGECHAT_WHISPER                       0x123E  ACTIVE
  *   CMSG_BINDER_ACTIVATE                           0x1248  ACTIVE
  *   CMSG_QUEST_CONFIRM_ACCEPT                      0x124B  ACTIVE
  *   CMSG_GET_ITEM_PURCHASE_DATA                    0x1258  DORMANT 
@@ -1802,8 +1802,8 @@ typedef uint16_t uint16;
  *   CMSG_CHALLENGE_MODE_REQUEST_LEADERS            0x15DB  DOC     
  *   CMSG_REQUEST_RESEARCH_HISTORY                  0x15E2  DOC     
  *   CMSG_UNKNOWN_0x160F                            0x160F  DOC     
- *   CMSG_MESSAGECHAT_INSTANCE                      0x162A  DORMANT 
- *   CMSG_MESSAGECHAT_RAID_WARNING                  0x16AB  DORMANT 
+ *   CMSG_MESSAGECHAT_INSTANCE                      0x162A  ACTIVE
+ *   CMSG_MESSAGECHAT_RAID_WARNING                  0x16AB  ACTIVE
  *   CMSG_UNKNOWN_0x1788                            0x1788  DOC     
  *   CMSG_UNKNOWN_0x1789                            0x1789  DOC     
  *   CMSG_GROUP_REQUEST_JOIN_UPDATES                0x178A  ACTIVE
@@ -1818,7 +1818,7 @@ typedef uint16_t uint16;
  *   CMSG_LFG_BOOT_PLAYER_VOTE                      0x17BE  DORMANT 
  *   CMSG_SET_PARTY_ASSIGNMENT                      0x1802  DOC     
  *   CMSG_BATTLEFIELD_MANAGER_ENTRY_INVITE_RESPONSE 0x1806  DORMANT 
- *   CMSG_MESSAGECHAT_ADDON_OFFICER                 0x180B  DORMANT 
+ *   CMSG_MESSAGECHAT_ADDON_OFFICER                 0x180B  ACTIVE
  *   CMSG_WARDEN_DATA                               0x1816  DORMANT 
  *   CMSG_UNLEARN_SPECIALIZATION                    0x1841  DORMANT 
  *   CMSG_FORCE_SWIM_SPEED_CHANGE_ACK               0x1853  ACTIVE

--- a/src/game/WorldHandlers/ChatHandler.cpp
+++ b/src/game/WorldHandlers/ChatHandler.cpp
@@ -218,22 +218,28 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
                 }
             }
 
-            if (type != CHAT_MSG_AFK && type != CHAT_MSG_DND)
-            {
-                if (!_player->CanSpeak())
-                {
-                    std::string timeStr = secsToTimeString(m_muteTime - time(NULL));
-                    SendNotification(GetMangosString(LANG_WAIT_BEFORE_SPEAKING), timeStr.c_str());
-                    return;
-                }
-
-                GetPlayer()->UpdateSpeakTime();
-            }
         }
     }
     else
     {
         lang = LANG_UNIVERSAL;
+    }
+
+    // Muting applies to anything the player says, emotes included. This check
+    // used to sit inside the language block above, which excludes emotes
+    // because they carry no language -- so a muted player could still emit
+    // arbitrary text to everyone nearby through TextEmote. Away and busy are
+    // status toggles rather than speech and stay exempt, as they were.
+    if (type != CHAT_MSG_AFK && type != CHAT_MSG_DND)
+    {
+        if (!_player->CanSpeak())
+        {
+            std::string timeStr = secsToTimeString(m_muteTime - time(NULL));
+            SendNotification(GetMangosString(LANG_WAIT_BEFORE_SPEAKING), timeStr.c_str());
+            return;
+        }
+
+        GetPlayer()->UpdateSpeakTime();
     }
 
     DEBUG_LOG("CHAT: packet received. type %u lang %u", type, lang);
@@ -634,6 +640,16 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
             std::string msg;
             msg = recv_data.ReadString(recv_data.ReadBits(9));
 
+            // A dot command typed with this destination selected has to be
+            // executed, not announced. Every other destination does this; the
+            // two that did not would have broadcast the command text to
+            // everyone instead, which is worse than the dropped commands this
+            // registration set out to fix.
+            if (ChatHandler(this).ParseCommands(msg.c_str()))
+            {
+                break;
+            }
+
             if (!processChatmessageFurtherAfterSecurityChecks(msg, lang))
             {
                 return;
@@ -751,6 +767,13 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
             uint32 msgLength = recv_data.ReadBits(9);
             msg = recv_data.ReadString(msgLength);
             channel = recv_data.ReadString(channelLength);
+
+            // As above: execute a dot command rather than saying it into the
+            // channel for everyone to read.
+            if (ChatHandler(this).ParseCommands(msg.c_str()))
+            {
+                break;
+            }
 
             if (!processChatmessageFurtherAfterSecurityChecks(msg, lang))
             {
@@ -964,6 +987,18 @@ void WorldSession::HandleAddonMessagechatOpcode(WorldPacket& recv_data)
 
             Player* receiver = sObjectMgr.GetPlayer(targetName.c_str());
             if (!receiver)
+            {
+                break;
+            }
+
+            // Addon payloads are still cross-faction chat. The regular whisper
+            // path refuses to carry them between teams when the server has
+            // two-side chat disabled, and routing arbitrary data around that
+            // over a second opcode would make the setting meaningless.
+            if (!sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT) &&
+                GetSecurity() == SEC_PLAYER &&
+                receiver->GetSession()->GetSecurity() == SEC_PLAYER &&
+                GetPlayer()->GetTeam() != receiver->GetTeam())
             {
                 break;
             }


### PR DESCRIPTION
[Chat] Register the eighteen unregistered chat opcodes

Only say and afk were registered, so everything else a player typed was dropped
without a trace: guild, officer, party, raid, raid warning, instance, whisper,
yell, emote, dnd and custom channels, plus all six addon channels and spam
reporting. GM commands ride the chat opcode, which is why a typed .revive
appeared to do nothing at all -- the operator's chat frame was on guild, and
guild was one of the dropped ones.

Body sizes were checked against retail capture before registering, which is the
gate the corpse-reclaim registrations should have had. All three handlers read
18414 shapes rather than inherited ones:

  HandleMessagechatOpcode      uint32 language, then ReadString(ReadBits(9))
  HandleAddonMessagechatOpcode ReadBits(9) message, ReadBits(5) prefix
  HandleChatIgnoredOpcode      ReadGuidMask/ReadGuidBytes

and the capture agrees exactly. Guild, raid, party and instance all bottom out
at six bytes, four for the language and two for the nine-bit length, which is
the same minimum as say -- already registered, already working. Channel and
whisper start at fifteen because they carry a target name as well.

    CHANNEL      174,972 observed   min 15
    ADDON_GUILD   17,443            min 10
    GUILD            351            min  6
    RAID             312            min  6
    WHISPER          269            min 15
    SAY (control)    492            min  6

CMSG_MESSAGECHAT_BATTLEGROUND stays dormant. Its value is inherited from 4.3.4
and unverified for 5.4.8, at 0x2156 it exceeds the thirteen bits the header
gives an opcode so the client cannot send it, and the handler has no case for it.

Reference overlay: eighteen opcodes move DORMANT to ACTIVE, CMSG 144 to 162.

Suite is 1085/1085.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/39)
<!-- Reviewable:end -->
