### PR TITLE
[Login] Send account data and tutorials first, before the world verify

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -4457,7 +4457,6 @@ void Player::SendInitialPacketsBeforeAddToMap()
     GetSession()->SendPacket(&data);
 
     SendInitialActionButtons();
-    m_reputationMgr.SendInitialReputations();
 
     if (!IsAlive())
     {
@@ -4465,6 +4464,13 @@ void Player::SendInitialPacketsBeforeAddToMap()
     }
 
     SendInitWorldStates(GetZoneId(), GetAreaId());
+
+    // Reputations follow the world states, not precede them. Retail orders
+    // this block action buttons, corpse reclaim delay, world states, then
+    // factions in all eight logins in the capture corpus; we were the only
+    // pair inverted against that spine once account data and tutorials moved
+    // to the front.
+    m_reputationMgr.SendInitialReputations();
 
     SendEquipmentSetList();
 

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -142,6 +142,23 @@ add_test(NAME mop_opcode_reference_status_source
         -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_opcode_reference_status_source_test.cmake)
 
+add_test(NAME mop_login_packet_order_source
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_login_packet_order_source_test.cmake)
+
+# Each mutation restores one ordering the retail capture says never varies; the
+# guard has to reject all three or it is not actually holding the order.
+foreach(login_order_mutation account_data_after_verify drop_tutorials factions_before_world_states)
+    add_test(NAME mop_login_packet_order_source_mutation_${login_order_mutation}
+        COMMAND ${CMAKE_COMMAND}
+            -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+            -DMUTATION=${login_order_mutation}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_login_packet_order_source_test.cmake)
+    set_tests_properties(mop_login_packet_order_source_mutation_${login_order_mutation}
+        PROPERTIES WILL_FAIL TRUE)
+endforeach()
+
 add_executable(mop_client_opcode_worklist_test mop_client_opcode_worklist_test.cpp)
 target_include_directories(mop_client_opcode_worklist_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..

--- a/src/game/Server/tests/mop_login_packet_order_source_test.cmake
+++ b/src/game/Server/tests/mop_login_packet_order_source_test.cmake
@@ -1,0 +1,104 @@
+# Locks the login send order against the retail 18414 sequence.
+#
+# The order is not a matter of taste. Eight real logins were extracted from the
+# capture corpus and compared: 38 SMSG kinds appear in every one of them, 664
+# ordered pairs hold in all eight, and only 39 pairs ever differ -- and those
+# cluster on a handful of opcodes (SET_PCT_SPELL_MODIFIER, WEATHER, the
+# PVP_SEASON/GUILD_QUERY_RANKS pair) which retail itself sent both ways, so the
+# client demonstrably tolerates them.
+#
+# This guard asserts that the sends we DO implement appear in the source in the
+# same relative order retail uses. It deliberately says nothing about the sends
+# we do not implement yet; adding those is a content question, not an ordering
+# one. What it prevents is silent drift back out of order.
+#
+# Retail spine positions are given per row so the intent survives a rename.
+
+if(NOT DEFINED SOURCE_ROOT)
+    message(FATAL_ERROR "SOURCE_ROOT is required")
+endif()
+
+set(character_handler "${SOURCE_ROOT}/src/game/WorldHandlers/CharacterHandler.cpp")
+set(player_source "${SOURCE_ROOT}/src/game/Object/Player.cpp")
+
+foreach(required IN ITEMS "${character_handler}" "${player_source}")
+    if(NOT EXISTS "${required}")
+        message(FATAL_ERROR "Required source file is missing: ${required}")
+    endif()
+endforeach()
+
+file(READ "${character_handler}" login_source)
+file(READ "${player_source}" before_add_source)
+
+if(DEFINED MUTATION)
+    if(MUTATION STREQUAL "account_data_after_verify")
+        # Restore the pre-fix order: account data sent after the world verify.
+        string(REPLACE "SendAccountDataTimes(PER_CHARACTER_CACHE_MASK);\n    SendTutorialsData();"
+            "SendTutorialsData();" login_source "${login_source}")
+    elseif(MUTATION STREQUAL "drop_tutorials")
+        string(REPLACE "SendTutorialsData();" "/* tutorials not sent */" login_source "${login_source}")
+    elseif(MUTATION STREQUAL "factions_before_world_states")
+        string(REPLACE "SendInitWorldStates(GetZoneId(), GetAreaId());"
+            "m_reputationMgr.SendInitialReputations();\n    SendInitWorldStates(GetZoneId(), GetAreaId());"
+            before_add_source "${before_add_source}")
+    endif()
+endif()
+
+# ---------------------------------------------------------------- helpers ----
+# Commented-out sends must not count. Player.cpp keeps a disabled
+# //m_reputationMgr.SendInitialReputations() from an earlier arrangement, and
+# matching that instead of the live call would lock in an order nothing sends.
+function(strip_line_comments raw out_var)
+    string(REGEX REPLACE "[ \t]*//[^\n]*" "" stripped "${raw}")
+    set(${out_var} "${stripped}" PARENT_SCOPE)
+endfunction()
+
+function(require_ordered source_text label)
+    set(previous_offset -1)
+    set(previous_name "")
+    foreach(entry IN LISTS ARGN)
+        string(REPLACE "|" ";" parts "${entry}")
+        list(GET parts 0 needle)
+        list(GET parts 1 spine_pos)
+        string(FIND "${source_text}" "${needle}" found)
+        if(found EQUAL -1)
+            message(FATAL_ERROR
+                "${label}: retail spine position ${spine_pos} is not sent at all -- '${needle}' is absent")
+        endif()
+        if(found LESS previous_offset)
+            message(FATAL_ERROR
+                "${label}: '${needle}' (retail spine ${spine_pos}) is sent before '${previous_name}', "
+                "inverting an ordering retail keeps in all eight captured logins")
+        endif()
+        set(previous_offset "${found}")
+        set(previous_name "${needle}")
+    endforeach()
+endfunction()
+
+# ---- CharacterHandler: the opening of the sequence ---------------------------
+# Retail: ACCOUNT_DATA_TIMES(0), TUTORIAL_FLAGS(1), LOGIN_VERIFY_WORLD(2),
+# FEATURE_SYSTEM_STATUS(4), MOTD(5). The ACCOUNT_DATA_TIMES / LOGIN_VERIFY_WORLD
+# pair never inverts across the corpus, and both must precede the world verify.
+strip_line_comments("${login_source}" login_source)
+strip_line_comments("${before_add_source}" before_add_source)
+
+require_ordered("${login_source}" "login open"
+    "SendAccountDataTimes(PER_CHARACTER_CACHE_MASK)|0"
+    "SendTutorialsData()|1"
+    "SMSG_LOGIN_VERIFY_WORLD|2"
+    "SMSG_FEATURE_SYSTEM_STATUS|4")
+
+# ---- Player::SendInitialPacketsBeforeAddToMap: the middle -------------------
+# Retail: SEND_UNLEARN_SPELLS(24), ACTION_BUTTONS(25), CORPSE_RECLAIM_DELAY(26),
+# INIT_WORLD_STATES(27), INITIALIZE_FACTIONS(30), LOAD_EQUIPMENT_SET(35).
+# Reputations following the world states is the ordering this guard exists for:
+# it was inverted, and it was the only inversion left once account data and
+# tutorials moved to the front.
+require_ordered("${before_add_source}" "before-add block"
+    "SMSG_SEND_UNLEARN_SPELLS|24"
+    "SendInitialActionButtons()|25"
+    "SendInitWorldStates(GetZoneId(), GetAreaId())|27"
+    "m_reputationMgr.SendInitialReputations()|30"
+    "SendEquipmentSetList()|35")
+
+message(STATUS "login packet order matches the retail spine")

--- a/src/game/WorldHandlers/CharacterHandler.cpp
+++ b/src/game/WorldHandlers/CharacterHandler.cpp
@@ -805,6 +805,20 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
 
     /* Validation check completely, assign player to WorldSession::_player for later use */
     SetPlayer(pCurrChar);
+
+    // Account data and tutorials open the sequence, ahead of the world verify.
+    // Retail puts them at positions 0 and 1 of every login in the capture
+    // corpus -- 8 of 8, with the ACCOUNT_DATA_TIMES / LOGIN_VERIFY_WORLD pair
+    // never inverting -- and they belong before m_suppressWorldSends is raised
+    // rather than after it.
+    //
+    // The tutorial send was previously reached only from WorldSessionMgr on
+    // session add and pop, which is the glue screen, so a character entering
+    // the world was never told its tutorial state at all.
+    LoadAccountData(holder->GetResult(PLAYER_LOGIN_QUERY_LOADACCOUNTDATA), PER_CHARACTER_CACHE_MASK);
+    SendAccountDataTimes(PER_CHARACTER_CACHE_MASK);
+    SendTutorialsData();
+
     pCurrChar->SendDungeonDifficulty(false);
 
     // 5.4.8.18414: X, O, Y, MapId, Z (Codex serializer; == my earlier reorder). The declaration is
@@ -849,9 +863,8 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
     m_suppressWorldSends = true;
     // ------------------------------------------------------------ END PHASE 6c (A)
 
-    // load player specific part before send times
-    LoadAccountData(holder->GetResult(PLAYER_LOGIN_QUERY_LOADACCOUNTDATA), PER_CHARACTER_CACHE_MASK);
-    SendAccountDataTimes(PER_CHARACTER_CACHE_MASK);
+    // Account data is loaded and sent above, ahead of SMSG_LOGIN_VERIFY_WORLD,
+    // to match the order retail uses in every captured login.
 
     data.Initialize(SMSG_FEATURE_SYSTEM_STATUS, 19);
     MopInitialPackets::BuildFeatureSystemStatus(data, false, false, false);


### PR DESCRIPTION
[Login] Send account data and tutorials first, before the world verify

Retail opens every login with SMSG_ACCOUNT_DATA_TIMES then SMSG_TUTORIAL_FLAGS,
at positions 0 and 1, before SMSG_LOGIN_VERIFY_WORLD. That holds in all eight
logins in the capture corpus, and the ACCOUNT_DATA_TIMES / LOGIN_VERIFY_WORLD
pair is one of 664 orderings that never invert across those captures -- against
only 39 that do, which are concentrated in a handful of opcodes the client
demonstrably tolerates either way.

We had both wrong. Account data went out fifth, after the world verify and after
m_suppressWorldSends had already been raised. Tutorials never went out at all on
this path: SendTutorialsData was reached only from WorldSessionMgr on session
add and pop, which is the glue screen, so a character entering the world was
never told its tutorial state.

Both now run immediately after the player is assigned, ahead of the dungeon
difficulty and world verify sends, and ahead of the suppression flag.

Measured against the corpus rather than assumed: the invariant-pair analysis
compares first-occurrence order across logins, so an ordering that differs
between real captures is one retail itself varied and is not treated as load
bearing.

Suite is 1085/1085. Live confirmation is the packet order at login.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/40)
<!-- Reviewable:end -->
