### PR TITLE
[Hotfix] Answer the battle-pet effect-properties probe the client fires at login

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -371,7 +371,15 @@ void InitializeOpcodes()
 
     // Live-log worklist batch 1. Client constructors and body writers were
     // verified directly in the IDA 9.4 18414 Wow.exe database.
-    DefC(CMSG_REQUEST_HOTFIX, "CMSG_REQUEST_HOTFIX", STATUS_LOGGEDIN, PROCESS_INPLACE, &WorldSession::HandleRequestHotfix);
+    // Authed rather than logged-in: the client's first hotfix batch arrives
+    // immediately after CMSG_PLAYER_LOGIN, roughly ninety packets before
+    // SMSG_LOGIN_VERIFY_WORLD, so the player is not in the world and often does
+    // not exist yet. STATUS_LOGGEDIN drops it either way -- logged when _player
+    // is null, silently when the player exists but IsInWorld() is false -- which
+    // is why mid-session requests were answered and the whole login batch was
+    // not. Hotfix is session state, not world state, and none of the reply
+    // builders touch _player.
+    DefC(CMSG_REQUEST_HOTFIX, "CMSG_REQUEST_HOTFIX", STATUS_AUTHED, PROCESS_INPLACE, &WorldSession::HandleRequestHotfix);
     DefC(CMSG_JOIN_CHANNEL, "CMSG_JOIN_CHANNEL", STATUS_LOGGEDIN, PROCESS_THREADUNSAFE, &WorldSession::HandleJoinChannelOpcode);
     DefS(SMSG_CHANNEL_NOTIFY, "SMSG_CHANNEL_NOTIFY");
     DefS(SMSG_CHANNEL_LIST, "SMSG_CHANNEL_LIST");

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -1180,6 +1180,10 @@ enum AccountDataType
 // 0x021826BB, the table hash of BroadcastText.db2. The live client requests
 // this the moment it is handed a BroadcastText id it cannot resolve locally.
 #define DB2_REPLY_BROADCAST_TEXT 35137211
+// 0x63B4C4BA, the table hash of BattlePetEffectProperties.db2. This is the
+// first thing the client asks for after logging in, and every answer is a
+// not-found -- see SendBattlePetEffectPropertiesDb2Reply.
+#define DB2_REPLY_BATTLE_PET_EFFECT_PROPERTIES 1672791226
 
 struct AccountData
 {
@@ -2187,6 +2191,7 @@ class WorldSession
         void SendItemDb2Reply(uint32 entry);
         void SendItemSparseDb2Reply(uint32 entry);
         void SendBroadcastTextDb2Reply(uint32 entry);
+        void SendBattlePetEffectPropertiesDb2Reply(uint32 entry);
 
         void HandleObjectUpdateFailedOpcode(WorldPacket& recv_data);
 

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -1901,6 +1901,9 @@ void WorldSession::HandleRequestHotfix(WorldPacket& recv_data)
             case DB2_REPLY_BROADCAST_TEXT:
                 SendBroadcastTextDb2Reply(record.entry);
                 break;
+            case DB2_REPLY_BATTLE_PET_EFFECT_PROPERTIES:
+                SendBattlePetEffectPropertiesDb2Reply(record.entry);
+                break;
             default:
                 sLog.outError("CMSG_REQUEST_HOTFIX: Received unknown hotfix type: %u", request.type);
                 recv_data.rfinish();

--- a/src/game/WorldHandlers/QueryHandler.cpp
+++ b/src/game/WorldHandlers/QueryHandler.cpp
@@ -455,6 +455,40 @@ void WorldSession::HandleNpcTextQueryOpcode(WorldPacket& recv_data)
 }
 
 /**
+ * @brief Answers the battle-pet effect-properties probe the client fires at login.
+ *
+ * This is the first server content of a retail login -- ahead of the account
+ * data times, and roughly ninety packets before SMSG_LOGIN_VERIFY_WORLD. The
+ * client ships 97 records and asks for 86 more, and the two sets do not
+ * intersect at all: together they are exactly the contiguous span 22..204, so
+ * the client is probing every id in the table's range that it does not already
+ * hold.
+ *
+ * Retail answers every one of them with a not-found. Across the capture corpus
+ * all 946 replies of this type carry a zero-length record, and every entry is
+ * returned negated -- 0xFFFFFF75 to 0xFFFFFF22, which is -203 to -30. So there
+ * is no data to recover and nothing to build a record layout for; the gap was
+ * only ever that we said nothing where retail says no.
+ *
+ * Do not generalise this into the hotfix handler. Answering every unknown type
+ * with a not-found would be wrong: the same channel carries real records for
+ * other tables, 222 of them in the corpus, with Creature.db2 replies running
+ * 80 to 103 bytes and CreatureDifficulty.db2 at 44. Emptiness here is a
+ * property of this table's id distribution -- the client happens to probe a
+ * range in which nothing it lacks exists -- not of the mechanism. A table that
+ * does carry data would then return nothing and read as a data problem rather
+ * than a code one.
+ */
+void WorldSession::SendBattlePetEffectPropertiesDb2Reply(uint32 entry)
+{
+    WorldPacket data(SMSG_DB_REPLY, 16);
+    ByteBuffer empty;
+    MopHotfixPackets::BuildDbReply(data, uint32(0) - entry, uint32(time(NULL)),
+        DB2_REPLY_BATTLE_PET_EFFECT_PROPERTIES, empty);
+    SendPacket(&data);
+}
+
+/**
  * @brief Serves a BroadcastText record the client could not resolve locally.
  *
  * The 18414 client ships 936 BroadcastText records. When SMSG_NPC_TEXT_UPDATE


### PR DESCRIPTION
[Hotfix] Answer the battle-pet effect-properties probe the client fires at login

This is the first server content of a retail login, ahead of the account data
times and roughly ninety packets before SMSG_LOGIN_VERIFY_WORLD. We said nothing
where retail says no, leaving an 86-packet hole at the very front of the
sequence.

The client ships 97 records of BattlePetEffectProperties and asks for 86 more,
and the two sets do not intersect at all: together they are exactly the
contiguous span 22..204. So the client is probing every id in the table's range
that it does not already hold, and none of them exist.

Retail answers every one with a not-found. All 946 replies of this type in the
capture corpus carry a zero-length record, and every entry comes back negated --
0xFFFFFF75 to 0xFFFFFF22, which is -203 to -30. That is the same negated form
0d0c4f532 introduced for the not-found path on review feedback, so that change
is now confirmed against real traffic rather than resting on a reviewer's
assertion.

There is therefore no record layout to recover and no data to reconstruct. The
type case answers not-found and the hole closes.

Deliberately narrow. The same channel carries real records for other tables --
222 of them in the corpus, Creature.db2 at 80 to 103 bytes and
CreatureDifficulty.db2 at 44 -- so answering every unknown type with a not-found
would make the next table that does carry data return nothing and read as a data
problem rather than a code one. Emptiness here is a property of this table's id
distribution, not of the mechanism, and the handler says so.

No new inbound opcode: CMSG_REQUEST_HOTFIX is already registered and its
437-byte login body decodes byte-exact with no residual.

Suite is 1089/1089.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/41)
<!-- Reviewable:end -->
