### PR TITLE
[Objects] Stop the MoP create gate rejecting vehicles

### DIFF
--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -169,10 +169,24 @@ bool MopUpdateObject::CanUseSimpleUnitMovement(SimpleUnitEligibility const& elig
     // combat when it entered view was never created client-side and stayed
     // invisible while still dealing damage.
     //
-    // Transport and vehicle states are still rejected: those change what the
-    // position means (transport-relative rather than world), so a stationary
-    // snapshot would place the unit somewhere wrong rather than merely stale.
-    return !eligibility.isVehicle && !eligibility.isBoarded && !eligibility.hasTransport;
+    // Boarding and transport are still rejected: those change what the position
+    // means (transport-relative rather than world), so a stationary snapshot
+    // would place the unit somewhere wrong rather than merely stale.
+    //
+    // Being a vehicle is not such a state. IsVehicle() is m_vehicleInfo != NULL,
+    // so it means the unit CAN carry passengers, not that it is riding anything;
+    // its own position is an ordinary world position. The transport-relative
+    // case is the passenger, already covered by isBoarded. Rejecting vehicles
+    // here hid every vehicle-flagged creature in the world -- 1,622 templates
+    // over 6,529 spawns across 48 maps -- including quest givers such as Master
+    // Shang Xi (53566), whose client never learned he existed and so never even
+    // queried his entry.
+    //
+    // AppendSimpleLivingMovement declares the vehicle block absent, so the
+    // create stays well formed and the unit renders as an ordinary creature. The
+    // cost is that it is not yet rideable, which needs a real vehicle create
+    // block; being visible but not rideable beats being invisible.
+    return !eligibility.isBoarded && !eligibility.hasTransport;
 }
 
 bool MopUpdateObject::CanUseStationaryGameObjectMovement(StationaryGameObjectEligibility const& eligibility)

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -645,9 +645,23 @@ int main(int /*argc*/, char** /*argv*/)
     // leaving creatures that were moving or in combat permanently invisible.
     MopUpdateObject::SimpleUnitEligibility eligibility{};
     CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
-    eligibility.isVehicle = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.isVehicle = false;
     eligibility.isBoarded = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.isBoarded = false;
     eligibility.hasTransport = true; CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility)); eligibility.hasTransport = false;
+
+    // A vehicle carries passengers; it does not ride anything. Its own position
+    // is a world position, so it encodes as a stationary snapshot like any other
+    // unit. Rejecting it emitted no create at all, hiding 6,529 spawns including
+    // quest givers. The passenger is the transport-relative case, and that is
+    // isBoarded above -- which stays rejected even when both are set.
+    eligibility.isVehicle = true;
+    CHECK(MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
+    eligibility.isBoarded = true;
+    CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
+    eligibility.isBoarded = false;
+    eligibility.hasTransport = true;
+    CHECK(!MopUpdateObject::CanUseSimpleUnitMovement(eligibility));
+    eligibility.hasTransport = false;
+    eligibility.isVehicle = false;
 
     // States the encoder represents as a stationary snapshot: the unit is still
     // created, and the SMSG_MONSTER_MOVE stream animates it from there.


### PR DESCRIPTION
## What

`CanUseSimpleUnitMovement` rejected any unit with `IsVehicle()` set. The unit path has no fallback encoder — `CanBuildMopCreateUpdate()` returning false makes `BuildCreateUpdateBlockForPlayer` emit nothing — so every vehicle-flagged creature was never created client-side and stayed invisible.

**1,622 templates across 6,529 spawns on 48 maps**, including quest givers such as Master Shang Xi (53566), the first Pandaren quest giver, who could not be seen or talked to.

## Why the original reasoning was wrong

The rejection was mine, from the earlier widening of this gate, and its stated justification does not hold:

> *Transport and vehicle states are still rejected: those change what the position means (transport-relative rather than world)*

That is true of a **passenger**, not a **vehicle**. `IsVehicle()` is `m_vehicleInfo != NULL` — it means the unit *can carry* passengers, not that it is riding anything, so its own position is an ordinary world position. The transport-relative case is the passenger, already covered by `isBoarded`, which stays rejected, as does `hasTransport`.

The test asserted the same misunderstanding, so it passed throughout. It now asserts the corrected behaviour: a vehicle passes, and a vehicle that is *also* boarded or on a transport is still rejected, so the real constraint remains enforced.

## Wire safety

`AppendSimpleLivingMovement` declares the vehicle block absent (`WriteBit(0)`), so the create stays well formed and the unit renders as an ordinary creature. The cost is that it is not yet rideable — that needs a real vehicle create block. Visible but not rideable beats invisible.

`eligibility.isVehicle` is left in the struct and still populated; a genuine vehicle create block will need it.

## Evidence

**Before** — with a Pandaren stood beside him, the client queried 17 creature entries including **53565**, the adjacent spawn, and never **53566**. It was never told he existed, so it never asked what he was. Neighbouring NPCs arriving normally rules out grid loading, phasing, the map and range in one stroke.

**After** — verified live on this branch: the Pandaren starting quest givers render and are usable.

## Tests

- `mop_updateobject` — **ALL PASS**, standalone and in-suite
- Full suite — **925/927**. The two failures are `mop_spell_cast_packets` and `mop_battlefield_status_packets`, both `0xC0000135` (`STATUS_DLL_NOT_FOUND`) on this machine. Both predate this change, touch no code it affects, and are reported passing elsewhere.
- RelWithDebInfo build and install clean, **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/42)
<!-- Reviewable:end -->
