### PR TITLE
[Quests] Reject out of range quest POI floorId at load

### DIFF
--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -1319,6 +1319,8 @@ void ObjectMgr::LoadQuestPOI()
 
     BarGoLink bar(result->GetRowCount());
 
+    uint32 badFloorCount = 0;
+
     do
     {
         Field* fields = result->Fetch();
@@ -1332,6 +1334,27 @@ void ObjectMgr::LoadQuestPOI()
         uint32 floorId          = fields[5].GetUInt32();
         uint32 unk3             = fields[6].GetUInt32();
         uint32 unk4             = fields[7].GetUInt32();
+
+        // An out-of-range floorId crashes the 5.4.8 client the moment it reads
+        // SMSG_QUEST_POI_QUERY_RESPONSE, which is sent on quest accept - so one
+        // bad row takes down every client that accepts that quest. Confirmed in
+        // game: floorId 252339 on quest 29406 crashed, zeroing it did not, and
+        // the same packet's objIndex 32 was carried through untouched both
+        // times, so this field is the sole trigger.
+        //
+        // floorId is a small map-floor ordinal. MAX_QUEST_POI_FLOOR_ID is the
+        // declared schema width rather than a measured client limit; the real
+        // ceiling is unknown, but every sane row observed so far is <= 7, so
+        // this rejects the six-figure import garbage without second-guessing
+        // legitimate data. Zero rather than drop: the marker still renders, on
+        // the default floor, instead of vanishing.
+        if (floorId > MAX_QUEST_POI_FLOOR_ID)
+        {
+            sLog.outErrorDb("Table `quest_poi` has questId %u poiId %u with out of range floorId %u, forced to 0.",
+                            questId, poiId, floorId);
+            floorId = 0;
+            ++badFloorCount;
+        }
 
         QuestPOI POI(poiId, objIndex, mapId, mapAreaId, floorId, unk3, unk4);
 
@@ -1377,6 +1400,11 @@ void ObjectMgr::LoadQuestPOI()
 
     sLog.outString();
     sLog.outString(">> Loaded %u quest POI definitions", count);
+
+    if (badFloorCount)
+    {
+        sLog.outErrorDb(">> %u quest POI definitions had an out of range floorId and were forced to floor 0. Fix them in `quest_poi`; left unpatched they crash the client on quest accept.", badFloorCount);
+    }
 }
 
 

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -1342,13 +1342,11 @@ void ObjectMgr::LoadQuestPOI()
         // the same packet's objIndex 32 was carried through untouched both
         // times, so this field is the sole trigger.
         //
-        // floorId is a small map-floor ordinal. MAX_QUEST_POI_FLOOR_ID is the
-        // declared schema width rather than a measured client limit; the real
-        // ceiling is unknown, but every sane row observed so far is <= 7, so
-        // this rejects the six-figure import garbage without second-guessing
-        // legitimate data. Zero rather than drop: the marker still renders, on
-        // the default floor, instead of vanishing.
-        if (floorId > MAX_QUEST_POI_FLOOR_ID)
+        // floorId is a small map-floor ordinal. MAX_QUEST_POI_FLOOR_ID is a
+        // deliberately loose heuristic rather than a measured client limit -
+        // see its definition. Zero rather than drop: the marker still renders,
+        // on the default floor, instead of vanishing.
+        if (!IsValidQuestPoiFloorId(floorId))
         {
             sLog.outErrorDb("Table `quest_poi` has questId %u poiId %u with out of range floorId %u, forced to 0.",
                             questId, poiId, floorId);

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -318,10 +318,22 @@ struct QuestPOIPoint
     QuestPOIPoint(int32 _x, int32 _y) : x(_x), y(_y) {}
 };
 
-// Upper bound accepted for `quest_poi`.`floorId`. This is the declared schema
-// width, not a measured client limit - see LoadQuestPOI() for why anything
-// above it must never reach the wire.
+// Upper bound accepted for `quest_poi`.`floorId`. See LoadQuestPOI() for why
+// anything above it must never reach the wire.
+//
+// This is a chosen heuristic, not a derived limit. The column is int(10)
+// unsigned, so the schema imposes no useful ceiling, and the client's real
+// ceiling is unknown - all that is established is that 252339 crashes it and
+// that every sane row observed is <= 7. 255 sits well above real data and well
+// below the six-figure import garbage. Narrowing it properly would need the
+// client's POI reader disassembled; until then this bound is deliberately
+// loose rather than falsely precise.
 #define MAX_QUEST_POI_FLOOR_ID 255
+
+inline bool IsValidQuestPoiFloorId(uint32 floorId)
+{
+    return floorId <= MAX_QUEST_POI_FLOOR_ID;
+}
 
 struct QuestPOI
 {

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -318,6 +318,11 @@ struct QuestPOIPoint
     QuestPOIPoint(int32 _x, int32 _y) : x(_x), y(_y) {}
 };
 
+// Upper bound accepted for `quest_poi`.`floorId`. This is the declared schema
+// width, not a measured client limit - see LoadQuestPOI() for why anything
+// above it must never reach the wire.
+#define MAX_QUEST_POI_FLOOR_ID 255
+
 struct QuestPOI
 {
     uint32 PoiId;

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -537,7 +537,7 @@ add_test(NAME mop_quest_poi_query_source
     COMMAND ${CMAKE_COMMAND}
         -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_quest_poi_query_source_test.cmake)
-foreach(mutation IN ITEMS request_parser response_builder inbound_registration outbound_registration allowlist)
+foreach(mutation IN ITEMS request_parser response_builder inbound_registration outbound_registration allowlist floor_clamp)
     add_test(NAME mop_quest_poi_query_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND}
             -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}

--- a/src/game/Server/tests/mop_quest_poi_query_source_test.cmake
+++ b/src/game/Server/tests/mop_quest_poi_query_source_test.cmake
@@ -2,6 +2,8 @@ file(READ "${SOURCE_ROOT}/src/game/Server/WorldSession.h" packet_helpers)
 file(READ "${SOURCE_ROOT}/src/game/WorldHandlers/QueryHandler.cpp" query_handler)
 file(READ "${SOURCE_ROOT}/src/game/Server/Opcodes.cpp" opcode_registry)
 file(READ "${SOURCE_ROOT}/src/game/Server/WorldSession.cpp" world_session)
+file(READ "${SOURCE_ROOT}/src/game/Object/ObjectMgr.cpp" object_mgr)
+file(READ "${SOURCE_ROOT}/src/game/Object/ObjectMgr.h" object_mgr_header)
 
 if(MUTATION STREQUAL "request_parser")
     string(REPLACE
@@ -28,6 +30,11 @@ elseif(MUTATION STREQUAL "allowlist")
         "case SMSG_QUEST_POI_QUERY_RESPONSE:"
         "case 0xFFFF: /* removed quest-POI allowlist */"
         world_session "${world_session}")
+elseif(MUTATION STREQUAL "floor_clamp")
+    string(REPLACE
+        "if (floorId > MAX_QUEST_POI_FLOOR_ID)"
+        "if (false) /* removed floorId clamp */"
+        object_mgr "${object_mgr}")
 endif()
 
 function(strip_cpp_comments output source)
@@ -80,6 +87,8 @@ strip_cpp_comments(packet_helpers "${packet_helpers}")
 strip_cpp_comments(query_handler "${query_handler}")
 strip_cpp_comments(opcode_registry "${opcode_registry}")
 strip_cpp_comments(world_session "${world_session}")
+strip_cpp_comments(object_mgr "${object_mgr}")
+strip_cpp_comments(object_mgr_header "${object_mgr_header}")
 
 extract_body(handler "${query_handler}"
     "void WorldSession::HandleQuestPOIQueryOpcode"
@@ -90,6 +99,23 @@ extract_body(parser "${packet_helpers}"
 extract_body(builder "${packet_helpers}"
     "inline bool MopQueryPackets::BuildQuestPoiQueryResponse"
     "inline uint64 MopStablePackets::ReadStableListRequest")
+
+extract_body(poi_loader "${object_mgr}"
+    "void ObjectMgr::LoadQuestPOI"
+    "void ObjectMgr::GetConditions")
+
+# An out-of-range floorId crashes the 5.4.8 client on quest accept, so the
+# loader must reject it before the value can ever reach the wire.
+require_ordered("${poi_loader}" "quest-POI loader floorId clamp"
+    "uint32 floorId          = fields[5].GetUInt32();"
+    "if (floorId > MAX_QUEST_POI_FLOOR_ID)"
+    "floorId = 0;"
+    "QuestPOI POI(poiId, objIndex, mapId, mapAreaId, floorId, unk3, unk4);")
+
+string(FIND "${object_mgr_header}" "#define MAX_QUEST_POI_FLOOR_ID" floor_bound)
+if(floor_bound EQUAL -1)
+    message(FATAL_ERROR "MAX_QUEST_POI_FLOOR_ID is not defined")
+endif()
 
 require_ordered("${handler}" "quest-POI handler"
     "MopQueryPackets::ParseQuestPoiQueryRequest(recv_data, questIds)"

--- a/src/game/Server/tests/mop_quest_poi_query_source_test.cmake
+++ b/src/game/Server/tests/mop_quest_poi_query_source_test.cmake
@@ -32,7 +32,7 @@ elseif(MUTATION STREQUAL "allowlist")
         world_session "${world_session}")
 elseif(MUTATION STREQUAL "floor_clamp")
     string(REPLACE
-        "if (floorId > MAX_QUEST_POI_FLOOR_ID)"
+        "if (!IsValidQuestPoiFloorId(floorId))"
         "if (false) /* removed floorId clamp */"
         object_mgr "${object_mgr}")
 endif()
@@ -108,13 +108,13 @@ extract_body(poi_loader "${object_mgr}"
 # loader must reject it before the value can ever reach the wire.
 require_ordered("${poi_loader}" "quest-POI loader floorId clamp"
     "uint32 floorId          = fields[5].GetUInt32();"
-    "if (floorId > MAX_QUEST_POI_FLOOR_ID)"
+    "if (!IsValidQuestPoiFloorId(floorId))"
     "floorId = 0;"
     "QuestPOI POI(poiId, objIndex, mapId, mapAreaId, floorId, unk3, unk4);")
 
-string(FIND "${object_mgr_header}" "#define MAX_QUEST_POI_FLOOR_ID" floor_bound)
+string(FIND "${object_mgr_header}" "inline bool IsValidQuestPoiFloorId" floor_bound)
 if(floor_bound EQUAL -1)
-    message(FATAL_ERROR "MAX_QUEST_POI_FLOOR_ID is not defined")
+    message(FATAL_ERROR "IsValidQuestPoiFloorId is not defined")
 endif()
 
 require_ordered("${handler}" "quest-POI handler"

--- a/src/game/Server/tests/mop_quest_poi_query_test.cpp
+++ b/src/game/Server/tests/mop_quest_poi_query_test.cpp
@@ -12,6 +12,7 @@
 #include "WorldSession.h"
 #include "Opcodes.h"
 #include "WorldPacket.h"
+#include "Object/ObjectMgr.h"
 
 #include <cstdint>
 #include <cstdio>
@@ -161,11 +162,41 @@ static void test_opcode_values()
     CHECK(uint32_t(SMSG_QUEST_POI_QUERY_RESPONSE) <= 0x1FFFu);
 }
 
+/**
+ * An out of range `quest_poi`.`floorId` crashes the 5.4.8 client when it reads
+ * SMSG_QUEST_POI_QUERY_RESPONSE on quest accept, so LoadQuestPOI() rejects it.
+ * The loader itself needs a database, but the bound it applies does not.
+ */
+static void test_floor_id_bound()
+{
+    // Real data. The whole imported table sits in this range.
+    CHECK(IsValidQuestPoiFloorId(0));
+    CHECK(IsValidQuestPoiFloorId(7));
+
+    // The bound itself, and the first value past it.
+    CHECK(IsValidQuestPoiFloorId(MAX_QUEST_POI_FLOOR_ID));
+    CHECK(!IsValidQuestPoiFloorId(MAX_QUEST_POI_FLOOR_ID + 1));
+
+    // 808 was an earlier candidate bound, taken from DungeonMap.dbc on the
+    // unverified assumption that floorId indexes that DBC. It does not survive
+    // the current bound, and nothing depends on it either way.
+    CHECK(!IsValidQuestPoiFloorId(808));
+
+    // The value that crashed the client in game on quest 29406, and the top of
+    // the observed garbage band across the 49 affected rows.
+    CHECK(!IsValidQuestPoiFloorId(252339));
+    CHECK(!IsValidQuestPoiFloorId(264091));
+
+    // The column is int(10) unsigned, so this is a reachable value.
+    CHECK(!IsValidQuestPoiFloorId(0xFFFFFFFFu));
+}
+
 int main(int /*argc*/, char** /*argv*/)
 {
     test_request();
     test_response();
     test_opcode_values();
+    test_floor_id_bound();
 
     if (g_fail)
     {


### PR DESCRIPTION
## Problem

An out-of-range `floorId` in `quest_poi` crashes the 5.4.8 client the moment it reads `SMSG_QUEST_POI_QUERY_RESPONSE`. That response is sent on **quest accept**, so a single bad integer in the imported world database takes down every client that accepts the quest.

On `mangos4_v2` this is **49 rows across 21 Wandering Isle starting quests**, all map 860 / area 808, carrying floor ids in the 250,000–265,000 range.

## Evidence

Confirmed in game on quest 29406 by controlled test:

| Run | `floorId` | `objIndex` | Result |
|---|---|---|---|
| 1 | 252339 | 32 | client crash |
| 2 | 0 | 32 (unchanged) | no crash |

`floorId` is the sole trigger. `objIndex` is **not** implicated and is deliberately left alone — it is negative in roughly half the table (14,985 of 29,117 rows), which is the conventional "no objective" sentinel, and the client handles it fine.

Field mapping is independently corroborated: `mapId = 860` and `mapAreaId = 808` decode exactly to the database row, so the byte-phase order in `BuildQuestPoiQueryResponse` is correct as written.

## Fix

Clamp at load rather than at send:

- one site, so every consumer is covered — clamping in the handler would leave the bad value live in `mQuestPOIMap`
- the offending `questId`/`poiId` pairs are logged once at startup, giving the database repository a work list
- **zero rather than drop** the record, so the marker still renders on the default floor instead of vanishing

## On the bound — read this before trusting it

`MAX_QUEST_POI_FLOOR_ID` (255) is **a chosen heuristic, not a derived limit.**

An earlier revision of this PR described it as the declared schema width. That was wrong: `quest_poi`.`floorId` is `int(10) unsigned`, a full 32-bit column, so the schema imposes no useful ceiling. The number behaves correctly on all real data, but the stated justification was invented, and it is corrected here rather than left for someone to reason from later.

What is actually established:

- 252,339 crashes the client (observed, in game)
- every sane row in the table is `<= 7`
- **everything between 8 and 255 is untested against the client**

So this bound is deliberately loose. If the client's real ceiling turns out to be small, a future import at floor 40 would pass straight through it. Narrowing it properly requires disassembling the client's POI reader to see what that field indexes; that work is not done and this fix does not depend on it.

## Database side

The rows should still be corrected at source, so the startup warning stops firing:

```sql
UPDATE `quest_poi` SET `floorId` = 0 WHERE `floorId` > 255;
```

## Testing

- full suite **1084/1084** (master is 1083; this adds one test and removes none)
- new `floor_clamp` mutation arm on `mop_quest_poi_query_source`, `WILL_FAIL` confirming the guard has teeth rather than merely being present
- `IsValidQuestPoiFloorId()` is extracted so the bound is checked behaviourally, not by source-token match: 0 and 7 accepted; the bound and the first value past it; 808 (an earlier candidate bound, taken from `DungeonMap.dbc` on an assumption about what `floorId` indexes that was never verified); the live crash value 252,339; the top of the observed band 264,091; and `0xFFFFFFFF`

**Not yet proven:** the end-to-end regression — restoring the 49 bad rows, deploying this branch, and confirming both that startup reports 49 forced rows and that quest 29406 accepts cleanly *with the bad data still in the table*. Until that runs against unsanitised data, the guard is untested against the fault it exists to stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/43)
<!-- Reviewable:end -->
