### PR TITLE
[Proto] Fix reversed CMSG_PING field order

### DIFF
--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -546,6 +546,19 @@ foreach(mutation IN ITEMS request_parser response_builder inbound_registration o
     set_tests_properties(mop_quest_poi_query_source_mutation_${mutation} PROPERTIES WILL_FAIL TRUE)
 endforeach()
 
+add_test(NAME mop_ping_field_order_source
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_ping_field_order_source_test.cmake)
+foreach(mutation IN ITEMS swapped_read echoed_latency)
+    add_test(NAME mop_ping_field_order_source_mutation_${mutation}
+        COMMAND ${CMAKE_COMMAND}
+            -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+            -DMUTATION=${mutation}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_ping_field_order_source_test.cmake)
+    set_tests_properties(mop_ping_field_order_source_mutation_${mutation} PROPERTIES WILL_FAIL TRUE)
+endforeach()
+
 add_executable(mop_name_query_test mop_name_query_test.cpp)
 target_include_directories(mop_name_query_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..

--- a/src/game/Server/tests/mop_ping_field_order_source_test.cmake
+++ b/src/game/Server/tests/mop_ping_field_order_source_test.cmake
@@ -16,7 +16,14 @@ endif()
 
 function(strip_cpp_comments output source)
     set(text "${source}")
-    while(TRUE)
+    # while(1), not while(TRUE): each test runs as a bare `cmake -P` script with
+    # no cmake_minimum_required, so CMP0012 is unset. Under that policy's OLD
+    # behaviour the boolean constant TRUE is treated as a variable name and
+    # evaluates false, so the loop would never run and block comments would
+    # survive - letting a token sequence inside one satisfy the guard. Numeric
+    # constants are unaffected. Not reproducible on CMake 4.x, which dropped the
+    # pre-3.5 policies, but this project supports CMake >= 3.18.
+    while(1)
         string(FIND "${text}" "/*" comment_start)
         if(comment_start EQUAL -1)
             break()

--- a/src/game/Server/tests/mop_ping_field_order_source_test.cmake
+++ b/src/game/Server/tests/mop_ping_field_order_source_test.cmake
@@ -1,0 +1,77 @@
+# Guards the 5.4.8 CMSG_PING field order against a silent revert to the 3.3.5
+# layout. See ClientConnection::HandlePing for the Wow.exe 18414 evidence.
+file(READ "${SOURCE_ROOT}/src/proto/ClientConnection.cpp" client_connection)
+
+if(MUTATION STREQUAL "swapped_read")
+    string(REPLACE
+        "packet >> latency;\n        packet >> ping;"
+        "packet >> ping;\n        packet >> latency;"
+        client_connection "${client_connection}")
+elseif(MUTATION STREQUAL "echoed_latency")
+    string(REPLACE
+        "pong << ping;"
+        "pong << latency;"
+        client_connection "${client_connection}")
+endif()
+
+function(strip_cpp_comments output source)
+    set(text "${source}")
+    while(TRUE)
+        string(FIND "${text}" "/*" comment_start)
+        if(comment_start EQUAL -1)
+            break()
+        endif()
+        math(EXPR tail_start "${comment_start} + 2")
+        string(SUBSTRING "${text}" ${tail_start} -1 tail)
+        string(FIND "${tail}" "*/" comment_end)
+        if(comment_end EQUAL -1)
+            message(FATAL_ERROR "Unterminated block comment while scanning source")
+        endif()
+        string(SUBSTRING "${text}" 0 ${comment_start} before)
+        math(EXPR after_start "${comment_end} + 2")
+        string(SUBSTRING "${tail}" ${after_start} -1 after)
+        set(text "${before}${after}")
+    endwhile()
+    string(REGEX REPLACE "//[^\r\n]*" "" text "${text}")
+    set(${output} "${text}" PARENT_SCOPE)
+endfunction()
+
+function(extract_body output source start_marker end_marker)
+    string(FIND "${source}" "${start_marker}" start)
+    string(FIND "${source}" "${end_marker}" end)
+    if(start EQUAL -1 OR end EQUAL -1 OR NOT start LESS end)
+        message(FATAL_ERROR "Could not isolate ${start_marker}")
+    endif()
+    math(EXPR length "${end} - ${start}")
+    string(SUBSTRING "${source}" ${start} ${length} body)
+    set(${output} "${body}" PARENT_SCOPE)
+endfunction()
+
+function(require_ordered source context)
+    set(remaining "${source}")
+    foreach(token IN LISTS ARGN)
+        string(FIND "${remaining}" "${token}" position)
+        if(position EQUAL -1)
+            message(FATAL_ERROR "${context}: missing active ordered token: ${token}")
+        endif()
+        string(LENGTH "${token}" token_length)
+        math(EXPR next_position "${position} + ${token_length}")
+        string(SUBSTRING "${remaining}" ${next_position} -1 remaining)
+    endforeach()
+endfunction()
+
+strip_cpp_comments(client_connection "${client_connection}")
+
+extract_body(handler "${client_connection}"
+    "bool ClientConnection::HandlePing"
+    "void ClientConnection::RejectAuth")
+
+# Wow.exe 18414 sub_66F403 writes *(this+6) before *(this+5) - byte offsets
+# 0x18 then 0x14 - so the latency dword precedes the sequence dword. The
+# sequence is what SMSG_PONG must echo; echoing the latency is what produces
+# the client's "Received pong with old sequence".
+require_ordered("${handler}" "CMSG_PING field order"
+    "packet >> latency;"
+    "packet >> ping;"
+    "OnPing(m_session, latency"
+    "pong << ping;")

--- a/src/proto/ClientConnection.cpp
+++ b/src/proto/ClientConnection.cpp
@@ -434,10 +434,31 @@ namespace proto
 
     bool ClientConnection::HandlePing(WorldPacket& packet)
     {
-        uint32 ping = 0;
+        // 5.4.8 reverses the 3.3.5 field order: latency is on the wire FIRST,
+        // then the sequence. Read from Wow.exe 18414, not assumed:
+        //
+        //   sub_798727  ping sender. The per-stream struct is
+        //               connection+0x4560 + index*0x58. It stamps the send
+        //               time at struct+8 and takes the sequence from
+        //               ++struct+0, storing it in the message at +0x14, with
+        //               the latency sample at +0x18.
+        //   sub_66F4D7  writes opcode 18 (0x12, CMSG_PING), then calls
+        //   sub_66F403  which writes *(this+6) BEFORE *(this+5) - byte
+        //               offsets 0x18 then 0x14, so latency precedes sequence.
+        //
+        // Reading these the 3.3.5 way echoes the latency back as the sequence.
+        // The client compares it against its current sequence at 0x79976C and
+        // logs "Received pong with old sequence" at 0x799770 - "old" rather
+        // than "bad" because a millisecond latency is a small number, so it
+        // reads as an earlier sequence rather than as garbage.
+        //
+        // It also reported the sequence to the gateway as if it were a latency
+        // measurement, which feeds movement timestamp adjustment
+        // (MovementHandler.cpp) as well as the exposed latency figure.
         uint32 latency = 0;
-        packet >> ping;
+        uint32 ping = 0;
         packet >> latency;
+        packet >> ping;
 
         // WorldSocket.cpp:1594-1628's 27-second overspeed-ping window.
         static const std::chrono::seconds MIN_PING_INTERVAL(27);


### PR DESCRIPTION
## Symptom

The live client spams `Received pong with old sequence` to its console throughout a session.

## Root cause

**5.4.8 reverses the 3.3.5 field order.** The latency dword is on the wire first, then the sequence. We read `ping` then `latency` and echoed `ping` — so we were echoing the **latency** back as the sequence.

That also explains the wording. The client says *old*, not *bad*, because a millisecond latency is a small number and the sequence counter starts at 1 and climbs — so the echoed value usually looks like an earlier sequence rather than garbage.

## Evidence — read from Wow.exe 18414

| Address | What it does |
|---|---|
| `sub_798727` | Ping sender. Per-stream struct = `connection+0x4560 + index*0x58`. Stamps the 64-bit send time at `struct+8`; the sequence is `++struct+0`. Places **sequence at message `+0x14`**, **latency at `+0x18`**. |
| `sub_66F4D7` | Writes opcode **18 (0x12)** — independently confirming `CMSG_PING` — then calls: |
| `sub_66F403` | `sub_40F075(a2, *(this + 6));` then `sub_40F075(a2, *(this + 5));` — `this` is `int*`, so byte offsets **`0x18` before `0x14`**: latency precedes sequence. |
| `0x79976C` | Pong handler compares the echoed dword against the current sequence at `struct+0`; logs the string at `0x799770` on mismatch. |

## Second effect, beyond the console spam

The sequence was being passed to `WorldGateway::OnPing` **as if it were a latency measurement**. That value feeds movement timestamp adjustment (`MovementHandler.cpp`) and the exposed latency figure, so both have been reading a ping counter rather than milliseconds.

Overspeed detection is **not** affected — it keys off arrival cadence and `m_fastPingRun`, not the latency value.

## Why there is no corpus evidence

Checked, so the absence is recorded rather than assumed: the 18414 captures **do** contain client→server traffic (28,407 records, 168 distinct CMSGs in one file), but `0x0012` appears **zero times across all 146 capture files** — sniffers routinely filter keepalives. The binary is the only available evidence for this one.

## Testing

- full suite **1087/1087**
- `mop_ping_field_order_source` 3/3, with `WILL_FAIL` mutation arms for the swapped read and the wrong echo

Guarded by a source test rather than a unit test: there is no `ClientConnection` harness, and standing one up for two dword reads is disproportionate. Codex independently looked for a cheap real-packet harness and found none.

**Not proven here:** the source test constrains our code, not the external 18414 grammar, and it cannot reproduce the live symptom. The proportionate follow-up is a live-client check that the spam stops and that stored latency values look plausible.

Reviewed by Codex — `APPROVE WITH FOLLOW-UP`, no blocking or important findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/44)
<!-- Reviewable:end -->
