### PR TITLE
[Objects] Extract the self-player field projection

### DIFF
--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -300,11 +300,15 @@ void MopUpdateObject::AppendSelfInventoryValuesBlock(ByteBuffer& out, uint64 gui
     AppendValuesBlock(out, guid, fields.data(), uint32(fields.size()));
 }
 
-void MopUpdateObject::AppendSelfPlayerValuesBlock(ByteBuffer& out, uint64 guid,
-    StaticField const* sourceFields, uint32 fieldCount)
+void MopUpdateObject::TranslateSelfPlayerFields(StaticField const* sourceFields,
+    uint32 fieldCount, std::vector<StaticField>& out)
 {
     MANGOS_ASSERT(sourceFields || fieldCount == 0);
 
+    // Projected into a local and swapped in at the end, so a caller may pass
+    // the storage it is reading from: TranslateSelfPlayerFields(v.data(),
+    // v.size(), v) is well defined. Clearing `out` up front instead would end
+    // the lifetime of those source elements before they were read.
     std::vector<StaticField> fields;
     fields.reserve(fieldCount + 1);
     for (uint32 i = 0; i < fieldCount; ++i)
@@ -472,6 +476,14 @@ void MopUpdateObject::AppendSelfPlayerValuesBlock(ByteBuffer& out, uint64 guid,
         }
     }
 
+    out.swap(fields);
+}
+
+void MopUpdateObject::AppendSelfPlayerValuesBlock(ByteBuffer& out, uint64 guid,
+    StaticField const* sourceFields, uint32 fieldCount)
+{
+    std::vector<StaticField> fields;
+    TranslateSelfPlayerFields(sourceFields, fieldCount, fields);
     AppendValuesBlock(out, guid, fields.data(), uint32(fields.size()));
 }
 

--- a/src/game/Server/MopUpdateObject.h
+++ b/src/game/Server/MopUpdateObject.h
@@ -42,6 +42,8 @@
 #include "Common.h"
 #include "SharedDefines.h"   // MAX_STORED_POWERS
 
+#include <vector>
+
 class WorldPacket;
 class ByteBuffer;
 
@@ -133,6 +135,19 @@ namespace MopUpdateObject
     /// 18414 [965,1137) and append one VALUES block. Zero values are retained.
     void AppendSelfInventoryValuesBlock(ByteBuffer& out, uint64 guid,
         StaticField const* sourceFields, uint32 fieldCount);
+
+    /// Project ordered legacy self-player field indices onto their 18414
+    /// CGPlayerData positions, replacing the contents of \a out. Source
+    /// indices must be strictly ascending; quest-log slots are re-strided
+    /// whole, so a partial slot would clear the remainder client-side.
+    ///
+    /// \a sourceFields may alias \a out's storage: the projection is built
+    /// separately and swapped in once the source has been fully read.
+    ///
+    /// Split out of AppendSelfPlayerValuesBlock so the create path can apply
+    /// the identical projection without going through a VALUES block.
+    void TranslateSelfPlayerFields(StaticField const* sourceFields,
+        uint32 fieldCount, std::vector<StaticField>& out);
 
     /// Translate the binary-proved self-player Unit and visible-item
     /// projections, existing inventory range, coinage/XP fields, and local

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -81,6 +81,41 @@ int main(int /*argc*/, char** /*argv*/)
     CHECK(MopUpdateObject::TranslateSelfInventoryIndex(960) == 965);
     CHECK(MopUpdateObject::TranslateSelfInventoryIndex(1131) == 1136);
 
+    // TranslateSelfPlayerFields is reached through AppendSelfPlayerValuesBlock
+    // everywhere else in these tests, which always hands it a fresh empty
+    // vector. Exercise the out-parameter contract directly: prior contents are
+    // replaced, not appended to, and the source is allowed to alias the
+    // destination's own storage.
+    {
+        const MopUpdateObject::StaticField source[] =
+        {
+            { 1142, 0x11111111u },       // coinage low  -> 1149
+            { 1144, 0x22222222u },       // XP           -> 1151
+        };
+
+        std::vector<MopUpdateObject::StaticField> projected;
+        projected.push_back({ 9999, 0xDEADBEEFu });   // must not survive
+        MopUpdateObject::TranslateSelfPlayerFields(source, 2, projected);
+        CHECK(projected.size() == 2);
+        CHECK(projected[0].index == 1149 && projected[0].value == 0x11111111u);
+        CHECK(projected[1].index == 1151 && projected[1].value == 0x22222222u);
+
+        // Reuse of the same vector must be idempotent, not cumulative.
+        MopUpdateObject::TranslateSelfPlayerFields(source, 2, projected);
+        CHECK(projected.size() == 2);
+
+        // Self-aliasing: read from the very storage being replaced. The
+        // legacy coinage pair 1142/1143 projects to 1149/1150, so feeding the
+        // result back in would hit the unsupported-field assert; use a range
+        // that is stable under the projection instead.
+        std::vector<MopUpdateObject::StaticField> aliased;
+        aliased.push_back({ 7, 0x33333333u });        // scale -> 7, fixed point
+        MopUpdateObject::TranslateSelfPlayerFields(aliased.data(),
+            uint32(aliased.size()), aliased);
+        CHECK(aliased.size() == 1);
+        CHECK(aliased[0].index == 7 && aliased[0].value == 0x33333333u);
+    }
+
     // Observer-visible Player fields use a deliberately narrow 18414
     // projection. Unit fields are individually admitted; visible-item pairs
     // move by +5. Private Player fields must not acquire a target index.


### PR DESCRIPTION
## What

`AppendSelfPlayerValuesBlock` did two things at once: project Four's legacy update-field indices onto their 18414 `CGPlayerData` positions, and emit a VALUES block. This splits the projection into `TranslateSelfPlayerFields` so the create path can apply the identical mapping without going through a VALUES block.

**Behaviour-neutral** — the byte-exact `mop_updateobject` tests pass unchanged.

## Why now

Groundwork for folding the login seed into the self create. Retail sends one `SMSG_UPDATE_OBJECT` on login carrying everything; we send a create followed by a separate values block, which is why coinage, the quest-accept sound and skill announcements arrive as *mutations* and trigger client-side feedback that shouldn't fire at login.

That follow-up work is **not** in this PR. This is the enabler only.

## Alias safety

The helper projects into a local vector and swaps at the end, so a caller may legally pass the same vector it is reading from:

```cpp
TranslateSelfPlayerFields(v.data(), v.size(), v);   // well defined
```

That shape is exactly what the create-path caller wants. The first revision cleared the caller's vector up front instead, which would have ended the lifetime of the source elements before they were read — undefined behaviour. Codex flagged it; this is the fix, made structural rather than documented around.

## Testing

- full suite **1087/1087**
- `mop_updateobject` byte-exact tests unchanged, which is what makes "behaviour-neutral" a measured claim rather than an assertion
- new direct coverage of the out-parameter contract: prior contents replaced rather than appended to, repeated calls idempotent rather than cumulative, and the self-aliasing call exercised (it would have been UB before the swap)

Reviewed by Codex — `APPROVE`, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/45)
<!-- Reviewable:end -->
