### PR TITLE
[Objects] Send the login self-player bootstrap as one packet

### DIFF
--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -710,13 +710,10 @@ void MopUpdateObject::BuildDestroyObject(WorldPacket& out, uint64 guid, bool ani
     out.WriteByteSeq(bytes[5]);
 }
 
-void MopUpdateObject::BuildSelfCreate(WorldPacket& out, const SelfPlayer& e)
+void MopUpdateObject::AppendSelfCreateBlock(ByteBuffer& out, const SelfPlayer& e,
+    StaticField const* extraFields, uint32 extraFieldCount)
 {
-    out.Initialize(SMSG_UPDATE_OBJECT);
-
-    // ---- packet header ----
-    out << uint16(e.mapId);
-    out << uint32(1);                    // one update block, no out-of-range section
+    MANGOS_ASSERT(extraFields || extraFieldCount == 0);
 
     SimpleLivingMovement movement{};
     movement.guid = e.guid;
@@ -768,6 +765,37 @@ void MopUpdateObject::BuildSelfCreate(WorldPacket& out, const SelfPlayer& e)
         { 69, e.displayId },                    // UNIT_FIELD_DISPLAY_ID (+0x3D)
         { 70, e.nativeDisplayId },              // UNIT_FIELD_NATIVE_DISPLAY_ID (+0x3E)
     };
-    AppendSimpleLivingCreateBlock(out, 2, e.guid, 4, movement, fields,
-        uint32(sizeof(fields) / sizeof(fields[0])));
+    const uint32 coreCount = uint32(sizeof(fields) / sizeof(fields[0]));
+
+    if (extraFieldCount == 0)
+    {
+        AppendSimpleLivingCreateBlock(out, 2, e.guid, 4, movement, fields, coreCount);
+        return;
+    }
+
+    // The core block ends at UNIT_FIELD_NATIVE_DISPLAY_ID (70) and every
+    // projected self-player field sits above it - the lowest is PLAYER_FLAGS at
+    // 162 - so appending preserves the ascending order the values serializer
+    // requires. Assert it rather than trust it: a caller that passed unsorted
+    // or overlapping fields would otherwise trip the serializer's own assert
+    // with no indication of which side was wrong.
+    MANGOS_ASSERT(extraFields[0].index > fields[coreCount - 1].index);
+
+    std::vector<StaticField> combined;
+    combined.reserve(coreCount + extraFieldCount);
+    combined.insert(combined.end(), fields, fields + coreCount);
+    combined.insert(combined.end(), extraFields, extraFields + extraFieldCount);
+    AppendSimpleLivingCreateBlock(out, 2, e.guid, 4, movement, combined.data(),
+        uint32(combined.size()));
+}
+
+void MopUpdateObject::BuildSelfCreate(WorldPacket& out, const SelfPlayer& e)
+{
+    out.Initialize(SMSG_UPDATE_OBJECT);
+
+    // ---- packet header ----
+    out << uint16(e.mapId);
+    out << uint32(1);                    // one update block, no out-of-range section
+
+    AppendSelfCreateBlock(out, e, nullptr, 0);
 }

--- a/src/game/Server/MopUpdateObject.h
+++ b/src/game/Server/MopUpdateObject.h
@@ -318,8 +318,18 @@ namespace MopUpdateObject
         uint32 displayId, nativeDisplayId;
     };
 
+    /// Append one CREATE_OBJECT2 block for the self player (living, stationary
+    /// at login) to an existing update stream, so it can share a packet with
+    /// the item creates the way retail's login burst does.
+    ///
+    /// \a extraFields are appended after the fixed core block, which ends at
+    /// index 70. They must already be in 18414 index order and start above 70
+    /// - the output of TranslateSelfPlayerFields satisfies both.
+    void AppendSelfCreateBlock(ByteBuffer& out, const SelfPlayer& e,
+        StaticField const* extraFields, uint32 extraFieldCount);
+
     /// Build a complete SMSG_UPDATE_OBJECT packet holding one CREATE_OBJECT2
-    /// block for the self player (living, stationary at login).
+    /// block for the self player, carrying the core fields only.
     void BuildSelfCreate(WorldPacket& out, const SelfPlayer& e);
 }
 

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -115,7 +115,7 @@ add_test(NAME mop_initial_self_appearance_source
     COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_initial_self_appearance_source_test.cmake)
 
-foreach(mutation IN ITEMS visible_item_feed combined_builder skill_feed questlog_feed)
+foreach(mutation IN ITEMS visible_item_feed combined_builder skill_feed questlog_feed values_block_seed)
     add_test(NAME mop_initial_self_appearance_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/mop_initial_self_appearance_source_test.cmake
+++ b/src/game/Server/tests/mop_initial_self_appearance_source_test.cmake
@@ -7,8 +7,13 @@ if(MUTATION STREQUAL "visible_item_feed")
         map_source "${map_source}")
 elseif(MUTATION STREQUAL "combined_builder")
     string(REPLACE
-        "MopUpdateObject::AppendSelfPlayerValuesBlock"
+        "MopUpdateObject::TranslateSelfPlayerFields"
         "MopUpdateObject::AppendSelfInventoryValuesBlock"
+        map_source "${map_source}")
+elseif(MUTATION STREQUAL "values_block_seed")
+    string(REPLACE
+        "MopUpdateObject::AppendSelfCreateBlock"
+        "MopUpdateObject::AppendSelfPlayerValuesBlock"
         map_source "${map_source}")
 elseif(MUTATION STREQUAL "questlog_feed")
     string(REPLACE
@@ -58,8 +63,11 @@ require_once(
     "MopUpdateObject::SelfQuestLogSourceStart"
     "initial self quest-log snapshot")
 require_once(
-    "MopUpdateObject::AppendSelfPlayerValuesBlock"
-    "combined initial self VALUES builder")
+    "MopUpdateObject::TranslateSelfPlayerFields"
+    "combined initial self projection")
+require_once(
+    "MopUpdateObject::AppendSelfCreateBlock"
+    "seed carried in the self create block")
 
 string(FIND "${self_body}"
     "MopUpdateObject::AppendSelfInventoryValuesBlock" inventory_only)
@@ -68,7 +76,20 @@ if(NOT inventory_only EQUAL -1)
         "initial self snapshot regressed to the inventory-only VALUES builder")
 endif()
 
-# AppendSelfPlayerValuesBlock asserts strictly ascending source indices. The
+# The seeded fields must ride IN the create block, not arrive after it as a
+# VALUES update. The client fires UI feedback for a value it sees CHANGE but
+# not for one present in the create, so seeding via VALUES is what made login
+# play the money sound, a spurious quest-accept sound and skill-up
+# announcements. Retail carries these in the create; regressing to
+# AppendSelfPlayerValuesBlock here would bring all three back.
+string(FIND "${self_body}"
+    "MopUpdateObject::AppendSelfPlayerValuesBlock" post_create_seed)
+if(NOT post_create_seed EQUAL -1)
+    message(FATAL_ERROR
+        "initial self seed regressed to a post-create VALUES block")
+endif()
+
+# TranslateSelfPlayerFields asserts strictly ascending source indices. The
 # quest-log range is 166..415, below visible items at 916, so its loop must be
 # emitted first or the block is built out of order and trips that assert.
 string(FIND "${self_body}" "MopUpdateObject::SelfQuestLogSlotCount" questlog_pos)

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -1064,6 +1064,135 @@ int main(int /*argc*/, char** /*argv*/)
     CHECK(dyn == 0);                                           // no dynamic fields
     CHECK(p.rpos() == p.size());                               // consumed to the end
 
+    // The login burst appends the projected self fields to this same create
+    // block, so they ride in the create rather than arriving afterwards as a
+    // VALUES block. Retail orders the login packet items-first, self-last.
+    {
+        // Core-only must be byte-identical whether reached through
+        // BuildSelfCreate or the block writer it now delegates to.
+        ByteBuffer bare;
+        MopUpdateObject::AppendSelfCreateBlock(bare, e, nullptr, 0);
+        CHECK(bare.size() + 6 == p.size());
+        CHECK(bare.size() + 6 == p.size() &&
+            std::memcmp(bare.contents(), p.contents() + 6, bare.size()) == 0);
+
+        // Two projected fields either side of a 32-bit mask boundary, both
+        // above the core block's last index (70).
+        const MopUpdateObject::StaticField extra[] =
+        {
+            { 162, 0x00000010u },        // PLAYER_FLAGS, lowest projected field
+            { 1149, 0x0000BEEFu },       // coinage low
+        };
+        ByteBuffer seeded;
+        MopUpdateObject::AppendSelfCreateBlock(seeded, e, extra, 2);
+
+        // Two more fields, and the mask grows to cover index 1149.
+        CHECK(seeded.size() == bare.size() + 2 * 4 + (1149 / 32 + 1 - 3) * 4);
+
+        // Decode the mask from the head of the values block. Everything before
+        // it is identical to the core-only block, so its offset is known.
+        const size_t valuesOffset = bare.size() - 114;
+        seeded.rpos(valuesOffset);
+        uint8 seededBlocks; seeded >> seededBlocks;
+        CHECK(seededBlocks == 1149 / 32 + 1);
+        std::vector<uint32> seededMask(seededBlocks);
+        for (uint8 i = 0; i < seededBlocks; ++i) { seeded >> seededMask[i]; }
+        auto seededBit = [&](int idx)
+        {
+            return (seededMask[idx / 32] >> (idx % 32)) & 1u;
+        };
+        CHECK(seededBit(70));            // last core field still present
+        CHECK(seededBit(162));           // appended
+        CHECK(seededBit(1149));          // appended
+        CHECK(!seededBit(163));          // nothing invented in between
+
+        // Values stay in index order: the 25 core values, then the two extras.
+        for (int i = 0; i < 25; ++i) { uint32 v; seeded >> v; }
+        uint32 v162, v1149;
+        seeded >> v162; seeded >> v1149;
+        CHECK(v162 == 0x00000010u);
+        CHECK(v1149 == 0x0000BEEFu);
+        uint8 seededDyn; seeded >> seededDyn;
+        CHECK(seededDyn == 0);
+        CHECK(seeded.rpos() == seeded.size());
+    }
+
+    // The real login path feeds LEGACY indices spanning every range Map.cpp
+    // seeds, projects them, and hands the result to the create block. The
+    // projection is not monotonic in general - ranges shift by +5, +7 and +8
+    // and the quest log re-strides 5->15 - so the property that matters is
+    // that it stays ascending across each range BOUNDARY for this input.
+    {
+        MopUpdateObject::StaticField legacy[] =
+        {
+            { 157, 0x00000010u },        // PLAYER_FLAGS      -> 162
+            { 166, 27353u },             // quest slot 0 id   -> 171 (whole slot)
+            { 167, 0u },
+            { 168, 0u },
+            { 169, 0u },
+            { 170, 0u },
+            { 916, 12345u },             // visible item 1    -> 921
+            { 960, 0x0000ABCDu },        // inventory slot 0  -> 965
+            { 1142, 0x0000BEEFu },       // coinage low       -> 1149
+            { 1146, 0x00010002u },       // skill line 0      -> 1153
+            { 1619, 0xFFFFFFFFu },       // explored zone 0   -> 1627
+        };
+        const uint32 legacyCount = uint32(sizeof(legacy) / sizeof(legacy[0]));
+
+        std::vector<MopUpdateObject::StaticField> projected;
+        MopUpdateObject::TranslateSelfPlayerFields(legacy, legacyCount, projected);
+
+        // Quest slots expand 5 words to 15, so the count grows.
+        CHECK(projected.size() == legacyCount - 5 + 15);
+        CHECK(projected.front().index == 162);
+        CHECK(projected.front().index > 70);   // clears the core block
+        CHECK(projected.back().index == 1627);
+        for (size_t i = 1; i < projected.size(); ++i)
+        {
+            CHECK(projected[i - 1].index < projected[i].index);
+        }
+
+        // Must not trip the serializer's ascending assert when appended.
+        ByteBuffer real;
+        MopUpdateObject::AppendSelfCreateBlock(real, e, projected.data(),
+            uint32(projected.size()));
+        CHECK(real.size() > 0);
+
+        // Retail orders the login packet item creates first, self create last.
+        // Verify the two blocks decode in that order from one stream.
+        ByteBuffer stream;
+        uint32 itemValues[MopUpdateObject::ItemFieldCount] = { 0 };
+        itemValues[0] = 0x22u;                 // OBJECT_FIELD_GUID low
+        itemValues[4] = 3u;                    // OBJECT_FIELD_TYPE, Item
+        MopUpdateObject::AppendInventoryCreateBlock(stream, 0x22, 1, itemValues,
+            MopUpdateObject::ItemFieldCount);
+        const size_t selfBlockStart = stream.size();
+        MopUpdateObject::AppendSelfCreateBlock(stream, e, projected.data(),
+            uint32(projected.size()));
+
+        stream.rpos(0);
+        uint8 firstType; stream >> firstType;
+        CHECK(firstType == 1);                 // CREATE_OBJECT for the item
+        uint8 firstGuidMask; stream >> firstGuidMask;
+        for (int i = 0; i < 8; ++i)
+        {
+            if (firstGuidMask & (1 << i)) { uint8 b; stream >> b; }
+        }
+        uint8 firstTypeId; stream >> firstTypeId;
+        CHECK(firstTypeId == 1);               // TYPEID_ITEM
+
+        stream.rpos(selfBlockStart);
+        uint8 secondType; stream >> secondType;
+        CHECK(secondType == 2);                // CREATE_OBJECT2 for the player
+        uint8 secondGuidMask; stream >> secondGuidMask;
+        for (int i = 0; i < 8; ++i)
+        {
+            if (secondGuidMask & (1 << i)) { uint8 b; stream >> b; }
+        }
+        uint8 secondTypeId; stream >> secondTypeId;
+        CHECK(secondTypeId == 4);              // TYPEID_PLAYER, last
+    }
+
     if (g_failures == 0) { std::printf("ALL PASS\n"); return 0; }
     std::printf("%d FAILURES\n", g_failures);
     return 1;

--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -1933,20 +1933,31 @@ void Map::SendInitSelf(Player* player)
     sp.displayId = player->GetDisplayId();
     sp.nativeDisplayId = player->GetNativeDisplayId();
 
-    WorldPacket packet;
-    MopUpdateObject::BuildSelfCreate(packet, sp);
-    player->GetSession()->SendPacket(&packet);
-
-    // Inventory objects must exist client-side before the self player links to
-    // them. Player's existing traversal emits top-level items/bags, while Bag's
+    // One packet, item creates first, the self player's create block last -
+    // measured from the 18414 retail login burst, where 62 of 62 fully
+    // accounted packets order it that way and none put the player first.
+    //
+    // The self create carries its inventory links in the same packet that
+    // creates those items, and retail does this too: its self create block
+    // references items whose own create blocks appear LATER in the same byte
+    // stream. An earlier comment here asserted the opposite - that inventory
+    // objects must exist client-side before the player links to them - and
+    // that is simply not how the client behaves.
+    //
+    // Player's existing traversal emits top-level items/bags, while Bag's
     // override recursively emits its contents.
     UpdateData inventoryData(player->GetMapId());
     player->BuildCreateUpdateBlockForPlayer(&inventoryData, player);
 
-    // BuildSelfCreate carries only the fixed login core, so seed the client's
-    // visible equipment here as well as its inventory links. Otherwise the
-    // first unequip sends a zero the client already assumes and leaves the
-    // login-time model displayed until a later nonzero equip update.
+    // The core create block carries only the fixed login fields, so seed the
+    // client's visible equipment here as well as its inventory links.
+    // Otherwise the first unequip sends a zero the client already assumes and
+    // leaves the login-time model displayed until a later nonzero equip update.
+    //
+    // Everything below rides IN the create rather than arriving afterwards as
+    // a VALUES block. That distinction is audible: a value the client sees
+    // change - rather than one present from the start - fires the matching UI
+    // feedback, which is why coinage used to play the money sound on login.
     std::vector<MopUpdateObject::StaticField> selfFields;
     selfFields.reserve(MopUpdateObject::SelfQuestLogFieldCount +
         MopUpdateObject::ObserverVisibleItemFieldCount +
@@ -2039,19 +2050,24 @@ void Map::SendInitSelf(Player* player)
         }
     }
 
+    // Project the legacy indices to their 18414 positions, then hand them to
+    // the create block. The projection preserves ascending order and its
+    // lowest output (PLAYER_FLAGS -> 162) sits above the core block's last
+    // field (70), which is what AppendSelfCreateBlock requires.
+    std::vector<MopUpdateObject::StaticField> projectedFields;
     if (!selfFields.empty())
     {
-        MopUpdateObject::AppendSelfPlayerValuesBlock(inventoryData.GetBuffer(), sp.guid,
-            selfFields.data(), uint32(selfFields.size()));
-        inventoryData.AddUpdateBlock();
+        MopUpdateObject::TranslateSelfPlayerFields(selfFields.data(),
+            uint32(selfFields.size()), projectedFields);
     }
 
-    if (inventoryData.HasData())
-    {
-        WorldPacket inventoryPacket;
-        inventoryData.BuildPacket(&inventoryPacket);
-        player->GetSession()->SendPacket(&inventoryPacket);
-    }
+    MopUpdateObject::AppendSelfCreateBlock(inventoryData.GetBuffer(), sp,
+        projectedFields.data(), uint32(projectedFields.size()));
+    inventoryData.AddUpdateBlock();
+
+    WorldPacket loginPacket;
+    inventoryData.BuildPacket(&loginPacket);
+    player->GetSession()->SendPacket(&loginPacket);
 }
 
 /**


### PR DESCRIPTION
## What changed

Login sent **two** `SMSG_UPDATE_OBJECT`s:

1. the self player's CREATE block (core fields, indices 0..70)
2. the item/bag CREATE blocks, **plus a separate VALUES block** re-stating the player's seeded fields

Now it sends **one**: item creates first, self create last, seeded fields appended into that create.

## Why this shape — measured, not assumed

From the 18414 retail corpus:

- the login burst is **one packet**; in the sampled login `blockCount = 154`, indices 0..152 are Item/Container creates and index **153 is the self Player create**
- across **62** fully-accounted packets: **62/62** item creates before the self create, **0/62** player first

It also removes a constraint that was never real. The old comment claimed *"inventory objects must exist client-side before the self player links to them."* Retail's own self create references inventory GUIDs whose create blocks appear **later in the same packet** — verified on a 49-block packet where the player block at index 37 links items at indices 38..48. Forward references within a packet are legal.

## Why it matters

Not tidiness. **A field the client sees *change* fires the matching UI feedback; a field present in the create does not.** Seeding via a post-create VALUES block is why login played the money sound, and the same mechanism drove a spurious quest-accept sound and skill-up announcements.

## The part worth scrutinising

The projection is **not monotonic in general** — ranges shift by +5, +7 and +8, and the quest log re-strides 5→15. Ascending output is a property of the ranges this caller feeds, not of the function. Every boundary was walked and holds:

`157→162` · quests `166..415→171..920` · visible items `916..953→921..958` · inventory `960..1131→965..1136` · progression `1142..1145→1149..1152` · skills `1146..1593→1153..1600` · explored/rest `1619..1819→1627..1827`

`AppendSelfCreateBlock` asserts only that the first appended field clears the core block (>70); the serializer then validates the full combined sequence.

Capacity and size, both checked: the login seed tops out at index 1827 = 58 mask dwords against a 63-dword ceiling; a conservative worst-case inventory stays well under the `0x7FFFF` framing limit.

## Guard change

`mop_initial_self_appearance` asserted the **old** design. Rather than relax it, it now guards the new invariant and is stricter: the seed must ride in the create, and a post-create `AppendSelfPlayerValuesBlock` in `SendInitSelf` is an explicit failure with its own `values_block_seed` mutation arm.

That regression would otherwise be **silent** — nothing breaks, the sounds just come back.

## Testing

- full suite **1088/1088**
- `mop_updateobject` extended: core-only path byte-identical through either entry point; a realistic legacy seed spanning every Map range projected and asserted ascending end to end; item block then self block decoded from one stream confirming `TYPEID_ITEM` first, `TYPEID_PLAYER` last
- `mop_initial_self_appearance` 6/6 including the new arm

## Review status — read this precisely

Codex reviewed the **code** change: `APPROVE WITH FOLLOW-UP`, no blocking or important findings. It independently verified the range boundaries, mask capacity, packet size, the now-unconditional send, and found no dependency on two packets or player-first ordering.

**The diff it reviewed predates two test-only additions**: the `mop_initial_self_appearance` guard rework and the integration coverage added in response to its own MINOR. Neither touches production code, but "Codex reviewed this" should not imply more than it covered.

**Not proven:** no live client test. The three sounds are the observable symptom and only a real login confirms they stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/46)
<!-- Reviewable:end -->
