### PR TITLE
[Objects] Gate the power-type update on IsInWorld()

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -2630,10 +2630,37 @@ void Unit::SetPowerType(Powers new_powertype)
             SetPower(new_powertype, curValue);
         }
 
-        // send power type update to client
-        WorldPacket data;
-        MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));
-        SendMessageToSet(&data, true);
+        // Gated on IsInWorld() exactly as the sibling emitter in
+        // Unit::SetPowerByIndex is. Without it this fires during login, before
+        // the client knows the unit exists, and lands as the FIRST SMSG after
+        // CMSG_PLAYER_LOGIN - the slot retail fills with
+        // SMSG_ACCOUNT_DATA_TIMES.
+        //
+        // The path is Player::LoadFromDB -> InitStatsForLevel ->
+        // InitDataForForm -> SetPowerType. LoadFromDB restores race, class and
+        // gender into UNIT_FIELD_BYTES_0 but never byte 3, so GetPowerType()
+        // still reads 0 (POWER_MANA) and InitDataForForm's
+        // `GetPowerType() != DisplayPower` guard trips once per login for every
+        // class whose display power is not mana. Player::SendMessageToSet
+        // delivers the self copy whether or not the player is in world, so
+        // nothing else suppressed it.
+        //
+        // Nothing is lost by withholding it: SetPowerType runs before
+        // Map::Add, so byte 3, UNIT_FIELD_POWER1+i and UNIT_FIELD_MAXPOWER1+i
+        // all ship inside the self create block Map::SendInitSelf then builds.
+        //
+        // In-world invocations keep their packet; construction and load-time
+        // invocations rely on that later create snapshot instead. Creature and
+        // pet paths are NOT in world by definition - Creature::UpdateEntry runs
+        // before world addition and pet loading calls this before map->Add -
+        // but they were already covered, because the non-player
+        // SendMessageToSet is itself gated on IsInWorld().
+        if (IsInWorld())
+        {
+            WorldPacket data;
+            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));
+            SendMessageToSet(&data, true);
+        }
     }
 }
 

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -1702,7 +1702,7 @@ add_test(NAME mop_power_update_packets_source
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_power_update_packets_source_test.cmake)
 
 foreach(mutation IN ITEMS mask_order count_width byte_order primary_sender switch_sender
-        registration allowlist reference)
+        switch_sender_gate registration allowlist reference)
     add_test(NAME mop_power_update_packets_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/mop_power_update_packets_source_test.cmake
+++ b/src/game/Server/tests/mop_power_update_packets_source_test.cmake
@@ -28,6 +28,11 @@ elseif(MUTATION STREQUAL "registration")
 elseif(MUTATION STREQUAL "allowlist")
     string(REPLACE "case SMSG_POWER_UPDATE:"
         "case REMOVED_SMSG_POWER_UPDATE:" session_source "${session_source}")
+elseif(MUTATION STREQUAL "switch_sender_gate")
+    string(REPLACE
+        "        if (IsInWorld())\n        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
+        "        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
+        unit_source "${unit_source}")
 elseif(MUTATION STREQUAL "reference")
     string(REPLACE "SMSG_POWER_UPDATE                              0x109F  ACTIVE"
         "SMSG_POWER_UPDATE                              0x109F  DORMANT"
@@ -68,6 +73,14 @@ require_once("${power_source}"
 require_once("${unit_source}"
     "MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
     "power-type switch sender")
+# Ungated, this fires during Player::LoadFromDB -> InitStatsForLevel ->
+# InitDataForForm, before the client knows the unit exists, and lands as the
+# first SMSG after CMSG_PLAYER_LOGIN - the slot retail gives to
+# SMSG_ACCOUNT_DATA_TIMES. Player::SendMessageToSet delivers the self copy
+# regardless of IsInWorld(), so nothing else holds it back.
+require_once("${unit_source}"
+    "        if (IsInWorld())\n        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
+    "power-type switch sender in-world gate")
 require_once("${opcode_registry}"
     "DefS(SMSG_POWER_UPDATE, \"SMSG_POWER_UPDATE\");"
     "power-update registration")


### PR DESCRIPTION
## Symptom

An `SMSG_POWER_UPDATE` arrived as the **first** SMSG after `CMSG_PLAYER_LOGIN` — the slot retail gives to `SMSG_ACCOUNT_DATA_TIMES`.

## Root cause

`Unit::SetPowerType` sent unconditionally. Its sibling emitter in `Unit::SetPowerByIndex` has always been gated on `IsInWorld()`; this one was not.

```
Player::LoadFromDB          CharacterHandler.cpp:791
 -> InitStatsForLevel()     PlayerLoadFromDB.cpp:501
 -> InitDataForForm()       Player.cpp:2730
 -> SetPowerType()          Player.cpp:4309-4311
 -> unconditional send      Unit.cpp:2634-2636
```

`LoadFromDB` restores race, class and gender into `UNIT_FIELD_BYTES_0` ([PlayerLoadFromDB.cpp:153-157](src/game/Object/PlayerLoadFromDB.cpp#L153-L157)) but **never byte 3**. So `GetPowerType()` reads 0 (`POWER_MANA`) and `InitDataForForm`'s `GetPowerType() != DisplayPower` guard trips once per login for every non-mana class. `Player::SendMessageToSet` delivers the self copy regardless of `IsInWorld()`, so nothing else held it back.

It lands at position 0 because `LoadFromDB` runs before `SendAccountDataTimes`, before `SMSG_LOGIN_VERIFY_WORLD`, and before `m_suppressWorldSends`.

## Correcting the earlier record

This was previously logged as **class-independent**. It isn't — it's **display-power driven**. Both original test subjects (warrior, monk) happened to be non-mana classes. A mage or priest never produced this packet at all.

The observed payloads are byte-exact predictions of [Unit.cpp:2611-2621](src/game/Object/Unit.cpp#L2611-L2621), not coincidences: monk energy 100 is `GetCreatePowers(POWER_ENERGY)`; warrior rage 0 is the `POWER_RAGE` special case.

## Nothing is lost

`SetPowerType` runs before `Map::Add`, so the final power type (byte 3 of field 30), current powers (34–38) and max powers (40–44) all ship inside the self create block. In-world switches keep their packet. Construction and load-time invocations rely on the create snapshot — and the creature/pet paths were already covered, because their `SendMessageToSet` is itself `IsInWorld()`-gated.

## Testing

- full suite **1089/1089**
- `mop_power_update_packets_source` 10/10, including a new `switch_sender_gate` `WILL_FAIL` arm that strips the guard

**Live prediction, stated narrowly** — an earlier, broader version of this was wrong. The regen tick (see below) can legitimately emit a power update later for any class, so "a mage emits nothing" is **not** the right test. The correct claim is: **no power update before `Map::Add`, and none in the first post-login packet slot.**

## Two adjacent defects found while tracing — deliberately not fixed here

- **[SpellAuraShapeshift.cpp:467](src/game/WorldHandlers/SpellAuraShapeshift.cpp#L467)** — form removal calls `SetPowerType` without comparing the current type, *and* sends `GetCreatePowers(POWER_MANA)` rather than the player's actual mana. The value-correctness half is the more serious part.
- **`m_regenTimer` starts at 0**, so `Player::Update` runs a full regen tick on the first world update after `Map::Add`.

Reviewed by Codex — `APPROVE WITH FOLLOW-UP`, no blocking findings. It confirmed both adjacent defects, corrected the over-broad live prediction, and caught a false claim in my code comment (creature/pet paths are *not* in-world by definition), which is fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/47)
<!-- Reviewable:end -->
