### PR TITLE
[Objects] Report real power, not the create value, on power-type change

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -2630,6 +2630,25 @@ void Unit::SetPowerType(Powers new_powertype)
             SetPower(new_powertype, curValue);
         }
 
+        // Report what the field actually holds, not curValue. Those agree for
+        // every type written above, but POWER_MANA is deliberately left alone,
+        // so curValue there is GetCreatePowers(POWER_MANA) - the base pool, not
+        // what the player has. A druid dropping form at 20% mana was being told
+        // it was at full base mana, and the client believed it until the next
+        // update happened to correct it.
+        //
+        // Nothing here validates that this unit's class HAS a slot for
+        // new_powertype, and GetPower() answers 0 for one it does not. Scripts
+        // can reach that: Eluna's SetPowerType checks only the MAX_POWERS
+        // range, not class support. Keep curValue in that case so the wire
+        // value is exactly what it was before this change, rather than
+        // silently becoming zero - the create value is at least a defensible
+        // answer for a power the unit cannot store.
+        const uint32 reportedValue =
+            (GetPowerIndex(new_powertype) == INVALID_POWER_INDEX)
+                ? curValue
+                : GetPower(new_powertype);
+
         // Gated on IsInWorld() exactly as the sibling emitter in
         // Unit::SetPowerByIndex is. Without it this fires during login, before
         // the client knows the unit exists, and lands as the FIRST SMSG after
@@ -2658,7 +2677,7 @@ void Unit::SetPowerType(Powers new_powertype)
         if (IsInWorld())
         {
             WorldPacket data;
-            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));
+            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), reportedValue);
             SendMessageToSet(&data, true);
         }
     }

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -1702,7 +1702,7 @@ add_test(NAME mop_power_update_packets_source
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_power_update_packets_source_test.cmake)
 
 foreach(mutation IN ITEMS mask_order count_width byte_order primary_sender switch_sender
-        switch_sender_gate registration allowlist reference)
+        switch_sender_gate reported_value druid_form_exit_guard registration allowlist reference)
     add_test(NAME mop_power_update_packets_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/mop_power_update_packets_source_test.cmake
+++ b/src/game/Server/tests/mop_power_update_packets_source_test.cmake
@@ -4,6 +4,7 @@ file(READ "${SOURCE_ROOT}/src/game/Object/Unit.cpp" unit_source)
 file(READ "${SOURCE_ROOT}/src/game/Server/Opcodes.cpp" opcode_registry)
 file(READ "${SOURCE_ROOT}/src/game/Server/Opcodes_reference.h" opcode_reference)
 file(READ "${SOURCE_ROOT}/src/game/Server/WorldSession.cpp" session_source)
+file(READ "${SOURCE_ROOT}/src/game/WorldHandlers/SpellAuraShapeshift.cpp" shapeshift_source)
 
 if(MUTATION STREQUAL "mask_order")
     string(REPLACE "out.WriteGuidMask<4, 6, 7, 5, 2, 3, 0, 1>(guid);"
@@ -20,7 +21,7 @@ elseif(MUTATION STREQUAL "primary_sender")
     string(REPLACE "MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(power), uint32(val));"
         "/* removed primary power-update sender */" power_source "${power_source}")
 elseif(MUTATION STREQUAL "switch_sender")
-    string(REPLACE "MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
+    string(REPLACE "MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), reportedValue);"
         "/* removed power-type switch sender */" unit_source "${unit_source}")
 elseif(MUTATION STREQUAL "registration")
     string(REPLACE "DefS(SMSG_POWER_UPDATE, \"SMSG_POWER_UPDATE\");"
@@ -30,9 +31,17 @@ elseif(MUTATION STREQUAL "allowlist")
         "case REMOVED_SMSG_POWER_UPDATE:" session_source "${session_source}")
 elseif(MUTATION STREQUAL "switch_sender_gate")
     string(REPLACE
-        "        if (IsInWorld())\n        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
-        "        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
+        "        if (IsInWorld())\n        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), reportedValue);"
+        "        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), reportedValue);"
         unit_source "${unit_source}")
+elseif(MUTATION STREQUAL "reported_value")
+    string(REPLACE "                : GetPower(new_powertype);"
+        "                : curValue;" unit_source "${unit_source}")
+elseif(MUTATION STREQUAL "druid_form_exit_guard")
+    string(REPLACE
+        "if (target->getClass() == CLASS_DRUID && target->GetPowerType() != POWER_MANA)"
+        "if (target->getClass() == CLASS_DRUID)"
+        shapeshift_source "${shapeshift_source}")
 elseif(MUTATION STREQUAL "reference")
     string(REPLACE "SMSG_POWER_UPDATE                              0x109F  ACTIVE"
         "SMSG_POWER_UPDATE                              0x109F  DORMANT"
@@ -71,15 +80,28 @@ require_once("${power_source}"
     "MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(power), uint32(val));"
     "normal power-change sender")
 require_once("${unit_source}"
-    "MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
+    "MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), reportedValue);"
     "power-type switch sender")
 # Ungated, this fires during Player::LoadFromDB -> InitStatsForLevel ->
 # InitDataForForm, before the client knows the unit exists, and lands as the
 # first SMSG after CMSG_PLAYER_LOGIN - the slot retail gives to
 # SMSG_ACCOUNT_DATA_TIMES. Player::SendMessageToSet delivers the self copy
 # regardless of IsInWorld(), so nothing else holds it back.
+# POWER_MANA is deliberately left untouched by the block above, so curValue
+# there is GetCreatePowers(POWER_MANA) - the base pool, not what the player
+# holds. Reporting the field keeps both branches honest.
 require_once("${unit_source}"
-    "        if (IsInWorld())\n        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), uint32(curValue));"
+    "            (GetPowerIndex(new_powertype) == INVALID_POWER_INDEX)
+                ? curValue
+                : GetPower(new_powertype);"
+    "power-type switch reports the real field value, with the legacy fallback for a class-unsupported power")
+# Druid forms that already display mana must not re-announce an unchanged
+# power type when they end.
+require_once("${shapeshift_source}"
+    "if (target->getClass() == CLASS_DRUID && target->GetPowerType() != POWER_MANA)"
+    "druid form-exit power-type change guard")
+require_once("${unit_source}"
+    "        if (IsInWorld())\n        {\n            WorldPacket data;\n            MopCompactPackets::BuildPowerUpdate(data, GetObjectGuid(), uint8(new_powertype), reportedValue);"
     "power-type switch sender in-world gate")
 require_once("${opcode_registry}"
     "DefS(SMSG_POWER_UPDATE, \"SMSG_POWER_UPDATE\");"

--- a/src/game/WorldHandlers/SpellAuraShapeshift.cpp
+++ b/src/game/WorldHandlers/SpellAuraShapeshift.cpp
@@ -464,7 +464,11 @@ void Aura::HandleAuraModShapeshift(bool apply, bool Real)
             target->SetDisplayId(target->GetNativeDisplayId());
         }
 
-        if (target->getClass() == CLASS_DRUID)
+        // Only when it actually changes. Forms that already display mana
+        // (Moonkin, Tree) would otherwise re-announce an unchanged power type
+        // on every exit. The apply path at the top of this function guards the
+        // same way.
+        if (target->getClass() == CLASS_DRUID && target->GetPowerType() != POWER_MANA)
         {
             target->SetPowerType(POWER_MANA);
         }


### PR DESCRIPTION
## What was wrong

`Unit::SetPowerType` computed `curValue = GetCreatePowers(new_powertype)` and sent it — but the block that writes `curValue` into the field is **skipped for `POWER_MANA`**:

```cpp
if (new_powertype != POWER_MANA)   // <-- mana deliberately untouched
{
    SetMaxPower(new_powertype, maxValue);
    SetPower(new_powertype, curValue);
}
```

So a druid dropping form at 20% mana was told it was at **full base mana**, and the client believed it until some later update happened to correct it.

Now it reports `GetPower(new_powertype)` — the field itself — which is right in both branches: every other type has just been written from `curValue`, and mana was left alone.

## The edge case, and the contract chosen

Nothing validates that the unit's class *has* a slot for `new_powertype`, and `GetPower()` answers **0** for one it doesn't. Scripts can reach that — Eluna's `SetPowerType` checks only the `MAX_POWERS` range, not class support. So the fallback keeps `curValue` there:

```cpp
const uint32 reportedValue =
    (GetPowerIndex(new_powertype) == INVALID_POWER_INDEX)
        ? curValue
        : GetPower(new_powertype);
```

The wire value in that case is **exactly what it was before this change**. The create value is at least a defensible answer for a power the unit cannot store; 0 is not. Codex raised this as its one IMPORTANT finding and offered two contracts — preserve the fallback, or reject unsupported combinations before writing byte 3. I took the first, as the narrower change: byte 3 is still written exactly as before.

## Second fix

Druid form-exit now only calls `SetPowerType` when the type actually changes, matching the guard the apply path already uses at [SpellAuraShapeshift.cpp:368](src/game/WorldHandlers/SpellAuraShapeshift.cpp#L368) — verified rather than assumed. Mana-displaying forms (Moonkin, Tree) were re-announcing an unchanged power type on every exit.

## Provenance

Both defects were found by Codex while reviewing the `IsInWorld()` gate in #47, and both were confirmed rather than speculative.

## Testing

- full suite **1091/1091**
- `mop_power_update_packets_source` 12/12, with two new `WILL_FAIL` arms: `reported_value` reverts to `curValue`, `druid_form_exit_guard` strips the type comparison
- the guard pins the complete ternary including the fallback branch, not just the `GetPower` call

Reviewed by Codex twice — `APPROVE WITH FOLLOW-UP` on the first pass, then **`APPROVE`** on a focused re-review of the fallback.

**Not proven:** no live test. The observable is a druid dropping form at partial mana and the client showing the real value rather than base mana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/48)
<!-- Reviewable:end -->
