### PR TITLE
[Objects] Stop the MoP create gate hiding destructible gameobjects

### DIFF
--- a/src/game/Object/ObjectUpdate.cpp
+++ b/src/game/Object/ObjectUpdate.cpp
@@ -472,8 +472,6 @@ bool Object::CanBuildMopCreateUpdate() const
         uint16 const supportedFlags = UPDATEFLAG_HAS_POSITION | UPDATEFLAG_ROTATION;
         MopUpdateObject::StationaryGameObjectEligibility eligibility{};
         eligibility.hasTemplate = gameObject->GetGOInfo() != NULL;
-        eligibility.isDestructibleBuilding = eligibility.hasTemplate &&
-            gameObject->GetGoType() == GAMEOBJECT_TYPE_DESTRUCTIBLE_BUILDING;
         eligibility.isTransport = gameObject->IsTransport();
         eligibility.isBoarded = gameObject->IsBoarded();
         eligibility.hasStationaryPosition = (m_updateFlag & UPDATEFLAG_HAS_POSITION) != 0;

--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -191,7 +191,40 @@ bool MopUpdateObject::CanUseSimpleUnitMovement(SimpleUnitEligibility const& elig
 
 bool MopUpdateObject::CanUseStationaryGameObjectMovement(StationaryGameObjectEligibility const& eligibility)
 {
-    return eligibility.hasTemplate && !eligibility.isDestructibleBuilding && !eligibility.isTransport &&
+    // Reject only what the encoder cannot represent, exactly as the unit gate
+    // does. AppendStationaryGameObjectMovement writes a state-invariant layout:
+    // stationary position plus rotation, every optional block declared absent.
+    // Nothing in it varies with the object's TYPE.
+    //
+    // Being a destructible building was rejected here on type alone, and a
+    // destructible building's movement is identical to any other stationary
+    // gameobject's - it carries UPDATEFLAG_HAS_POSITION | UPDATEFLAG_ROTATION
+    // like the rest. Its damage state lives in the values block, not the
+    // movement block. Rejecting it meant no create block was emitted at all,
+    // so the client was never told the object existed and never even sent
+    // CMSG_GAMEOBJECT_QUERY for it: 147 spawns invisible, 88 of them
+    // open-world scenery - harbour ships on map 0, Gooblin Boats on map 1,
+    // Jade Forest ship cosmetics on 870, Forlorn Spires and a Moonwell on 861.
+    //
+    // Confirmed in game at -7259.48 4101.91 -1.73 on map 0, with a control
+    // that rules out grid loading, phasing, range and the map together: an
+    // ordinary Rope Ladder (203735) thirteen yards away rendered and was
+    // queried, while Alliance Ship 000 (203400) was never queried and never
+    // appeared. Players see it as NPCs standing in mid-air, because creatures
+    // resting on these objects render correctly while their platform does not.
+    //
+    // The residual cost is bounded but real, and NOT self-correcting. The
+    // gameobject projection stops at target index 17 and never emits
+    // GAMEOBJECT_BYTES_1, whose byte 3 carries destructible animation and
+    // health progress - and the incremental VALUES path reuses the same
+    // projection, so that field never arrives later either. Damaged and
+    // destroyed transitions still propagate through GAMEOBJECT_FLAGS and
+    // GAMEOBJECT_DISPLAYID, which are emitted. The omission predates this
+    // change and applies to every gameobject type equally, so nothing here
+    // makes destructibles a special case; a mask-and-values block simply
+    // clears the bit for a field it does not send, and stays well formed.
+    // Rendering with a default sub-state beats not rendering at all.
+    return eligibility.hasTemplate && !eligibility.isTransport &&
         !eligibility.isBoarded && eligibility.hasStationaryPosition && eligibility.hasRotation &&
         !eligibility.hasUnsupportedMovement;
 }

--- a/src/game/Server/MopUpdateObject.h
+++ b/src/game/Server/MopUpdateObject.h
@@ -200,7 +200,6 @@ namespace MopUpdateObject
     struct StationaryGameObjectEligibility
     {
         bool hasTemplate;
-        bool isDestructibleBuilding;
         bool isTransport;
         bool isBoarded;
         bool hasStationaryPosition;

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -735,8 +735,14 @@ int main(int /*argc*/, char** /*argv*/)
     CHECK(!MopUpdateObject::CanUseStationaryGameObjectMovement(gameObjectEligibility));
     gameObjectEligibility.hasRotation = true; gameObjectEligibility.hasTemplate = false;
     CHECK(!MopUpdateObject::CanUseStationaryGameObjectMovement(gameObjectEligibility));
-    gameObjectEligibility.hasTemplate = true; gameObjectEligibility.isDestructibleBuilding = true;
-    CHECK(!MopUpdateObject::CanUseStationaryGameObjectMovement(gameObjectEligibility));
+    gameObjectEligibility.hasTemplate = true;
+    // Being a destructible building is deliberately absent from this struct.
+    // It was a rejection reason, on type alone, and hid 147 spawns - 88 of
+    // them open-world scenery. Movement does not vary with type, so there is
+    // nothing here to assert about it: the eligibility boundary no longer
+    // sees the type at all. Proving a type-33 object is now created needs an
+    // object-level test that builds a real GameObject, which this unit test
+    // has no fixture for.
 
     MopUpdateObject::PositionOnlyEligibility positionOnlyEligibility{};
     positionOnlyEligibility.hasPosition = true;


### PR DESCRIPTION
## Symptom

Destructible gameobjects were **invisible** — not mis-rendered, absent. The client was never told they existed, so it never even sent `CMSG_GAMEOBJECT_QUERY` for them.

`CanUseStationaryGameObjectMovement` rejected a gameobject for *being* a destructible building, so `Object::CanBuildMopCreateUpdate` returned false and no create block was emitted at all.

## Why the rejection was wrong

It was on **type**, not on anything the encoder cannot express. `AppendStationaryGameObjectMovement` takes only a position-and-rotation struct — no type, no `GameObject` — and writes a fixed layout with every optional block declared absent. **Type never enters the function**, so a destructible cannot encode differently from any other stationary gameobject.

## Live evidence, with a control

At `-7259.48 4101.91 -1.73` on map 0:

| Object | Type | Result |
|---|---|---|
| Rope Ladder **203735** | 22, ordinary | `CMSG_GAMEOBJECT_QUERY` fires → renders |
| Alliance Ship 000 **203400** | 33, destructible | never queried → absent |
| Tidebreaker Deckhand **301870** | creature | renders at z = 10.5, floating where the deck should be |

The rope ladder thirteen yards away eliminates grid loading, phasing, range and the map in one stroke. Every other creature nearby sits on the seabed at z = -263.

**Scale**, from Four's own world DB: 157 templates over 147 spawns, **88 of them open-world scenery** — harbour ships on map 0, Gooblin Boats on map 1, Jade Forest ship cosmetics on 870, Forlorn Spires and a Moonwell on 861. Not battleground walls, as was first assumed.

Players would report this as **NPCs standing in mid-air**, not as missing scenery, because creatures resting on these objects render correctly while their platform does not.

Same class as #42 (vehicle gate) and #32 (moving/combat unit gate).

## Residual cost — bounded, but not self-correcting

The gameobject projection stops at target index 17 and **never emits `GAMEOBJECT_BYTES_1`**, whose byte 3 carries destructible animation and health progress. The incremental VALUES path reuses the same projection, so it never arrives later either.

Damaged and destroyed transitions **do** propagate, via `GAMEOBJECT_FLAGS` and `GAMEOBJECT_DISPLAYID`.

That omission predates this change and applies to **every** gameobject type equally — chests and doors are equally without it — so nothing here makes destructibles a special case. A mask-and-values block clears the bit for a field it doesn't send and stays well formed, so the packet cannot be mis-parsed.

An earlier draft of this PR said the wrong state would correct itself "once its values say otherwise". That was wrong, and is corrected above.

## Testing

- full suite **1089/1089**
- `mop_updateobject` and the gameobject group pass

**Coverage gap, stated plainly:** removing `isDestructibleBuilding` means the eligibility struct no longer *sees* the type, so there is nothing left to assert about it at unit level. Proving a type-33 object is now created needs an object-level fixture that builds a real `GameObject`, which this test has none.

## Live checks this needs

1. **Alliance Ship 000 renders and `CMSG_GAMEOBJECT_QUERY` fires for 203400** — the direct prediction.
2. **One damage transition on a destructible**, inspecting both the VALUES update and `SMSG_DESTRUCTIBLE_BUILDING_DAMAGE`. Codex flags that this packet still uses a legacy sequential packed-GUID body while the opcode is marked dormant/low-confidence — pre-existing, and not caused by this change, but it means the damaged-object path is unproven rather than known-good.

Reviewed by Codex — `APPROVE WITH FOLLOW-UP`, no blocking. It independently confirmed the movement path is type-invariant, that no `isDestructibleBuilding` references remain, and that transport classification is type-based (types 11 and 15 only) so it cannot interact with type 33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/49)
<!-- Reviewable:end -->
