### PR TITLE
[Objects] Project the three packed PLAYER_BYTES words

### DIFF
--- a/src/game/Object/ObjectUpdate.cpp
+++ b/src/game/Object/ObjectUpdate.cpp
@@ -317,6 +317,16 @@ namespace
         addTranslated(UNIT_FIELD_DISPLAYID);
         addTranslated(UNIT_FIELD_NATIVEDISPLAYID);
         addTranslated(UNIT_FIELD_MOUNTDISPLAYID, true);
+        // The packed appearance words. These must be in the CREATE, not left
+        // to the changed-value path: Object::ClearUpdateMask drops the change
+        // flags on entering the world, and PLAYER_BYTES in particular never
+        // changes again afterwards, so an observer that only ever saw the
+        // create would otherwise never learn this player's hair, facial hair
+        // or gender at all. Zero is meaningful for all three (male, sober,
+        // no arena faction), so they are emitted unconditionally.
+        addTranslated(PLAYER_BYTES);
+        addTranslated(PLAYER_BYTES_2);
+        addTranslated(PLAYER_BYTES_3);
         for (uint16 i = 0; i < MopUpdateObject::ObserverVisibleItemFieldCount; ++i)
         {
             addTranslated(uint16(MopUpdateObject::ObserverVisibleItemSourceStart + i), true);
@@ -634,6 +644,16 @@ void Object::BuildValuesUpdateBlockForPlayer(UpdateData* data, Player* target) c
             // of the quest log because the serializer requires ascending
             // legacy indices.
             addIfChanged(PLAYER_FLAGS);
+            // Rest state lives in byte 3 of PLAYER_BYTES_2 and changes when the
+            // player enters or leaves an inn - i.e. always AFTER login, so the
+            // login seed alone would never deliver a single transition and
+            // GetRestState() would go stale the moment it mattered. Drunkenness
+            // (byte 1 of PLAYER_BYTES_3) and barber-shop appearance changes have
+            // the same shape. Ordered between PLAYER_FLAGS at 157 and the quest
+            // log at 166 to keep the legacy indices ascending.
+            addIfChanged(PLAYER_BYTES);
+            addIfChanged(PLAYER_BYTES_2);
+            addIfChanged(PLAYER_BYTES_3);
 
             // QuestLogFrame renders a slot only once the client holds its
             // quest id, so an accepted quest never appears until these private

--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -105,6 +105,13 @@ bool MopUpdateObject::TranslateObserverPlayerIndex(uint16 legacyIndex, uint16& t
         case 63: targetIndex = 69; return true; // display ID
         case 64: targetIndex = 70; return true; // native display ID
         case 65: targetIndex = 71; return true; // mount display ID
+        // Packed appearance words, all PUBLIC in the legacy layout and all
+        // previously dropped here. Facial hair and gender are visible to
+        // other players, not just to the owner. See the self projection for
+        // where these indices come from.
+        case 161: targetIndex = 166; return true; // skin/face/hair/hair colour
+        case 162: targetIndex = 167; return true; // facial hair, rest state
+        case 163: targetIndex = 168; return true; // gender, drunk, arena faction
         default: return false;
     }
 }
@@ -503,6 +510,30 @@ void MopUpdateObject::TranslateSelfPlayerFields(StaticField const* sourceFields,
             // 11, and its absolute 18414 index is already pinned at 171 by the
             // quest-log projection, which puts the block base at 160.
             case 157: fields.push_back({ 162, value }); break;
+            // The three packed PLAYER_BYTES words. None was projected at all,
+            // in either path, despite Player.cpp:2933-2935 marking all three
+            // as visual bits - so rest state, facial hair and gender never
+            // reached any client.
+            //
+            // Indices read from the client's own CGPlayerData descriptor
+            // table (12-byte stride from dword_10F52B8, names written by
+            // sub_7A0B33), not interpolated: entry 6 "hairColorID", entry 7
+            // "restState", entry 8 "arenaFaction", against a block base of
+            // 160 pinned independently by entry 2 "playerFlags" at 162 and
+            // entry 11 "questLog" at 171. The client names each packed word
+            // after its byte 3, and all three names match the legacy byte-3
+            // meaning - hair colour, rest state, arena faction - which
+            // corroborates the mapping rather than merely fitting it.
+            //
+            // Byte 3 of 167 is what GetRestState() reads; without it the Lua
+            // returns nil and MainMenuBar.lua fails on the comparison at :119
+            // and the arithmetic at :202. Byte 0 of 168 is gender, which for
+            // a PLAYER the client reads from here rather than from
+            // UNIT_FIELD_SEX - the reason a female character used male voice
+            // and emote sounds while rendering correctly.
+            case 161: fields.push_back({ 166, value }); break;
+            case 162: fields.push_back({ 167, value }); break;
+            case 163: fields.push_back({ 168, value }); break;
             default:
                 MANGOS_ASSERT(false && "unsupported legacy self-player field");
                 break;

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -102,7 +102,7 @@ add_test(NAME mop_self_values_source
     COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_self_values_source_test.cmake)
 
-foreach(mutation IN ITEMS inventory_only health_feed progression_feed visible_item_feed skill_feed buyback_feed questlog_feed)
+foreach(mutation IN ITEMS inventory_only health_feed progression_feed visible_item_feed skill_feed buyback_feed questlog_feed packed_bytes_self_feed packed_bytes_observer_create)
     add_test(NAME mop_self_values_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/mop_self_values_source_test.cmake
+++ b/src/game/Server/tests/mop_self_values_source_test.cmake
@@ -27,6 +27,14 @@ elseif(MUTATION STREQUAL "buyback_feed")
         "for (uint16 i = MopUpdateObject::SelfBuybackSourceStart;"
         "for (uint16 i = 0; /* removed self buyback feed */"
         object_update "${object_update}")
+elseif(MUTATION STREQUAL "packed_bytes_self_feed")
+    string(REPLACE "            addIfChanged(PLAYER_BYTES_2);"
+        "            /* removed self packed-bytes feed */"
+        object_update "${object_update}")
+elseif(MUTATION STREQUAL "packed_bytes_observer_create")
+    string(REPLACE "        addTranslated(PLAYER_BYTES_2);"
+        "        /* removed observer packed-bytes create */"
+        object_update "${object_update}")
 elseif(MUTATION STREQUAL "questlog_feed")
     string(REPLACE
         "for (uint16 slot = 0; slot < MopUpdateObject::SelfQuestLogSlotCount; ++slot)"
@@ -96,3 +104,27 @@ if(NOT inventory_only EQUAL -1)
     message(FATAL_ERROR
         "self-player branch regressed to the inventory-only VALUES builder")
 endif()
+
+# Both producers must feed the three packed appearance words, not just one.
+#
+# The observer CREATE matters because Object::ClearUpdateMask drops change
+# flags on entering the world and PLAYER_BYTES never changes again, so an
+# observer relying on the changed-value path alone would never learn a
+# player's hair, facial hair or gender.
+#
+# The self INCREMENTAL feed matters because rest state (byte 3 of
+# PLAYER_BYTES_2) changes on entering an inn - always after login - so the
+# login seed alone delivers no transition at all and GetRestState() goes
+# stale exactly when it is needed.
+foreach(token IN ITEMS
+        "addTranslated(PLAYER_BYTES);"
+        "addTranslated(PLAYER_BYTES_2);"
+        "addTranslated(PLAYER_BYTES_3);"
+        "addIfChanged(PLAYER_BYTES);"
+        "addIfChanged(PLAYER_BYTES_2);"
+        "addIfChanged(PLAYER_BYTES_3);")
+    string(FIND "${object_update}" "${token}" position)
+    if(position EQUAL -1)
+        message(FATAL_ERROR "packed appearance word missing from a producer: ${token}")
+    endif()
+endforeach()

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -126,6 +126,10 @@ int main(int /*argc*/, char** /*argv*/)
             { 7, 7 }, { 26, 30 }, { 28, 33 }, { 34, 39 },
             { 50, 55 }, { 51, 57 }, { 52, 58 }, { 53, 59 },
             { 54, 60 }, { 63, 69 }, { 64, 70 }, { 65, 71 },
+            // Packed appearance words, previously dropped by both paths.
+            // Indices come from the client's CGPlayerData descriptor names:
+            // entry 6 hairColorID, 7 restState, 8 arenaFaction, base 160.
+            { 161, 166 }, { 162, 167 }, { 163, 168 },
         };
         for (const auto& mapping : sparseMappings)
         {
@@ -1144,6 +1148,24 @@ int main(int /*argc*/, char** /*argv*/)
             { 1619, 0xFFFFFFFFu },       // explored zone 0   -> 1627
         };
         const uint32 legacyCount = uint32(sizeof(legacy) / sizeof(legacy[0]));
+
+        // The same three words must also survive the SELF projection - they
+        // carry rest state (byte 3 of 162) and gender (byte 0 of 163), which
+        // the owner's own client needs for GetRestState() and for voice.
+        {
+            const MopUpdateObject::StaticField bytes[] =
+            {
+                { 161, 0x01020304u },
+                { 162, 0x05060708u },
+                { 163, 0x090A0B0Cu },
+            };
+            std::vector<MopUpdateObject::StaticField> out;
+            MopUpdateObject::TranslateSelfPlayerFields(bytes, 3, out);
+            CHECK(out.size() == 3);
+            CHECK(out[0].index == 166 && out[0].value == 0x01020304u);
+            CHECK(out[1].index == 167 && out[1].value == 0x05060708u);
+            CHECK(out[2].index == 168 && out[2].value == 0x090A0B0Cu);
+        }
 
         std::vector<MopUpdateObject::StaticField> projected;
         MopUpdateObject::TranslateSelfPlayerFields(legacy, legacyCount, projected);

--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -1973,6 +1973,22 @@ void Map::SendInitSelf(Player* player)
         selfFields.push_back({ PLAYER_FLAGS, player->GetUInt32Value(PLAYER_FLAGS) });
     }
 
+    // The packed appearance words. Byte 3 of PLAYER_BYTES_2 carries rest
+    // state, which GetRestState() reads and MainMenuBar.lua compares; byte 0
+    // of PLAYER_BYTES_3 carries gender, which the client reads from here for
+    // a player rather than from UNIT_FIELD_SEX; PLAYER_BYTES carries skin,
+    // face, hair and hair colour. None of the three was ever projected, so
+    // none had ever reached a client. They sort between PLAYER_FLAGS at 157
+    // and the quest log at 166, so they belong here to keep the run ascending.
+    for (uint16 i = PLAYER_BYTES; i <= PLAYER_BYTES_3; ++i)
+    {
+        const uint32 value = player->GetUInt32Value(i);
+        if (value != 0)
+        {
+            selfFields.push_back({ i, value });
+        }
+    }
+
     // Quests reach the client only through this seed and the incremental
     // values path. Without it a character logs in with its quest log empty
     // and the quest only appears if one of its fields happens to change


### PR DESCRIPTION
## What was missing

`PLAYER_BYTES`, `PLAYER_BYTES_2` and `PLAYER_BYTES_3` were absent from **every** path — self projection, observer projection, observer create feed, self incremental feed, and the login seed. [Player.cpp:2933-2935](src/game/Object/Player.cpp#L2933-L2935) marks all three as visual bits, so the legacy core considers them observer-visible; the MoP layer dropped them silently. Nothing they carry had ever reached any client.

## Symptoms this accounts for, previously tracked separately

| field | byte | symptom |
|---|---|---|
| `PLAYER_BYTES_2` | 3 | rest state → `GetRestState()` returns nil for all six values → `MainMenuBar.lua` fails at `:119` (compare number with nil) and `:202` (arithmetic on `exhaustionStateMultiplier`) → XP-bar tooltip dead |
| `PLAYER_BYTES_3` | 0 | **gender** → female character renders correctly but uses male voice and emote sounds |
| `PLAYER_BYTES_2` | 0 | facial hair invisible to every observer |

For a **player**, the client reads gender from `PLAYER_BYTES_3`, not `UNIT_FIELD_SEX` — which is why our correctly-encoded field 30 never helped.

## Index derivation — read from the client, not interpolated

The `CGPlayerData` descriptor table is a 12-byte stride from `dword_10F52B8`, populated by `sub_7A0B33` with literal name strings:

| entry | name | absolute |
|---|---|---|
| 2 | `playerFlags` | 162 *(pins base)* |
| 6 | `hairColorID` | **166** |
| 7 | `restState` | **167** |
| 8 | `arenaFaction` | **168** |
| 11 | `questLog` | 171 *(pins base)* |

Base 160 is pinned independently at both ends. The client names each packed word after its **byte 3**, and all three match the legacy byte-3 meaning — hair colour, rest state, arena faction — which corroborates the mapping rather than merely fitting it.

**Corroborated again in the retail corpus**, independent of the binary: index 167 appears in **3,009** VALUES blocks with byte 3 confined to `{1, 2}` — exactly `REST_STATE_RESTED` and `REST_STATE_NORMAL`, the two values `PlayerRest.cpp` sets. Index 168 appears in **773** blocks with byte 0 confined to `{0, 1}` — gender. Both are ordinary observer traffic, which is why both projections get them. Index 166 never appears in VALUES blocks, as expected for appearance that doesn't mutate.

## Both producers are wired — not just the mapping

The first revision of this PR was **blocked by Codex** for having the translation with neither producer. That version would have passed every test and failed in use:

- **observer create** — `Object::ClearUpdateMask` drops change flags on entering the world, and `PLAYER_BYTES` never changes again, so an observer relying on the changed-value path would never learn a player's appearance at all
- **self incremental** — rest state changes on entering an inn, i.e. **always after login**, so the seed alone delivers no transition. `GetRestState()` would have stopped returning nil and started returning a value frozen at login — worse than nil, because nil is visibly broken and a stale value isn't

## Zero-skip: safe by coincidence, not design

A sober, arena-factionless male is all-zero, so the seed skips the field and the client falls back to its default of zero — which happens to mean male. Correct outcome, wrong reason: had gender been numbered the other way, every male would render female. **The same reasoning does not transfer** to byte 1 (drunk) or byte 3 (arena faction); each needs the "is the client's default zero?" question asked separately.

## Also measured, and NOT changed here

`UNIT_FIELD_SEX` byte 3 really is gender. Across retail values of index 30, byte 3 is confined to `{0, 1, 2}` — male, female, `GENDER_NONE` — while byte 2 holds power type. `RepackUnitBytes0` was never wrong. The voice bug was a missing field, not a bad layout.

## Testing

- full suite **1093/1093**
- two new `WILL_FAIL` arms — `packed_bytes_self_feed`, `packed_bytes_observer_create` — plus a required-token loop pinning **both** producer families, since one-without-the-other is the exact failure mode that was blocked
- Codex executed both arms directly and confirmed they bite

Codex: **BLOCK** on the first revision, **APPROVE** on re-review with no findings at any level. It independently confirmed the emission order is strictly ascending (`71 → 166 → 167 → 168 → 921…`) and the source order (`157 → 161 → 162 → 163 → 166`).

## Acceptance test — three characters, not one

The two paths differ, so one login proves only half:

| character | gender | `PLAYER_BYTES_3` | proves |
|---|---|---|---|
| Huwarrior | 1 female | non-zero → **seeded** | projection fires |
| Pandamonk | 1 female | non-zero → **seeded** | projection fires |
| Huhunter | 0 male | all-zero → **not seeded**, defaults | zero-skip fallback is harmless |

If Huhunter comes out female-voiced, the skip is unsafe and zeros must be seeded explicitly. Also expect `GetRestState()` to stop returning nil, the XP-bar tooltip to work, and facial hair to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/50)
<!-- Reviewable:end -->
