### PR TITLE
[Quests] Stop sending null quest items in the gameobject query response

### DIFF
--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -488,7 +488,7 @@ add_test(NAME mop_gameobject_query_source
     COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_gameobject_query_source_test.cmake)
 
-foreach(mutation IN ITEMS request_parser_call response_builder_call inbound_registration)
+foreach(mutation IN ITEMS quest_item_zero_skip request_parser_call response_builder_call inbound_registration)
     add_test(NAME mop_gameobject_query_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/mop_gameobject_query_source_test.cmake
+++ b/src/game/Server/tests/mop_gameobject_query_source_test.cmake
@@ -2,7 +2,11 @@ file(READ "${SOURCE_ROOT}/src/game/Server/WorldSession.h" packet_helpers)
 file(READ "${SOURCE_ROOT}/src/game/WorldHandlers/QueryHandler.cpp" query_handler)
 file(READ "${SOURCE_ROOT}/src/game/Server/Opcodes.cpp" opcode_registry)
 
-if(MUTATION STREQUAL "request_parser_call")
+if(MUTATION STREQUAL "quest_item_zero_skip")
+    string(REPLACE "            if (questItem != 0)"
+        "            if (true) /* removed quest-item zero skip */"
+        query_handler "${query_handler}")
+elseif(MUTATION STREQUAL "request_parser_call")
     string(REPLACE
         "        MopQueryPackets::ReadGameObjectQueryRequest(recv_data);"
         "        // MopQueryPackets::ReadGameObjectQueryRequest(recv_data);"
@@ -199,3 +203,13 @@ require_exactly_one("${normalized_registry}" "${inbound_registration}"
     "CMSG_GAMEOBJECT_QUERY registration")
 require_exactly_one("${normalized_registry}" "${outbound_registration}"
     "SMSG_GAMEOBJECT_QUERY_RESPONSE registration")
+
+# A zero quest-item entry makes the client resolve a null item record and write
+# through it. GameObjectInfo::questItems is a fixed six-slot array whose unused
+# slots are zero, and the response's count is simply the vector's length, so
+# pushing every slot claimed six items and crashed any client with a cold cache
+# on the first gameobject it saw.
+string(FIND "${query_handler}" "if (questItem != 0)" zero_skip)
+if(zero_skip EQUAL -1)
+    message(FATAL_ERROR "gameobject quest-item zero skip is missing; a cold-cache client will crash")
+endif()

--- a/src/game/Server/tests/mop_gameobject_query_test.cpp
+++ b/src/game/Server/tests/mop_gameobject_query_test.cpp
@@ -199,6 +199,67 @@ static void test_populated_hit()
     CHECK(ExpectBytes(packet, expected));
 }
 
+/**
+ * The on-wire questItem count is whatever the caller's vector holds, so a
+ * caller that pads the fixed six-slot template array with zeros makes this
+ * packet claim six items and hand the client six entry ids of 0. The client
+ * resolves each one, gets no item record, and writes through null - the
+ * observed ACCESS_VIOLATION at null + 0x10 on a cold WDB cache.
+ *
+ * Retail never pads: across 54,209 responses in the 18414 corpus the count is
+ * 0 in 95.8%, never exceeds 4, and no non-empty list contains a zero. These
+ * cases pin the two shapes the populated test above does not cover.
+ */
+static void test_quest_item_counts()
+{
+    auto countByteOf = [](MopQueryPackets::GameObjectQueryResponse const& record)
+    {
+        WorldPacket packet(SMSG_GAMEOBJECT_QUERY_RESPONSE, 256);
+        MopQueryPackets::BuildGameObjectQueryResponse(packet, record);
+        // header: 1 bit + flush, entry, blobSize; then the blob. The count
+        // byte sits after type, displayId, seven strings, 32 data words and
+        // the float size.
+        size_t offset = 1 + 4 + 4 + 4 + 4;
+        uint8 const* p = packet.contents();
+        // Bounded, so a future layout change fails this test deterministically
+        // instead of reading past the packet.
+        for (int i = 0; i < 7; ++i)
+        {
+            while (offset < packet.size() && p[offset] != 0) ++offset;
+            CHECK(offset < packet.size());
+            ++offset;
+        }
+        offset += 32 * 4 + 4;
+        CHECK(offset < packet.size());
+        return offset < packet.size() ? p[offset] : uint8(0xFF);
+    };
+
+    MopQueryPackets::GameObjectQueryResponse record;
+    record.hasData = true;
+    record.entry = 203735;                    // Rope Ladder, the object that crashed
+    record.type = 22;
+    record.displayId = 9094;
+    record.names = {{ "Rope Ladder", "", "", "" }};
+    record.iconName = "";
+    record.castBarCaption = "";
+    record.unknownString = "";
+    record.size = 0.5f;
+    record.trailingUnknown = 0;
+
+    // No quest items at all - the overwhelmingly common case, and the one
+    // that crashed. The count must be 0, not the array's six slots.
+    record.questItems.clear();
+    CHECK(countByteOf(record) == 0);
+
+    // A single real item, as 2,278 retail responses carry.
+    record.questItems = { 44830u };
+    CHECK(countByteOf(record) == 1);
+
+    // Four, the largest count observed in retail.
+    record.questItems = { 1u, 2u, 3u, 4u };
+    CHECK(countByteOf(record) == 4);
+}
+
 static void test_opcode_values_are_framable()
 {
     CHECK(uint32_t(CMSG_GAMEOBJECT_QUERY) == 0x1461u);
@@ -213,6 +274,7 @@ int main(int /*argc*/, char** /*argv*/)
     test_missing_template();
     test_minimal_hit();
     test_populated_hit();
+    test_quest_item_counts();
     test_opcode_values_are_framable();
 
     if (g_fail)

--- a/src/game/WorldHandlers/QueryHandler.cpp
+++ b/src/game/WorldHandlers/QueryHandler.cpp
@@ -358,8 +358,36 @@ void WorldSession::HandleGameObjectQueryOpcode(WorldPacket& recv_data)
         for (size_t i = 0; i < response.data.size(); ++i)
             response.data[i] = info->raw.data[i];
         response.size = info->size;
+        // Real entries only. GameObjectInfo::questItems is a fixed six-slot
+        // array and unused slots are zero, so pushing every element made
+        // questItems.size() always six - and BuildGameObjectQueryResponse
+        // writes that size as the on-wire count. The client loops the count
+        // and resolves each entry; entry 0 has no item record, so it
+        // dereferences null and writes at null + 0x10. That is exactly the
+        // observed fault: ACCESS_VIOLATION writing 0x0000000000000010, within
+        // four seconds of entering the world with a cold WDB cache, on the
+        // first gameobject queried.
+        //
+        // A warm cache never re-queries, which is why this survived: it could
+        // only ever affect clients we do not run. Blast radius is every one of
+        // the 36,122 gameobject templates, for every new player.
+        //
+        // Retail never pads. Across 54,209 SMSG_GAMEOBJECT_QUERY_RESPONSE in
+        // the 18414 corpus the count is 0 in 95.8%, never exceeds 4 - so even
+        // a full template would not fill six - and not one non-empty list
+        // contains a zero.
+        //
+        // The creature path above is already correct for the structural
+        // reason that it copies into a fixed-size destination and so cannot
+        // fabricate a count. Only this one built a vector and reported its
+        // length.
         for (uint32 questItem : info->questItems)
-            response.questItems.push_back(questItem);
+        {
+            if (questItem != 0)
+            {
+                response.questItems.push_back(questItem);
+            }
+        }
 
         DETAIL_LOG("WORLD: CMSG_GAMEOBJECT_QUERY '%s' - Entry: %u.",
                    response.names[0].c_str(), request.entry);


### PR DESCRIPTION
## The crash

**Every client with a cold WDB cache crashes on the first gameobject it sees.**

```
wipe Cache\WDB\enGB\*.wdb, log in
ACCESS_VIOLATION 0xC0000005, writing 0x0000000000000010
~4 seconds after entering the world
last server packet: SMSG_GAMEOBJECT_QUERY_RESPONSE, entry 203735 "Rope Ladder"
```

## Cause

`GameObjectInfo::questItems` is a fixed **six-slot** array whose unused slots are zero. The handler pushed every element into the response vector, and `BuildGameObjectQueryResponse` writes that vector's **length** as the on-wire count.

So an ordinary gameobject claimed six quest items and handed the client six entry ids of `0`. The client loops the count and resolves each entry; entry 0 has no item record, so it dereferences null and writes at **null + 0x10** — the observed fault address exactly.

The crashing packet decoded cleanly with no residual: `count 6`, six zero entries. **It was well formed and wrong.**

## Why retail confirms the fix rather than just quietening it

Across **54,209** `SMSG_GAMEOBJECT_QUERY_RESPONSE` in the 18414 corpus:

| count | responses |
|---|---|
| 0 | 51,918 (95.8%) |
| 1 | 2,278 |
| 2 / 3 / 4 | 5 / 3 / 5 |

**Never above 4** — so even a fully populated template wouldn't fill six slots — and **not one** non-empty list contains a zero. Retail never pads. Parsing all 54,209 with zero residual also validates this response's grammar against retail for the first time.

## Why this survived

A warm cache never re-queries, so this could only ever affect clients we don't run. Our own cache predates the bug. **Blast radius was all 36,122 gameobject templates, for every new player.**

## Structural note

The creature path immediately above was always correct, and for a structural reason: it copies into a **fixed-size destination** and so cannot fabricate a count. Only the gameobject path built a vector and reported its length.

## Testing

- full suite **1094/1094**
- the existing builder test used a fully-populated six-item list, **which is why this was never caught**. Added the two shapes it omitted: an empty list must produce count 0, and counts of 1 and 4 must round-trip — the sizes retail actually uses
- source guard plus a `quest_item_zero_skip` `WILL_FAIL` arm pinning the skip

Codex — `APPROVE WITH FOLLOW-UP`. It confirmed the wire format carries no source-slot index (so `{5, 0, 7}` → `{5, 7}` is correct and cannot reassociate items), that no other consumer indexes `questItems`, and that no caller assumes six elements. Its MINOR — an unbounded string walk in the new test — is fixed here.

## Follow-up found by the same review, NOT fixed here

[GossipDef.cpp:582](src/game/WorldHandlers/GossipDef.cpp#L582) has **the same bug class**: `Quest::DetailsEmote` is a fixed four-slot array pushed unconditionally, and `emotes.size()` becomes a 21-bit wire count — so quests with unused emote slots advertise and serialize zero emote records. Its sibling at [:988](src/game/WorldHandlers/GossipDef.cpp#L988) breaks at the first unused slot and is correct.

Client impact is **not** established, so it doesn't block this crash fix and gets its own change.

## Still required

Cold-cache in-game verification. And once that passes, **#49's destructible-gameobject test must be repeated** — it was voided by this crash and that PR is currently merged but unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/52)
<!-- Reviewable:end -->
