### PR TITLE
[Objects] Send the gameobject type byte the client reads

### DIFF
--- a/src/game/Object/ObjectUpdate.cpp
+++ b/src/game/Object/ObjectUpdate.cpp
@@ -277,6 +277,14 @@ namespace
         for (uint16 i = 0; i < 4; ++i) add(uint16(12 + i), object.GetUInt32Value(GAMEOBJECT_PARENTROTATION + i));
         add(16, object.GetUInt32Value(GAMEOBJECT_FACTION));
         add(17, object.GetUInt32Value(GAMEOBJECT_LEVEL));
+        // Byte 1 of this field is the GAMEOBJECT_TYPE. Omitting it left every
+        // gameobject looking like type 0 (DOOR) to the client, which routes the
+        // display record's model name into the M2 cache. That cache rejects any
+        // extension other than .m2/.mdl/.mdx and returns null, and the caller
+        // releases the null handle without checking it. WMO-backed types read
+        // their type byte here to take the branch that skips the M2 load
+        // entirely, so this field is what keeps them off that path.
+        add(18, object.GetUInt32Value(GAMEOBJECT_BYTES_1));
     }
 
     void BuildMopObserverPlayerStaticFields(Object const& object,
@@ -455,7 +463,7 @@ void Object::BuildCreateUpdateBlockForPlayer(UpdateData* data, Player* target) c
         movement.o = gameObject->GetOrientation();
         movement.rotation = uint64(gameObject->GetPackedWorldRotation());
 
-        fields.reserve(18);
+        fields.reserve(19);
         BuildMopGameObjectStaticFields(*this, target, fields);
         MopUpdateObject::AppendStationaryGameObjectCreateBlock(data->GetBuffer(), updateType, guid,
             m_objectTypeId, movement, fields.data(), uint32(fields.size()));
@@ -805,7 +813,7 @@ void Object::BuildValuesUpdateBlockForPlayer(UpdateData* data, Player* target) c
     }
     else
     {
-        fields.reserve(18);
+        fields.reserve(19);
         BuildMopGameObjectStaticFields(*this, target, fields);
     }
     MopUpdateObject::AppendValuesBlock(data->GetBuffer(), GetObjectGuid().GetRawValue(),

--- a/src/game/Server/MopUpdateObject.cpp
+++ b/src/game/Server/MopUpdateObject.cpp
@@ -220,16 +220,14 @@ bool MopUpdateObject::CanUseStationaryGameObjectMovement(StationaryGameObjectEli
     // appeared. Players see it as NPCs standing in mid-air, because creatures
     // resting on these objects render correctly while their platform does not.
     //
-    // The residual cost is bounded but real, and NOT self-correcting. The
-    // gameobject projection stops at target index 17 and never emits
-    // GAMEOBJECT_BYTES_1, whose byte 3 carries destructible animation and
-    // health progress - and the incremental VALUES path reuses the same
-    // projection, so that field never arrives later either. Damaged and
-    // destroyed transitions still propagate through GAMEOBJECT_FLAGS and
-    // GAMEOBJECT_DISPLAYID, which are emitted. The omission predates this
-    // change and applies to every gameobject type equally, so nothing here
-    // makes destructibles a special case; a mask-and-values block simply
-    // clears the bit for a field it does not send, and stays well formed.
+    // Admitting these objects then exposed a second, older omission: the
+    // projection stopped at target index 17 and never emitted
+    // GAMEOBJECT_BYTES_1, so every gameobject read back as type 0. The
+    // client's model resolver excludes the WMO-backed types 11, 14, 15 and 33
+    // and sends everything else to the M2 cache, which rejects a WMO filename,
+    // returns null, and is dereferenced unchecked. That is now fixed by
+    // emitting index 18 in the same projection, which the incremental VALUES
+    // path reuses, so the type arrives on both paths.
     // Rendering with a default sub-state beats not rendering at all.
     return eligibility.hasTemplate && !eligibility.isTransport &&
         !eligibility.isBoarded && eligibility.hasStationaryPosition && eligibility.hasRotation &&

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -124,6 +124,19 @@ foreach(mutation IN ITEMS visible_item_feed combined_builder skill_feed questlog
         PROPERTIES WILL_FAIL TRUE)
 endforeach()
 
+add_test(NAME mop_gameobject_projection_source
+    COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_gameobject_projection_source_test.cmake)
+
+foreach(mutation IN ITEMS drop_bytes1 bytes1_index_drift bytes1_wrong_source short_rotation_loop stale_reserve)
+    add_test(NAME mop_gameobject_projection_source_mutation_${mutation}
+        COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+            -DMUTATION=${mutation}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_gameobject_projection_source_test.cmake)
+    set_tests_properties(mop_gameobject_projection_source_mutation_${mutation}
+        PROPERTIES WILL_FAIL TRUE)
+endforeach()
+
 add_executable(mop_opcode_foundation_test mop_opcode_foundation_test.cpp)
 target_include_directories(mop_opcode_foundation_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..

--- a/src/game/Server/tests/mop_gameobject_projection_source_test.cmake
+++ b/src/game/Server/tests/mop_gameobject_projection_source_test.cmake
@@ -1,0 +1,97 @@
+file(READ "${SOURCE_ROOT}/src/game/Object/ObjectUpdate.cpp" update_source)
+
+if(MUTATION STREQUAL "drop_bytes1")
+    string(REPLACE
+        "add(18, object.GetUInt32Value(GAMEOBJECT_BYTES_1));"
+        ""
+        update_source "${update_source}")
+elseif(MUTATION STREQUAL "bytes1_index_drift")
+    string(REPLACE
+        "add(18, object.GetUInt32Value(GAMEOBJECT_BYTES_1));"
+        "add(19, object.GetUInt32Value(GAMEOBJECT_BYTES_1));"
+        update_source "${update_source}")
+elseif(MUTATION STREQUAL "bytes1_wrong_source")
+    string(REPLACE
+        "add(18, object.GetUInt32Value(GAMEOBJECT_BYTES_1));"
+        "add(18, object.GetUInt32Value(GAMEOBJECT_LEVEL));"
+        update_source "${update_source}")
+elseif(MUTATION STREQUAL "short_rotation_loop")
+    string(REPLACE
+        "for (uint16 i = 0; i < 4; ++i) add(uint16(12 + i), object.GetUInt32Value(GAMEOBJECT_PARENTROTATION + i));"
+        "for (uint16 i = 0; i < 3; ++i) add(uint16(12 + i), object.GetUInt32Value(GAMEOBJECT_PARENTROTATION + i));"
+        update_source "${update_source}")
+elseif(MUTATION STREQUAL "stale_reserve")
+    string(REPLACE
+        "fields.reserve(19);"
+        "fields.reserve(18);"
+        update_source "${update_source}")
+endif()
+
+string(FIND "${update_source}" "void BuildMopGameObjectStaticFields" go_start)
+string(FIND "${update_source}" "void BuildMopObserverPlayerStaticFields" next_start)
+if(go_start EQUAL -1 OR next_start EQUAL -1 OR NOT go_start LESS next_start)
+    message(FATAL_ERROR "could not isolate BuildMopGameObjectStaticFields")
+endif()
+math(EXPR go_length "${next_start} - ${go_start}")
+string(SUBSTRING "${update_source}" ${go_start} ${go_length} go_body)
+
+# The 18414 gameobject descriptor is OBJECT_END(8) + GAMEOBJECT_END(0x0C) with
+# GAMEOBJECT_DYNAMIC lifted into the object block at wire 6, giving a contiguous
+# wire range 0..18 and nothing else. The client indexes this array directly, so
+# an omitted slot is not a smaller packet, it is a field the client reads as
+# zero. Wire 18 is GAMEOBJECT_BYTES_1, whose byte 1 is the GAMEOBJECT_TYPE.
+set(EXPECTED_LITERAL_INDICES "0,1,2,3,4,5,6,7,8,9,10,11,16,17,18")
+
+string(REGEX MATCHALL "add\\([0-9]+," raw_adds "${go_body}")
+set(literal_indices "")
+foreach(one_add IN LISTS raw_adds)
+    string(REGEX REPLACE "add\\(([0-9]+),.*" "\\1" one_index "${one_add}")
+    list(APPEND literal_indices ${one_index})
+endforeach()
+string(REPLACE ";" "," actual_literal_indices "${literal_indices}")
+
+if(NOT actual_literal_indices STREQUAL EXPECTED_LITERAL_INDICES)
+    message(FATAL_ERROR
+        "gameobject wire projection changed shape\n"
+        "  expected literal indices: ${EXPECTED_LITERAL_INDICES}\n"
+        "  actual literal indices:   ${actual_literal_indices}")
+endif()
+
+# 12..15 are emitted by a loop rather than four literals, so the literal list
+# above legitimately skips them. Pin the loop so the gap stays covered.
+string(FIND "${go_body}"
+    "for (uint16 i = 0; i < 4; ++i) add(uint16(12 + i), object.GetUInt32Value(GAMEOBJECT_PARENTROTATION + i));"
+    rotation_loop)
+if(rotation_loop EQUAL -1)
+    message(FATAL_ERROR
+        "GAMEOBJECT_PARENTROTATION must fill wire indices 12..15 as four entries")
+endif()
+
+# Byte 1 of GAMEOBJECT_BYTES_1 is the GAMEOBJECT_TYPE. Without it every
+# gameobject reads as type 0 on the client, and the WMO-backed types
+# (11 TRANSPORT, 14 MAP_OBJECT, 15 MO_TRANSPORT, 33 DESTRUCTIBLE_BUILDING)
+# lose the branch that keeps their model out of the M2 cache.
+string(FIND "${go_body}"
+    "add(18, object.GetUInt32Value(GAMEOBJECT_BYTES_1));" bytes1)
+if(bytes1 EQUAL -1)
+    message(FATAL_ERROR
+        "wire index 18 must carry GAMEOBJECT_BYTES_1, the field holding GAMEOBJECT_TYPE")
+endif()
+
+# Both producers - the create block and the values block - build from the same
+# projection, so a reserve left behind is a reliable sign one of them was
+# updated and the other was not.
+string(FIND "${update_source}" "fields.reserve(18);" stale_reserve)
+if(NOT stale_reserve EQUAL -1)
+    message(FATAL_ERROR
+        "a gameobject field reserve still says 18; the projection emits 19")
+endif()
+
+# No trailing semicolon in the pattern: a match containing ";" would split into
+# two CMake list elements and double the count.
+string(REGEX MATCHALL "fields\\.reserve\\(19\\)" reserves "${update_source}")
+list(LENGTH reserves reserve_count)
+if(NOT reserve_count EQUAL 2)
+    message(FATAL_ERROR
+        "expected the create and values producers to reserve 19 gameobject fields, found ${reserve_count}")
+endif()

--- a/src/game/Server/tests/mop_updateobject_test.cpp
+++ b/src/game/Server/tests/mop_updateobject_test.cpp
@@ -833,10 +833,14 @@ int main(int /*argc*/, char** /*argv*/)
         CHECK(rotation == movement.rotation);
         CHECK(bytes.rpos() == bytes.size());
 
+        // 0xFF002100 is a real destructible BYTES_1: state 0, type 33, artKit
+        // 0, animProgress 255. Index 18 is the highest slot in the gameobject
+        // descriptor, so it also pins the mask width at one block.
         const MopUpdateObject::StaticField fields[] =
         {
             { 0, 0xAABBCCDDu },
             { 17, 60u },
+            { 18, 0xFF002100u },
         };
         ByteBuffer create;
         MopUpdateObject::AppendStationaryGameObjectCreateBlock(create, 2, 0x10, 5, movement,
@@ -847,6 +851,25 @@ int main(int /*argc*/, char** /*argv*/)
         MopUpdateObject::AppendStaticValuesNoDynamic(expected, fields, sizeof(fields) / sizeof(fields[0]));
         CHECK(create.size() == expected.size());
         CHECK(create.size() == expected.size() && std::memcmp(create.contents(), expected.contents(), expected.size()) == 0);
+
+        // Both buffers above come from the same builder, so assert the tail
+        // against a mask and payload written out by hand instead.
+        ByteBuffer values;
+        MopUpdateObject::AppendStaticValuesNoDynamic(values, fields, sizeof(fields) / sizeof(fields[0]));
+        const uint8 expectedBlockCount = 1;
+        const uint32 expectedMask = (1u << 0) | (1u << 17) | (1u << 18);
+        // block count, one mask, three values, then the trailing terminator
+        CHECK(values.size() == sizeof(uint8) + sizeof(uint32) + 3 * sizeof(uint32) + sizeof(uint8));
+        uint8 blockCount, terminator;
+        uint32 mask, valueZero, valueSeventeen, valueEighteen;
+        values >> blockCount >> mask >> valueZero >> valueSeventeen >> valueEighteen >> terminator;
+        CHECK(terminator == 0);
+        CHECK(blockCount == expectedBlockCount);
+        CHECK(mask == expectedMask);
+        CHECK(valueZero == 0xAABBCCDDu);
+        CHECK(valueSeventeen == 60u);
+        CHECK(valueEighteen == 0xFF002100u);
+        CHECK(values.rpos() == values.size());
     }
 
     // Binary-proved DynamicObject/Corpse movement subset: stationary position


### PR DESCRIPTION
## What

`BuildMopGameObjectStaticFields` emitted wire indices 0–17 and stopped. The 18414 gameobject descriptor runs to **18**, and index 18 is `GAMEOBJECT_BYTES_1` — **byte 1 of which is the `GAMEOBJECT_TYPE`**.

So every gameobject this core has ever created on an 18414 client has read back as **type 0**, for all 36k templates.

## Why it crashes the client

Traced through `Wow-64.exe` (build 18414, 64-bit), from a full memory dump of the live fault:

1. The client reads the type byte from the create block's own field array — `obj+408+41`, i.e. byte 1 of field 18. With the field absent it reads **0**.
2. The model resolver `sub_140622BC0` (vtable+456) excludes types **{11 TRANSPORT, 14 MAP_OBJECT, 15 MO_TRANSPORT, 33 DESTRUCTIBLE_BUILDING}** at `0x140622BEB` — the WMO-backed ones. Type 0 is not excluded, so it falls through and returns a model **path**.
3. That path is the display record's `ModelName`, a **WMO**. The client names it as such itself: `"Destructible building WMO(%s) has invalid geobox"` at `0x140EF1628`.
4. `sub_140175610` is the **M2 cache** (`"M2Cache.cpp"`); `sub_14016FEE0` rejects any extension that is not `.m2/.mdl/.mdx` — `"Model2: Invalid file extension: %s"` — and returns **null**.
5. `sub_1406A6910` releases that null handle **unguarded** → `sub_14019D130(NULL)` → access violation at `0x14019D136` writing `[0x10]`. The sibling call site `sub_140622940` guards this exact idiom; this one does not.

The full stack is one synchronous unwind of a single packet — net pump → data-received → opcode dispatch → `ObjectMgrClient.cpp` update parser → per-block CREATE → GameObject vtable+208. No render tick, no deferred queue, no class or combat code anywhere in it.

## Scope

This is not destructible-specific and it is not a regression from the destructible gate removal (#49). That change only made one of the four exposed types reachable; **11, 14 and 15 were always exposed** and would fault identically. Sending the field the client already expects covers all four, and is the honest projection regardless.

## Change

- `add(18, GAMEOBJECT_BYTES_1)` in `BuildMopGameObjectStaticFields`
- both `fields.reserve(18)` → `19`, on the create path and the values path
- new `mop_gameobject_projection_source_test.cmake` pinning the whole wire shape 0–18 — the literal index list, the `PARENTROTATION` loop covering 12–15, the `BYTES_1` source, and both reserves — with five `WILL_FAIL` mutation arms
- `mop_updateobject_test.cpp` now serialises a real destructible `BYTES_1` (`0xFF002100`) and asserts the block count, mask word and payload against bytes written by hand, rather than against another call to the same builder

## Verification

- `game.lib` builds clean, MSVC Release
- `ctest -R "gameobject|updateobject"` → **37/37**, including 6 new
- each mutation arm confirmed to fail for its own distinct reason
- Codex read-only review: **APPROVE WITH FOLLOW-UP**, no BLOCKING. It independently confirmed the index derivation, that mask width is computed from the highest index (18 stays inside the first 32-bit block), and that the VALUES path needs no separate change-mask handling. Both MINORs are fixed in `eccb8fc46`.

**Not yet verified live** — that the access violation actually stops is a client test, `.go xyz -7259.48 4101.91 -1.73`.

## Deliberately not in this PR

`GameObject.cpp:295` is missing a `break`: destructibles fall through into the `TRANSPORT` arm, taking `SetUInt32Value(GAMEOBJECT_LEVEL, getMSTime())` — a field we do put on the wire at index 17 — and a `transport.startOpen` / `destructibleBuilding.creditProxyCreature` union alias that can force `GO_STATE_ACTIVE`. A real defect, and Codex agrees it is not a newly introduced wire regression (the client read state 0 before this change too). Held back so the live A/B changes exactly one byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/54)
<!-- Reviewable:end -->
