### PR TITLE
[Objects] Stop destructibles falling into the transport arm

### DIFF
--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -294,8 +294,8 @@ bool GameObject::Create(uint32 guidlow, uint32 name_id, Map* map, uint32 phaseMa
             ForceGameObjectHealth(GetMaxHealth(), NULL);
             SetUInt32Value(GAMEOBJECT_PARENTROTATION, m_goInfo->destructibleBuilding.destructibleData);
             // Do not fall through. The transport arm below writes a timestamp
-            // into GAMEOBJECT_LEVEL, which nothing reads back but which we do
-            // send at wire index 17, and it reads data word 1 as
+            // into GAMEOBJECT_LEVEL, which no destructible behaviour consumes
+            // but which we do send at wire index 17, and it reads data word 1 as
             // transport.startOpen - the same word a destructible uses for
             // creditProxyCreature. Any destructible with a credit proxy was
             // being spawned into GO_STATE_ACTIVE because of that alias.

--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -293,6 +293,13 @@ bool GameObject::Create(uint32 guidlow, uint32 name_id, Map* map, uint32 phaseMa
         case GAMEOBJECT_TYPE_DESTRUCTIBLE_BUILDING:
             ForceGameObjectHealth(GetMaxHealth(), NULL);
             SetUInt32Value(GAMEOBJECT_PARENTROTATION, m_goInfo->destructibleBuilding.destructibleData);
+            // Do not fall through. The transport arm below writes a timestamp
+            // into GAMEOBJECT_LEVEL, which nothing reads back but which we do
+            // send at wire index 17, and it reads data word 1 as
+            // transport.startOpen - the same word a destructible uses for
+            // creditProxyCreature. Any destructible with a credit proxy was
+            // being spawned into GO_STATE_ACTIVE because of that alias.
+            break;
         case GAMEOBJECT_TYPE_TRANSPORT:
             SetUInt32Value(GAMEOBJECT_LEVEL, getMSTime());
             if (goinfo->transport.startOpen)

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -137,6 +137,19 @@ foreach(mutation IN ITEMS drop_bytes1 bytes1_index_drift bytes1_wrong_source sho
         PROPERTIES WILL_FAIL TRUE)
 endforeach()
 
+add_test(NAME mop_destructible_spawn_state_source
+    COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_destructible_spawn_state_source_test.cmake)
+
+foreach(mutation IN ITEMS restore_fallthrough drop_destructible_data)
+    add_test(NAME mop_destructible_spawn_state_source_mutation_${mutation}
+        COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+            -DMUTATION=${mutation}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_destructible_spawn_state_source_test.cmake)
+    set_tests_properties(mop_destructible_spawn_state_source_mutation_${mutation}
+        PROPERTIES WILL_FAIL TRUE)
+endforeach()
+
 add_executable(mop_opcode_foundation_test mop_opcode_foundation_test.cpp)
 target_include_directories(mop_opcode_foundation_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..

--- a/src/game/Server/tests/mop_destructible_spawn_state_source_test.cmake
+++ b/src/game/Server/tests/mop_destructible_spawn_state_source_test.cmake
@@ -28,14 +28,24 @@ string(SUBSTRING "${go_source}" ${destructible_start} ${arm_length} destructible
 # whether it spawns GO_STATE_ACTIVE. The transport arm also writes getMSTime()
 # into GAMEOBJECT_LEVEL, which no reader consumes but which the 18414
 # projection sends at wire index 17.
-# No ";" in the pattern: a match containing one would split into two CMake
-# list elements and double the count.
-string(REGEX MATCHALL "[\r\n][ \t]*break" arm_breaks "${destructible_arm}")
-list(LENGTH arm_breaks break_count)
-if(NOT break_count EQUAL 1)
+# Counting breaks is not enough: "if (x) break;" would satisfy a count and
+# still fall through. Require the arm to END in a break that is alone on its
+# line, and forbid any conditional in the arm, so the break cannot be guarded
+# by one. Scalar REGEX MATCH, not MATCHALL, so the ";" cannot split the result
+# into extra list elements.
+string(REGEX MATCH "[\r\n][ \t]*break;[ \t\r\n]*$" terminal_break "${destructible_arm}")
+if(terminal_break STREQUAL "")
     message(FATAL_ERROR
-        "the destructible arm must end in exactly one break so it cannot fall "
-        "into GAMEOBJECT_TYPE_TRANSPORT; found ${break_count}")
+        "the destructible arm must end in an unconditional break on its own "
+        "line so it cannot fall into GAMEOBJECT_TYPE_TRANSPORT")
+endif()
+
+string(REGEX MATCHALL "[^a-zA-Z_]if[ \t]*\\(" arm_conditionals "${destructible_arm}")
+list(LENGTH arm_conditionals conditional_count)
+if(NOT conditional_count EQUAL 0)
+    message(FATAL_ERROR
+        "the destructible arm must stay unconditional; a branch here could "
+        "guard the terminal break and reopen the fall-through")
 endif()
 
 string(FIND "${destructible_arm}" "ForceGameObjectHealth" health)

--- a/src/game/Server/tests/mop_destructible_spawn_state_source_test.cmake
+++ b/src/game/Server/tests/mop_destructible_spawn_state_source_test.cmake
@@ -1,0 +1,60 @@
+file(READ "${SOURCE_ROOT}/src/game/Object/GameObject.cpp" go_source)
+
+if(MUTATION STREQUAL "restore_fallthrough")
+    string(REPLACE
+        "            break;\n        case GAMEOBJECT_TYPE_TRANSPORT:"
+        "        case GAMEOBJECT_TYPE_TRANSPORT:"
+        go_source "${go_source}")
+elseif(MUTATION STREQUAL "drop_destructible_data")
+    string(REPLACE
+        "SetUInt32Value(GAMEOBJECT_PARENTROTATION, m_goInfo->destructibleBuilding.destructibleData);"
+        ""
+        go_source "${go_source}")
+endif()
+
+string(FIND "${go_source}" "case GAMEOBJECT_TYPE_DESTRUCTIBLE_BUILDING:" destructible_start)
+string(FIND "${go_source}" "case GAMEOBJECT_TYPE_TRANSPORT:" transport_start)
+if(destructible_start EQUAL -1 OR transport_start EQUAL -1
+   OR NOT destructible_start LESS transport_start)
+    message(FATAL_ERROR
+        "could not isolate the destructible arm of GameObject::Create")
+endif()
+math(EXPR arm_length "${transport_start} - ${destructible_start}")
+string(SUBSTRING "${go_source}" ${destructible_start} ${arm_length} destructible_arm)
+
+# GameObjectInfo is a union. transport.startOpen and
+# destructibleBuilding.creditProxyCreature are both data word 1, so falling
+# through into the transport arm makes a destructible's credit proxy decide
+# whether it spawns GO_STATE_ACTIVE. The transport arm also writes getMSTime()
+# into GAMEOBJECT_LEVEL, which no reader consumes but which the 18414
+# projection sends at wire index 17.
+# No ";" in the pattern: a match containing one would split into two CMake
+# list elements and double the count.
+string(REGEX MATCHALL "[\r\n][ \t]*break" arm_breaks "${destructible_arm}")
+list(LENGTH arm_breaks break_count)
+if(NOT break_count EQUAL 1)
+    message(FATAL_ERROR
+        "the destructible arm must end in exactly one break so it cannot fall "
+        "into GAMEOBJECT_TYPE_TRANSPORT; found ${break_count}")
+endif()
+
+string(FIND "${destructible_arm}" "ForceGameObjectHealth" health)
+if(health EQUAL -1)
+    message(FATAL_ERROR "the destructible arm must still initialise health")
+endif()
+
+string(FIND "${destructible_arm}"
+    "m_goInfo->destructibleBuilding.destructibleData" destructible_data)
+if(destructible_data EQUAL -1)
+    message(FATAL_ERROR
+        "GAMEOBJECT_PARENTROTATION must carry destructibleData; the client keys "
+        "DestructibleModelData off exactly that slot")
+endif()
+
+# getMSTime() belongs to the transport arm alone. Its appearance in the
+# destructible arm would mean the fall-through came back.
+string(FIND "${destructible_arm}" "getMSTime" leaked_timestamp)
+if(NOT leaked_timestamp EQUAL -1)
+    message(FATAL_ERROR
+        "the destructible arm must not reach the transport timestamp write")
+endif()


### PR DESCRIPTION
## What

`GameObject::Create`'s `GAMEOBJECT_TYPE_DESTRUCTIBLE_BUILDING` arm had no `break`, so every destructible also ran the transport initialisation.

## Consequences

`GameObjectInfo` is a union. `transport.startOpen` is **data word 1** ([GameObject.h:410](../blob/master/src/game/Object/GameObject.h#L410)) and `destructibleBuilding.creditProxyCreature` is **also data word 1** ([GameObject.h:593](../blob/master/src/game/Object/GameObject.h#L593)). So the transport arm's `if (goinfo->transport.startOpen) SetGoState(GO_STATE_ACTIVE)` was really reading the destructible's credit-proxy creature id.

Any destructible with a credit proxy therefore spawned `GO_STATE_ACTIVE` — and an active destructible has **collision disabled** ([GameObject.cpp:988](../blob/master/src/game/Object/GameObject.cpp#L988)). That is the user-visible half: affected buildings could be walked through.

The transport arm also writes `getMSTime()` into `GAMEOBJECT_LEVEL`. No destructible behaviour consumes it, but the 18414 projection sends it at **wire index 17**, so the client has been receiving a millisecond timestamp where a level belongs.

## Not the crash

The access violation in this area was a different defect — the missing `GAMEOBJECT_BYTES_1` at wire index 18, fixed in #54 and confirmed live. This PR was deliberately held back until #54 was verified, so that A/B changed exactly one byte and nothing else. Neither problem here is new; both predate the destructible gate removal.

## Change

- the missing `break`
- new `mop_destructible_spawn_state_source_test.cmake`: requires an unconditional `break` alone on the arm's last line, forbids conditionals in the arm so one cannot guard it, requires `ForceGameObjectHealth` and the `destructibleData` → `GAMEOBJECT_PARENTROTATION` write to survive, and rejects `getMSTime` appearing in the arm

## Verification

- `game.lib` builds clean, MSVC Release
- `ctest -R "destructible|gameobject|updateobject"` → **40/40**
- baseline exits 0; both `WILL_FAIL` arms exit non-zero for their own distinct reasons
- the hardened guard was tested against the exact bypass it exists to stop: wrapping the `break` in `if (GetGoState() == GO_STATE_READY)` is rejected
- Codex read-only review: **APPROVE WITH FOLLOW-UP**, no BLOCKING. It independently verified the union word indices, that no battleground, outdoor-PvP, update, transport or destructible-damage path relies on the accidental timestamp or active spawn state, and that damage/repair handling does not depend on `GetGoState()`. Its IMPORTANT (the count-based guard admitted a conditional `break`) and MINOR (comment overstated "nothing reads it back") are both fixed in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/55)
<!-- Reviewable:end -->
