### PR TITLE
[Calendar] Send the raid reset period instead of a clamped zero

### DIFF
--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -154,7 +154,7 @@ add_test(NAME mop_calendar_reset_period_source
     COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_calendar_reset_period_source_test.cmake)
 
-foreach(mutation IN ITEMS restore_subtraction clamp_lockout_away drop_period_source)
+foreach(mutation IN ITEMS restore_subtraction clamp_lockout_away drop_period_source drop_overflow_clamp ignore_period_value)
     add_test(NAME mop_calendar_reset_period_source_mutation_${mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${mutation}

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -150,6 +150,19 @@ foreach(mutation IN ITEMS restore_fallthrough drop_destructible_data)
         PROPERTIES WILL_FAIL TRUE)
 endforeach()
 
+add_test(NAME mop_calendar_reset_period_source
+    COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_calendar_reset_period_source_test.cmake)
+
+foreach(mutation IN ITEMS restore_subtraction clamp_lockout_away drop_period_source)
+    add_test(NAME mop_calendar_reset_period_source_mutation_${mutation}
+        COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+            -DMUTATION=${mutation}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_calendar_reset_period_source_test.cmake)
+    set_tests_properties(mop_calendar_reset_period_source_mutation_${mutation}
+        PROPERTIES WILL_FAIL TRUE)
+endforeach()
+
 add_executable(mop_opcode_foundation_test mop_opcode_foundation_test.cpp)
 target_include_directories(mop_opcode_foundation_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..

--- a/src/game/Server/tests/mop_calendar_reset_period_source_test.cmake
+++ b/src/game/Server/tests/mop_calendar_reset_period_source_test.cmake
@@ -1,0 +1,78 @@
+file(READ "${SOURCE_ROOT}/src/game/WorldHandlers/CalendarHandler.cpp" handler_source)
+
+if(MUTATION STREQUAL "restore_subtraction")
+    string(REPLACE
+        "record.resetRemaining = int32(resetPeriod);"
+        "record.resetRemaining = resetPeriod > currTime ? int32(resetPeriod - currTime) : 0;"
+        handler_source "${handler_source}")
+elseif(MUTATION STREQUAL "clamp_lockout_away")
+    string(REPLACE
+        "record.resetRemaining = state->GetResetTime() > currTime ?
+                uint32(state->GetResetTime() - currTime) : 0;"
+        "record.resetRemaining = uint32(state->GetResetTime());"
+        handler_source "${handler_source}")
+elseif(MUTATION STREQUAL "drop_period_source")
+    string(REPLACE
+        "GetMaxResetTimeFor(mapDiff)"
+        "GetResetTimeFor(mapId, Difficulty(0))"
+        handler_source "${handler_source}")
+endif()
+
+# Two adjacent loops fill two different countdown-looking fields, and only one
+# of them is a countdown. Isolate them so a guard meant for one cannot be
+# satisfied by the other.
+string(FIND "${handler_source}"
+    "MopCalendarPackets::CalendarListLockout record;" lockout_start)
+string(FIND "${handler_source}"
+    "std::vector<MopCalendarPackets::CalendarListReset> resetRecords;" reset_start)
+string(FIND "${handler_source}"
+    "WorldPacket data(SMSG_CALENDAR_SEND_CALENDAR);" send_start)
+if(lockout_start EQUAL -1 OR reset_start EQUAL -1 OR send_start EQUAL -1
+   OR NOT lockout_start LESS reset_start OR NOT reset_start LESS send_start)
+    message(FATAL_ERROR
+        "could not isolate the lockout and reset loops in HandleCalendarGetCalendar")
+endif()
+math(EXPR lockout_length "${reset_start} - ${lockout_start}")
+math(EXPR reset_length "${send_start} - ${reset_start}")
+string(SUBSTRING "${handler_source}" ${lockout_start} ${lockout_length} lockout_arm)
+string(SUBSTRING "${handler_source}" ${reset_start} ${reset_length} reset_arm)
+
+# A personal lockout carries DungeonPersistentState::GetResetTime(), a time_t
+# absolute timestamp, so subtracting currTime is the correct countdown and the
+# guard against going negative is required. This half must NOT be "fixed".
+string(FIND "${lockout_arm}" "state->GetResetTime() > currTime" lockout_guard)
+if(lockout_guard EQUAL -1)
+    message(FATAL_ERROR
+        "the personal lockout countdown must keep its guard: GetResetTime() is "
+        "an absolute time_t, so currTime can legitimately exceed it")
+endif()
+
+# The global reset word is not a countdown at all. GetMaxResetTimeFor returns a
+# DURATION - RaidDuration scaled and floored to whole days, minimum one day -
+# and the client uses it as a recurrence period, stepping from the calendar
+# epoch by this value and dividing by it. Retail carries 604800, 259200 and
+# 86400 and never zero. Comparing a duration against an absolute currTime can
+# only ever be false, which is how every record came to be sent as zero.
+string(FIND "${reset_arm}" "GetMaxResetTimeFor(mapDiff)" period_source)
+if(period_source EQUAL -1)
+    message(FATAL_ERROR
+        "the global reset word must come from GetMaxResetTimeFor, the helper "
+        "that yields the retail period class")
+endif()
+
+string(FIND "${reset_arm}" "record.resetRemaining = int32(resetPeriod);" direct_assign)
+if(direct_assign EQUAL -1)
+    message(FATAL_ERROR
+        "the global reset period must be sent as-is, not turned into a countdown")
+endif()
+
+# Match the operator forms, not a bare "currTime": the explanatory comment in
+# the source names the variable, and a substring check would trip on prose.
+string(FIND "${reset_arm}" "> currTime" reset_compares)
+string(FIND "${reset_arm}" "- currTime" reset_subtracts)
+if(NOT reset_compares EQUAL -1 OR NOT reset_subtracts EQUAL -1)
+    message(FATAL_ERROR
+        "the global reset arm must not compare against or subtract currTime: "
+        "the value is a period, and measuring a duration against an absolute "
+        "time is the defect that zeroed every record")
+endif()

--- a/src/game/Server/tests/mop_calendar_reset_period_source_test.cmake
+++ b/src/game/Server/tests/mop_calendar_reset_period_source_test.cmake
@@ -1,9 +1,10 @@
 file(READ "${SOURCE_ROOT}/src/game/WorldHandlers/CalendarHandler.cpp" handler_source)
+set(pristine_source "${handler_source}")
 
 if(MUTATION STREQUAL "restore_subtraction")
     string(REPLACE
-        "record.resetRemaining = int32(resetPeriod);"
-        "record.resetRemaining = resetPeriod > currTime ? int32(resetPeriod - currTime) : 0;"
+        "int32(resetPeriod > maxResetPeriod ? maxResetPeriod : resetPeriod);"
+        "resetPeriod > currTime ? int32(resetPeriod - currTime) : 0;"
         handler_source "${handler_source}")
 elseif(MUTATION STREQUAL "clamp_lockout_away")
     string(REPLACE
@@ -16,6 +17,32 @@ elseif(MUTATION STREQUAL "drop_period_source")
         "GetMaxResetTimeFor(mapDiff)"
         "GetResetTimeFor(mapId, Difficulty(0))"
         handler_source "${handler_source}")
+elseif(MUTATION STREQUAL "drop_overflow_clamp")
+    string(REPLACE
+        "int32(resetPeriod > maxResetPeriod ? maxResetPeriod : resetPeriod);"
+        "int32(resetPeriod);"
+        handler_source "${handler_source}")
+elseif(MUTATION STREQUAL "ignore_period_value")
+    string(REPLACE
+        "uint32 resetPeriod = sMapPersistentStateMgr.GetScheduler().GetMaxResetTimeFor(mapDiff);"
+        "sMapPersistentStateMgr.GetScheduler().GetMaxResetTimeFor(mapDiff);
+        uint32 resetPeriod = 0;"
+        handler_source "${handler_source}")
+endif()
+
+# A mutation whose string(REPLACE) target has drifted out of the source is a
+# silent no-op: the arm then passes for the wrong reason, because WILL_FAIL
+# accepts any non-zero exit and the unmutated source of course still fails
+# nothing. Exit SUCCESSFULLY in that case - under WILL_FAIL a zero exit is
+# reported as a failure, so a dead mutation shows up in ctest instead of
+# hiding. This happened here once already, when the assignment was reworded.
+if(DEFINED MUTATION AND NOT MUTATION STREQUAL "")
+    if(handler_source STREQUAL pristine_source)
+        message("MUTATION '${MUTATION}' did not change the source - its "
+                "replacement target no longer exists. Exiting 0 so WILL_FAIL "
+                "reports this arm as broken.")
+        return()
+    endif()
 endif()
 
 # Two adjacent loops fill two different countdown-looking fields, and only one
@@ -60,10 +87,34 @@ if(period_source EQUAL -1)
         "that yields the retail period class")
 endif()
 
-string(FIND "${reset_arm}" "record.resetRemaining = int32(resetPeriod);" direct_assign)
+# Bind the helper call to the value that is actually sent. Checking the call
+# and the assignment separately would accept a discarded call followed by
+# "uint32 resetPeriod = 0", which is the shape this whole commit removes.
+string(FIND "${reset_arm}"
+    "uint32 resetPeriod = sMapPersistentStateMgr.GetScheduler().GetMaxResetTimeFor(mapDiff);"
+    period_bound)
+if(period_bound EQUAL -1)
+    message(FATAL_ERROR
+        "the value sent must be bound directly to the GetMaxResetTimeFor call, "
+        "not merely accompanied by one")
+endif()
+
+# Rate.InstanceResetTime is validated only against being negative, so a large
+# enough rate overflows the int32 cast and the client ends up dividing by a
+# negative number. The clamp is the only thing standing between an admin's
+# config typo and that.
+string(FIND "${reset_arm}"
+    "int32(resetPeriod > maxResetPeriod ? maxResetPeriod : resetPeriod);" direct_assign)
 if(direct_assign EQUAL -1)
     message(FATAL_ERROR
-        "the global reset period must be sent as-is, not turned into a countdown")
+        "the global reset period must be sent as-is under an overflow clamp, "
+        "not turned into a countdown and not cast unchecked")
+endif()
+
+string(FIND "${reset_arm}" "uint32 const maxResetPeriod = 0x7FFFFFFF;" clamp_bound)
+if(clamp_bound EQUAL -1)
+    message(FATAL_ERROR
+        "the overflow clamp must bound the period at INT32_MAX")
 endif()
 
 # Match the operator forms, not a bare "currTime": the explanatory comment in

--- a/src/game/WorldHandlers/CalendarHandler.cpp
+++ b/src/game/WorldHandlers/CalendarHandler.cpp
@@ -136,14 +136,23 @@ void WorldSession::HandleCalendarGetCalendar(WorldPacket& /*recv_data*/)
         if (!sentMaps.insert(mapId).second)
             continue;
 
-        uint32 resetTime = sMapPersistentStateMgr.GetScheduler().GetMaxResetTimeFor(mapDiff);
+        // GetMaxResetTimeFor returns a DURATION - RaidDuration scaled and
+        // floored to whole days - not an absolute reset timestamp. It was
+        // being compared against currTime, which a duration can never exceed,
+        // so every record went out as zero. The client uses this word as the
+        // recurrence period: it steps from the calendar epoch by this value,
+        // and divides by it. Retail carries exactly the value class this
+        // helper produces - 604800, 259200 and 86400 - and never zero.
+        uint32 resetPeriod = sMapPersistentStateMgr.GetScheduler().GetMaxResetTimeFor(mapDiff);
         MopCalendarPackets::CalendarListReset record;
         record.mapId = int32(mapId);
-        record.resetRemaining = resetTime > currTime ?
-            int32(resetTime - currTime) : 0;
-        record.offset = 0; // Direct reader proves the scalar, not a nonzero meaning.
+        record.resetRemaining = int32(resetPeriod);
+        // Retail sends zero here for every raid but one, which carries a
+        // seconds-into-the-day reset offset, so zero is a legal value rather
+        // than an absent one. We do not model per-map reset hours yet.
+        record.offset = 0;
         resetRecords.push_back(record);
-        DEBUG_FILTER_LOG(LOG_FILTER_CALENDAR, "MapId [%u] -> Reset in: %d", mapId, record.resetRemaining);
+        DEBUG_FILTER_LOG(LOG_FILTER_CALENDAR, "MapId [%u] -> Reset period: %d", mapId, record.resetRemaining);
     }
     DEBUG_FILTER_LOG(LOG_FILTER_CALENDAR, "Map sent [%zu]", resetRecords.size());
 

--- a/src/game/WorldHandlers/CalendarHandler.cpp
+++ b/src/game/WorldHandlers/CalendarHandler.cpp
@@ -141,12 +141,19 @@ void WorldSession::HandleCalendarGetCalendar(WorldPacket& /*recv_data*/)
         // being compared against currTime, which a duration can never exceed,
         // so every record went out as zero. The client uses this word as the
         // recurrence period: it steps from the calendar epoch by this value,
-        // and divides by it. Retail carries exactly the value class this
-        // helper produces - 604800, 259200 and 86400 - and never zero.
+        // and divides by it. Retail carries 604800 for the weekly raids and
+        // 259200 for map 509, which is what the IsRaid filter above admits,
+        // and never zero.
         uint32 resetPeriod = sMapPersistentStateMgr.GetScheduler().GetMaxResetTimeFor(mapDiff);
         MopCalendarPackets::CalendarListReset record;
         record.mapId = int32(mapId);
-        record.resetRemaining = int32(resetPeriod);
+        // Rate.InstanceResetTime is only validated against being negative, so
+        // a large enough rate makes the scaled duration exceed INT32_MAX and
+        // the cast wrap negative. The client divides by this word, so a
+        // negative divisor is worse than an implausibly distant reset.
+        uint32 const maxResetPeriod = 0x7FFFFFFF;
+        record.resetRemaining =
+            int32(resetPeriod > maxResetPeriod ? maxResetPeriod : resetPeriod);
         // Retail sends zero here for every raid but one, which carries a
         // seconds-into-the-day reset offset, so zero is a legal value rather
         // than an absent one. We do not model per-map reset hours yet.


### PR DESCRIPTION
## What

`DungeonResetScheduler::GetMaxResetTimeFor` returns a **duration** — `RaidDuration` scaled and floored to whole days, minimum one day — not an absolute reset timestamp. `HandleCalendarGetCalendar` compared it against absolute `currTime`, which a duration can never exceed, so the guard fired on every record and **all 32 went out as zero**.

The client uses this word as a **recurrence period**: it steps from the calendar epoch by this value, and divides by it.

## Evidence

Measured against 312 retail `SMSG_CALENDAR_SEND_CALENDAR` captures (10,920 reset records):

```
word2 values: {604800: 9672, 259200: 312, 86400: 936}   zero NEVER occurs
```

It is also **constant per map across four months of captures**, which a countdown cannot be.

Confirmed a second way: our live 408-byte packet was diffed byte-for-byte against the four retail captures with the identical shape (`holidays = lockouts = invites = events = 0`, 444 bytes). Every one of the 32 maps we share with retail had `word2 = 0` on our side and a real period on theirs:

```
map 249   ours(0, 0)   retail(604800, 0)
map 509   ours(0, 0)   retail(259200, 68400)
...
```

Codex independently parsed the local 5.4.8 `MapDifficulty.dbc` and `Map.dbc` and confirmed the value class is exactly `{86400, 259200, 604800}`, so with the default rate this helper reproduces retail's numbers per-map.

## The adjacent loop is deliberately untouched

The personal lockout loop immediately above looks identical but is **correct**: `DungeonPersistentState::GetResetTime()` really is an absolute `time_t`, so subtracting `currTime` there is a genuine countdown and the guard against going negative is required. The test pins both halves, with a `clamp_lockout_away` arm that fails if anyone "fixes" the good one by analogy.

## Overflow clamp

`Rate.InstanceResetTime` is validated only against being negative — no upper bound. Above a rate of roughly 3550.857 a seven-day row exceeds `INT32_MAX` and the cast wraps negative; rate 4000 yields `-1,875,767,296`. Since the client *divides* by this word, the period is now clamped at `INT32_MAX`.

## Known remaining deltas vs retail

Both predate this change and are deliberately out of scope, to keep the live A/B narrow:

- **Maps 938, 939, 940** — retail lists them at 86400. They sit behind the `IsRaid()` filter along with **53 other daily-duration instance maps**, so admitting them needs its own eligibility rule; simply dropping `IsRaid()` would add all 56.
- **Map 509's `offset = 68400`** — the only non-zero reset-hour in the retail list. We send 0 and do not model per-map reset hours.

## Verification

- `game.lib` builds clean, MSVC Release
- `ctest -R calendar` → **28/28**
- baseline exits 0; all five `WILL_FAIL` arms exit non-zero for their own distinct reasons
- Codex read-only review: **APPROVE WITH FOLLOW-UP**, no BLOCKING. Both IMPORTANTs (the unbounded rate conversion, and a comment overstating the emitted value set) and both MINORs are fixed in `64fee1be3`.

**Not a claimed hang fix.** This is a protocol-correctness change and is correct on the wire regardless. A client hang in this area is under separate investigation and its causation is not established.

## Test hardening

A mutation whose `string(REPLACE)` target drifts out of the source becomes a silent no-op, and `WILL_FAIL` cannot distinguish that from a real failure — which bit this test during this very commit, when rewording the assignment quietly disarmed `restore_subtraction`. The script now exits **zero** when a mutation changes nothing, so `WILL_FAIL` reports that arm as broken rather than green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/56)
<!-- Reviewable:end -->
