### PR TITLE
[Movement] Stop rejecting every near-teleport acknowledgement

### DIFF
--- a/src/game/WorldHandlers/MovementHandler.cpp
+++ b/src/game/WorldHandlers/MovementHandler.cpp
@@ -328,14 +328,27 @@ void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)
     DEBUG_LOG("CMSG_MOVE_TELEPORT_ACK");
 
     ObjectGuid guid;
-    uint32 counter, time;
-    recv_data >> counter >> time;
+    // 18414 writes its own millisecond timestamp first, then echoes the counter
+    // the server put in SMSG_MOVE_TELEPORT. Reading them the other way round is
+    // why the log printed "Counter <ms timestamp>, time 0" on every ack: the
+    // zero is our own counter coming back, and the timestamp is the client's.
+    uint32 clientTime, counter;
+    recv_data >> clientTime >> counter;
 
+    // The mover guid follows as a packed guid. The bit/byte permutation below
+    // is NOT wire-confirmed: every character on this realm has a guid under 256,
+    // so only one mask bit is ever set and only the first slot can be observed.
+    // The captured acks carry mask 0x80 with a single trailing byte equal to the
+    // player's guid, which places the first-read bit at byte 0 -- the order below
+    // put it at byte 5, so the parse yielded 0x0000030000000000 and printed as
+    // "Guid: 0". Byte consumption is permutation-independent (one mask byte, then
+    // popcount(mask) bytes), so the remaining seven slots cannot be recovered
+    // from our own traffic and are left as found rather than invented.
     recv_data.ReadGuidMask<5, 0, 1, 6, 3, 7, 2, 4>(guid);
     recv_data.ReadGuidBytes<4, 2, 7, 6, 5, 1, 3, 0>(guid);
 
     DEBUG_LOG("Guid: %s", guid.GetString().c_str());
-    DEBUG_LOG("Counter %u, time %u", counter, time / IN_MILLISECONDS);
+    DEBUG_LOG("Counter %u, clientTime %u", counter, clientTime / IN_MILLISECONDS);
 
     Unit* mover = _player->GetMover();
     Player* plMover = mover->GetTypeId() == TYPEID_PLAYER ? (Player*)mover : NULL;
@@ -345,10 +358,14 @@ void WorldSession::HandleMoveTeleportAckOpcode(WorldPacket& recv_data)
         return;
     }
 
-    if (guid != plMover->GetObjectGuid())
-    {
-        return;
-    }
+    // No guid equality check. It rejected every valid ack -- the parse above
+    // cannot be trusted until the permutation is recovered, and the guard adds
+    // nothing here: this opcode arrives on the player's own authenticated
+    // session, plMover comes from that session, and IsBeingTeleportedNear()
+    // already establishes that a near teleport is outstanding. Rejecting on a
+    // mis-parsed guid meant SetPosition() below never ran, so the server left
+    // the player at the origin while the client had already moved -- no grid
+    // transition, no visibility rebuild, and an empty destination until relog.
 
     plMover->SetSemaphoreTeleportNear(false);
 


### PR DESCRIPTION
`HandleMoveTeleportAckOpcode` parsed the mover guid with a permutation that places the first mask bit at guid **byte 5**. The 18414 client sets that bit for **byte 0**, so the parse produced `0x0000030000000000` and the handler's `guid != plMover->GetObjectGuid()` guard rejected every ack. The server log printed `Guid: Player (Guid: 0)` on **all nine** acks of a test session.

## Why this was worse than an empty destination

The guard returns *before* `SetSemaphoreTeleportNear(false)`, so `IsBeingTeleported()` stayed true for the rest of the session — and `Player::Update` skips the visibility observer sweep while it is set. **A single same-map teleport stopped object creation session-wide.**

That is the exact failure the existing `mop_movement_source` test describes, whose registration half was already fixed. The ack was reaching the handler and being discarded inside it.

## Measured on 5.4.8.18414

Object **blocks** per phase (not packets — one `SMSG_UPDATE_OBJECT` carries 1 to 400+):

| | blocks | biggest packet |
|---|---|---|
| **before** — login | 755 | 311 |
| **before** — 8 near-teleports | 0 / 1 / 54 / 64 / 115 / 0 / 0 / 1 | ≤ 10 |
| **after** — 3 near-teleports | 233 / 189 / 257 | 113–169 |

Unchanged by a 93-second wait or by 55 movement packets, so it was never slow grid loading. Cross-map teleport was never affected — it runs the worldport path, which rebuilds visibility through a full remove/add cycle. Relog appeared to fix the destination only because `m_teleport_dest` is what `SaveToDB` writes.

Live-verified in game: NPCs now present at the destination after `.tele`.

## Scalars were also swapped

The client sends its own millisecond timestamp first, then echoes the counter the server put in `SMSG_MOVE_TELEPORT`. That is why the log read `Counter <ms timestamp>, time 0` and now reads `Counter 0, clientTime 15843`.

## What this deliberately does NOT fix

**The guid permutation is unchanged.** Every character on this realm has a guid below 256, so exactly one mask bit is ever set and only the first slot is observable — seven of the eight entries cannot be recovered from our own traffic, and inventing them would be worse than leaving them.

The guard is removed instead. This opcode arrives on the player's own authenticated session, `plMover` is derived from that session, and `IsBeingTeleportedNear()` already establishes an outstanding near teleport. Byte consumption is permutation-independent (one mask byte, then `popcount(mask)` bytes), so nothing desyncs.

**Follow-up:** a retail capture containing `CMSG_MOVE_TELEPORT_ACK` from a player with a large guid sets multiple mask bits and yields the true order directly. The 146-capture corpus should have one.

## Checks

- `mop_movement_source_test.cmake` baseline exit 0; `teleport_ack_registration` mutation exit 1 (correctly fails)
- `mop_world_entry_packets_source_test.cmake` exit 0
- Build: RelWithDebInfo, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/57)
<!-- Reviewable:end -->
