### PR TITLE
[World] Send SMSG_SET_TIME_ZONE_INFORMATION at login

### DIFF
--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1265,6 +1265,37 @@ namespace MopWorldEntryPackets
         out << counter;
     }
 
+    /**
+     * @brief SMSG_SET_TIME_ZONE_INFORMATION - two 7-bit lengths, then two strings.
+     *
+     * The client copies both strings into fixed 127-byte buffers and then
+     * resolves each by NAME against a registry compiled into the binary. Until
+     * this arrives those buffers are zero, the lookup returns null, and the
+     * timezone conversion silently writes nothing - leaving its caller to copy
+     * an all-minus-one scratch struct over an otherwise valid date. That is what
+     * hangs the client's calendar: a date with a negative day, month or year can
+     * never advance, and the comparison it is tested against can never fail.
+     *
+     * The name must be one the client actually knows. Its registry holds IANA
+     * identifiers - Etc/UTC, the US zones, Europe/Paris and others - so a Windows
+     * display name such as "GMT Standard Time" will not resolve, and neither will
+     * anything read from the host's timezone database.
+     *
+     * Both strings are the same value, which is what the reference server sends
+     * and what sidesteps the one thing we cannot pin: the client reads the second
+     * length's string first, so with differing values the pairing would matter.
+     * If this ever needs to send two distinct zones, recover that order first.
+     */
+    inline void BuildSetTimeZoneInformation(WorldPacket& out,
+        std::string const& location)
+    {
+        out.WriteBits(location.length(), 7);
+        out.WriteBits(location.length(), 7);
+        out.FlushBits();
+        out.WriteStringData(location);
+        out.WriteStringData(location);
+    }
+
     struct DiscardedTimeSyncAcksReport
     {
         bool hasValue = false;

--- a/src/game/Server/tests/mop_world_entry_packets_test.cpp
+++ b/src/game/Server/tests/mop_world_entry_packets_test.cpp
@@ -96,6 +96,34 @@ static void test_time_sync()
     CHECK(ExpectBytes(packet, { 0x44, 0x33, 0x22, 0x11 }));
 }
 
+static void test_set_time_zone_information()
+{
+    // Two 7-bit lengths packed MSB-first, so 7 and 7 give 0000111 0000111,
+    // flushed to 0x0E 0x1C, then the string twice. The client copies each into
+    // a 127-byte buffer and resolves it by name, so the bytes must be the
+    // literal identifier and the lengths must precede both strings.
+    WorldPacket packet(SMSG_SET_TIME_ZONE_INFORMATION, 2 + 2 * 7);
+    MopWorldEntryPackets::BuildSetTimeZoneInformation(packet, "Etc/UTC");
+    CHECK(ExpectBytes(packet, {
+        0x0E, 0x1C,
+        0x45, 0x74, 0x63, 0x2F, 0x55, 0x54, 0x43,
+        0x45, 0x74, 0x63, 0x2F, 0x55, 0x54, 0x43
+    }));
+}
+
+static void test_set_time_zone_information_length_is_seven_bits()
+{
+    // A length of 64 must still fit: the field is 7 bits, so anything up to 127
+    // is legal and the client's own copy caps at 127. A 6-bit field would wrap
+    // this to 0 and the client would resolve an empty name.
+    const std::string sixtyFour(64, 'A');
+    WorldPacket packet(SMSG_SET_TIME_ZONE_INFORMATION, 2 + 2 * 64);
+    MopWorldEntryPackets::BuildSetTimeZoneInformation(packet, sixtyFour);
+    CHECK(packet.size() == 2 + 2 * 64);
+    CHECK(packet.contents()[0] == 0x81);   // 1000000 1000000 -> 0x81 0x00
+    CHECK(packet.contents()[1] == 0x00);
+}
+
 static void test_discarded_time_sync_acks_absent()
 {
     uint8_t const body[] = { 0x80 };
@@ -261,6 +289,8 @@ int main(int /*argc*/, char** /*argv*/)
     test_new_world();
     test_login_set_time_speed();
     test_time_sync();
+    test_set_time_zone_information();
+    test_set_time_zone_information_length_is_seven_bits();
     test_discarded_time_sync_acks_absent();
     test_discarded_time_sync_acks_present();
     test_time_sync_response_dropped();

--- a/src/game/WorldHandlers/CharacterHandler.cpp
+++ b/src/game/WorldHandlers/CharacterHandler.cpp
@@ -853,6 +853,18 @@ void WorldSession::HandlePlayerLogin(LoginQueryHolder* holder)
         lts << packedNow;
         lts << float(0.01666667f);
         SendPacket(&lts, true);
+
+        // SMSG_SET_TIME_ZONE_INFORMATION: names the server's timezone so the
+        // client can populate the two 127-byte buffers its date conversion
+        // resolves against. Without it those stay zero, the conversion writes
+        // nothing, and its caller copies an all-minus-one scratch struct over
+        // the date -- which is what hangs the calendar on open. Etc/UTC is one
+        // of the identifiers compiled into the client; a host timezone name is
+        // not, so this is deliberately a constant rather than anything read
+        // from the machine.
+        WorldPacket tz(SMSG_SET_TIME_ZONE_INFORMATION, 2 + 2 * 7);
+        MopWorldEntryPackets::BuildSetTimeZoneInformation(tz, "Etc/UTC");
+        SendPacket(&tz, true);
     }
     // PHASE 6c: NO control/mover packet is sent -- none is needed. The 18414 client grants player
     // control itself when it processes the SELF create-block: the create/add-to-world path marks the


### PR DESCRIPTION
## What

We have never sent `SMSG_SET_TIME_ZONE_INFORMATION` (`0x19C1`). The opcode was declared and registered for logging, with **no sender anywhere in the tree**.

## Why it hangs the calendar

The client copies the packet's two strings into fixed 127-byte buffers and resolves each **by name** against a timezone registry compiled into the binary. Until the packet arrives those buffers stay zero, the lookup returns null, and `sub_1403857B0` — which writes its output on exactly one path — returns without writing anything. Its caller copies the result in regardless:

```c
sub_140A65BD0(&v41);        // v41 = all -1
sub_1403857B0(&v41, a4);    // returns without writing
*(_QWORD *)a4 = v41;        // copied back UNCONDITIONALLY
```

A date with a negative day, month or year can never be advanced (`sub_140A664A0` no-ops), and the comparison it's tested against treats a negative on either side as a match (`sub_140A65E20`), so the holiday expansion loop spins forever — one core pinned, client unresponsive.

Two memory dumps of hung clients show **both buffers as 272 consecutive zero bytes**, never written.

## Corpus evidence

Measured against 238 retail captures:

```
SMSG_SET_TIME_ZONE_INFORMATION (0x19C1, S->C): 843
len 26   len1=12  len2=12   s2='Europe/Paris'  s1='Europe/Paris'  residual=0
size distribution: {26: 843}
```

843 instances, all 26 bytes, every one decoding to two 7-bit lengths plus two identical strings with **zero residual**. That pins the opcode value — our table carried it as `name reference-consensus`, the same provenance class that proved wrong for another symbol earlier — and the wire layout, simultaneously.

## Two things the evidence dictates

**The name must be an IANA identifier.** The client's registry holds `Etc/UTC`, `Europe/Paris`, the US zones and others. A Windows display name like `GMT Standard Time` will not resolve, and neither will anything read from the host's timezone database — Windows discovery runs through a separate path into separate storage and never touches these buffers.

**Both strings carry the same value, deliberately.** The client reads the *second* length's string first. Sending one value sidesteps a pairing we have not pinned. If this ever needs two distinct zones, recover that order first — there's a comment saying so at the call site.

## Change

- `MopWorldEntryPackets::BuildSetTimeZoneInformation` in `Player.h`, beside `BuildLoginSetTimeSpeed`
- sent at character login, immediately after `SMSG_LOGIN_SETTIMESPEED` and before `m_suppressWorldSends`
- two byte-exact tests: the `Etc/UTC` encoding (`0x0E 0x1C` + the string twice), and a 64-character case proving the length field is 7 bits and not 6 — a 6-bit field would wrap to zero and the client would resolve an empty name

## Verification

- `game.lib` builds clean, MSVC Release
- `ctest -R "world_entry|calendar|initial"` → **55/55**
- the executable test confirmed to actually run the new assertions, not merely compile them

**Not yet verified live.** Whether the calendar opens is a client test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/58)
<!-- Reviewable:end -->
