### PR TITLE
[Server] Send the addon public key in the client's scatter order

### DIFF
--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -1666,11 +1666,16 @@ void WorldSession::SendAddonsInfo()
     // the 18414 client rejected every addon (all shown disabled / "download an updated version"):
     // it cannot parse a single field of the flat form. Layout: header = banned-addon count (18 bits)
     // + addon count (23 bits); then ONE 3-bit flag group per addon (hasUrl, enabled, serverSendsKey),
-    // byte-aligned via FlushBits; then per-addon byte data; then the banned block. This first pass
-    // omits the server public key (serverSendsKey = 0) to validate the packed framing against the live
-    // client -- the 256-byte key and its scatter permutation are added once the framing is confirmed.
-    // Enable/ban/allow policy will move into a dedicated module (AddonRegistry). tdata (the Blizzard
-    // public key) is kept for that follow-up.
+    // byte-aligned via FlushBits; then per-addon byte data; then the banned block.
+    //
+    // The framing below is confirmed against retail: all 128 SMSG_ADDON_INFO bodies in the 18414
+    // capture corpus are 286 bytes and decode under exactly this grammar with zero residual
+    // (bannedCount 0, addonCount 44, every flag group 0b010, every per-addon record
+    // 01 00 00 00 00 02). Retail clears serverSendsKey and ships no key at all, because a retail
+    // client already holds one in its .pub cache; we send ours so that a fresh install validates
+    // without depending on what the archives happen to carry.
+    //
+    // Enable/ban/allow policy will move into a dedicated module (AddonRegistry).
     WorldPacket data(SMSG_ADDON_INFO);
 
     data.WriteBits(0, 18);                                  // banned-addon count (none yet)
@@ -1685,13 +1690,12 @@ void WorldSession::SendAddonsInfo()
 
     for (AddonsList::const_iterator itr = m_addonsList.begin(); itr != m_addonsList.end(); ++itr)
     {
-        // serverSendsKey bit set -> the 256-byte RSA public key. The client uses this key directly as
-        // the RSA modulus to verify the addon signature; a MISSING key left the modulus 0 and the client
-        // faulted INT_DIVIDE_BY_ZERO inside its bignum modular-reduce (sub_1402E2B20). Sent raw this pass
-        // to confirm the key is what the parser needs -- if the addons validate, the raw byte order is
-        // correct; if they stay disabled (no crash), the order needs the scatter permutation and I'll
-        // derive it from the client parser.
-        data.append(tdata, sizeof(tdata));
+        // serverSendsKey bit set -> the 256-byte RSA public key, emitted in the client's scatter
+        // order rather than modulus order. See MopAddonPackets::kAddonKeyWireOrder: the parser
+        // stores wire byte i at key[kAddonKeyWireOrder[i]], so a raw append left the client with a
+        // key wrong at 254 of 256 positions, failing signature verification and loading every
+        // "## Secure:" Blizzard addon untrusted.
+        MopAddonPackets::AppendAddonPublicKey(data, tdata);
         // 'enabled' bit was set -> { u8 enabled, u32 reserved }; then the state byte (2 = valid/loaded).
         data << uint8(1);
         data << uint32(0);

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -1209,6 +1209,55 @@ struct AddonInfo
 
 typedef std::list<AddonInfo> AddonsList;
 
+namespace MopAddonPackets
+{
+    // SMSG_ADDON_INFO does not carry the addon public key in modulus order. The client's
+    // generated parser (JamAddonInfo, sub_14050D1B0 in the 18414 x64 client) reads the 256
+    // key bytes one at a time and scatters each one to a fixed destination inside the addon
+    // record: wire byte i is stored at key[kAddonKeyWireOrder[i]]. To make the client
+    // reconstruct the modulus, the server must therefore emit key[kAddonKeyWireOrder[i]].
+    //
+    // Sending the modulus in its natural order left the client holding a key that differed
+    // from the real one at 254 of 256 positions, so the RSA check inside sub_140D0CFD0
+    // failed, sub_140D0D480 returned 1 ("corrupt signature") instead of 3, and every
+    // "## Secure:" Blizzard addon loaded UNTRUSTED. An untrusted addon is executed under its
+    // own taint identity, which is why Blizzard_TimeManager, Blizzard_CompactRaidFrames and
+    // the rest tainted their globals at the very first line of each file.
+    //
+    // The table was recovered from the parser and then confirmed against live client output:
+    // the 44 .pub files the client wrote back satisfy pub[kAddonKeyWireOrder[i]] == tdata[i]
+    // for all 256 i, which is exactly the raw-order send being scattered.
+    uint8 const kAddonKeyWireOrder[256] =
+    {
+          5, 176, 148,  43,  28, 135,  64,   8, 160, 145, 226, 119, 181, 192, 240,  72,
+        243, 212, 209, 172,  21, 237,  85,  10,  75, 117, 244,  82,  24,  20,  18,  76,
+         67,  57, 157,  59, 198,  90,  22,   6,  49,  12,  95, 193, 118,  94,  40,  98,
+        255, 169, 214,  83, 128, 219,  73, 247, 132, 202, 218, 154, 112, 131, 177, 111,
+        144,  56,  39, 152,  48,  63,  25, 114,  38,  84,  99, 165, 126,  34,  69, 183,
+        185,  52, 103,  36, 233,   3,  47, 141, 162, 232, 194, 253, 116,  27,  80,  46,
+         89, 107, 189,  14, 225, 167, 140, 250, 188,  17,  29, 137, 133,  74, 178,  62,
+        236,  31, 101,   9, 164, 200, 136, 159, 197, 216, 246, 134,   0,  97, 234, 166,
+        204,  65,  60, 223, 122,   2,   4, 239, 249,  30, 252, 211, 124,  26,  23, 161,
+         92, 138,  37, 227, 120, 153, 115, 151, 254, 173, 175, 108, 130, 251, 170, 158,
+         11, 245, 190, 104, 217,   7,  78, 231, 155, 171,  55,  81, 143, 206,  70, 156,
+         88,  45, 201, 182, 180,  16, 215, 230,  50, 149, 203, 168, 220, 187,  41,  61,
+        238, 208, 224, 106, 205, 222,  42,  68, 127, 210,  77, 129, 213,  15, 102, 146,
+         54,  35,  91,  19, 199,  32, 139, 150, 196, 125,  53, 100, 113, 110,  71, 191,
+         58, 242, 248,  13, 184, 163, 147,  79,  93, 229, 228, 186, 207,   1,  66,  33,
+        121,  96, 123, 179, 235, 241, 109, 142,  44,  86, 195, 174,  87, 105,  51, 221
+    };
+
+    // Append the 256-byte addon public key in the scatter order the client's parser expects.
+    // 'key' must point at 256 bytes of modulus in natural order.
+    inline void AppendAddonPublicKey(ByteBuffer& out, uint8 const* key)
+    {
+        for (uint32 i = 0; i < 256; ++i)
+        {
+            out << uint8(key[kAddonKeyWireOrder[i]]);
+        }
+    }
+}
+
 /**
  * @brief Party operation enumeration
  */

--- a/src/game/Server/WorldSession.h
+++ b/src/game/Server/WorldSession.h
@@ -1227,7 +1227,11 @@ namespace MopAddonPackets
     // The table was recovered from the parser and then confirmed against live client output:
     // the 44 .pub files the client wrote back satisfy pub[kAddonKeyWireOrder[i]] == tdata[i]
     // for all 256 i, which is exactly the raw-order send being scattered.
-    uint8 const kAddonKeyWireOrder[256] =
+    // inline constexpr, not plain const: a namespace-scope const has internal linkage, so an
+    // external-linkage inline function odr-using it would name a different object in every
+    // translation unit that includes this header -- ill-formed, no diagnostic required, and it
+    // would also duplicate the table across a lot of object files.
+    inline constexpr uint8 kAddonKeyWireOrder[256] =
     {
           5, 176, 148,  43,  28, 135,  64,   8, 160, 145, 226, 119, 181, 192, 240,  72,
         243, 212, 209, 172,  21, 237,  85,  10,  75, 117, 244,  82,  24,  20,  18,  76,

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -413,6 +413,14 @@ foreach(mutation IN ITEMS time_sync_registration time_sync_parse_order)
         PROPERTIES WILL_FAIL TRUE)
 endforeach()
 
+add_executable(mop_addon_packets_test mop_addon_packets_test.cpp)
+target_include_directories(mop_addon_packets_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${CMAKE_SOURCE_DIR}/src/shared)
+set_target_properties(mop_addon_packets_test PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+target_link_libraries(mop_addon_packets_test PRIVATE game)
+add_test(NAME mop_addon_packets COMMAND mop_addon_packets_test)
+
 add_executable(mop_control_packets_test mop_control_packets_test.cpp)
 target_include_directories(mop_control_packets_test PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/..

--- a/src/game/Server/tests/mop_addon_packets_test.cpp
+++ b/src/game/Server/tests/mop_addon_packets_test.cpp
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2026 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+/**
+ * Tests for the SMSG_ADDON_INFO public-key scatter order.
+ *
+ * The 18414 client does not read the addon public key in modulus order. Its generated
+ * parser stores wire byte i at key[kAddonKeyWireOrder[i]]. Getting this wrong is silent:
+ * the client simply ends up with a different modulus, signature verification fails, and
+ * every "## Secure:" Blizzard addon loads untrusted with no error anywhere in the log.
+ * These tests exist because that failure mode has no other alarm.
+ */
+
+#include "WorldSession.h"
+#include "Opcodes.h"
+#include "WorldPacket.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <set>
+#include <vector>
+
+static int g_fail = 0;
+#define CHECK(c) do { if (!(c)) { std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #c); ++g_fail; } } while (0)
+
+/**
+ * The table must be a bijection on 0..255. If it is not, some modulus byte is dropped and
+ * another duplicated, and the client can never reconstruct the key no matter what we send.
+ */
+static void TestScatterOrderIsAPermutation()
+{
+    std::set<uint8> seen;
+    for (uint32 i = 0; i < 256; ++i)
+    {
+        seen.insert(MopAddonPackets::kAddonKeyWireOrder[i]);
+    }
+
+    CHECK(seen.size() == 256);
+    CHECK(*seen.begin() == 0);
+    CHECK(*seen.rbegin() == 255);
+}
+
+/**
+ * Anchors against the client. These specific pairs were read out of the client's parser and
+ * then independently confirmed against the 44 .pub files it wrote back to disk, so they are
+ * the one part of the table that is externally pinned. A round-trip test alone would happily
+ * accept a differently-scrambled but still bijective table; these pairs would not.
+ */
+static void TestScatterOrderMatchesTheClient()
+{
+    static uint8 const head[8] = { 5, 176, 148, 43, 28, 135, 64, 8 };
+    static uint8 const tail[8] = { 44, 86, 195, 174, 87, 105, 51, 221 };
+
+    for (uint32 i = 0; i < 8; ++i)
+    {
+        CHECK(MopAddonPackets::kAddonKeyWireOrder[i] == head[i]);
+        CHECK(MopAddonPackets::kAddonKeyWireOrder[248 + i] == tail[i]);
+    }
+}
+
+/**
+ * Emitting an identity key makes the wire bytes equal the table itself, which pins the
+ * direction of the mapping. Sending key[i] instead of key[kAddonKeyWireOrder[i]] -- the
+ * bug this replaced -- fails here immediately.
+ */
+static void TestIdentityKeyEmitsTheTable()
+{
+    uint8 key[256];
+    for (uint32 i = 0; i < 256; ++i)
+    {
+        key[i] = uint8(i);
+    }
+
+    WorldPacket packet(SMSG_ADDON_INFO, 256);
+    MopAddonPackets::AppendAddonPublicKey(packet, key);
+
+    CHECK(packet.size() == 256);
+    if (packet.size() != 256)
+    {
+        return;
+    }
+
+    for (uint32 i = 0; i < 256; ++i)
+    {
+        CHECK(packet.contents()[i] == MopAddonPackets::kAddonKeyWireOrder[i]);
+    }
+}
+
+/**
+ * Replay what the client does: scatter each wire byte to its destination and check the
+ * modulus comes back out intact. This is the property the whole change exists to hold.
+ */
+static void TestClientReconstructsTheModulus()
+{
+    uint8 key[256];
+    for (uint32 i = 0; i < 256; ++i)
+    {
+        key[i] = uint8((i * 7u + 13u) & 0xFF);       // arbitrary, just not the identity
+    }
+
+    WorldPacket packet(SMSG_ADDON_INFO, 256);
+    MopAddonPackets::AppendAddonPublicKey(packet, key);
+
+    CHECK(packet.size() == 256);
+    if (packet.size() != 256)
+    {
+        return;
+    }
+
+    uint8 reconstructed[256] = { 0 };
+    for (uint32 i = 0; i < 256; ++i)
+    {
+        reconstructed[MopAddonPackets::kAddonKeyWireOrder[i]] = packet.contents()[i];
+    }
+
+    for (uint32 i = 0; i < 256; ++i)
+    {
+        CHECK(reconstructed[i] == key[i]);
+    }
+}
+
+/**
+ * Guard the regression directly: a raw append is wrong at 254 of 256 positions against the
+ * real modulus. Only the two fixed points of the permutation coincide.
+ */
+static void TestRawOrderIsWrongAtAlmostEveryPosition()
+{
+    uint32 fixedPoints = 0;
+    for (uint32 i = 0; i < 256; ++i)
+    {
+        if (MopAddonPackets::kAddonKeyWireOrder[i] == i)
+        {
+            ++fixedPoints;
+        }
+    }
+
+    CHECK(fixedPoints == 2);
+}
+
+int main()
+{
+    TestScatterOrderIsAPermutation();
+    TestScatterOrderMatchesTheClient();
+    TestIdentityKeyEmitsTheTable();
+    TestClientReconstructsTheModulus();
+    TestRawOrderIsWrongAtAlmostEveryPosition();
+
+    if (g_fail)
+    {
+        std::fprintf(stderr, "%d check(s) failed\n", g_fail);
+        return 1;
+    }
+
+    std::printf("mop_addon_packets_test: all checks passed\n");
+    return 0;
+}

--- a/src/game/Server/tests/mop_addon_packets_test.cpp
+++ b/src/game/Server/tests/mop_addon_packets_test.cpp
@@ -81,6 +81,33 @@ static void TestScatterOrderMatchesTheClient()
 }
 
 /**
+ * Pin all 256 entries, not just the anchors above.
+ *
+ * The other tests are self-consistent: swapping two middle entries preserves the bijection,
+ * the fixed-point count, the head/tail anchors, the identity comparison and the reconstruction
+ * round trip -- and still ships a corrupt modulus, silently, because nothing on the client
+ * logs a bad key. This digest is the only check that constrains the interior of the table.
+ *
+ * FNV-1a/32 over the 256 entries in order. The value comes from the table as recovered from
+ * the client parser and confirmed against the 44 .pub files the client wrote back.
+ */
+static void TestScatterOrderDigest()
+{
+    uint32 hash = 0x811C9DC5u;
+    for (uint32 i = 0; i < 256; ++i)
+    {
+        hash ^= MopAddonPackets::kAddonKeyWireOrder[i];
+        hash *= 0x01000193u;
+    }
+
+    CHECK(hash == 0x11A63A0Fu);
+    if (hash != 0x11A63A0Fu)
+    {
+        std::fprintf(stderr, "  table digest 0x%08X, wanted 0x11A63A0F\n", hash);
+    }
+}
+
+/**
  * Emitting an identity key makes the wire bytes equal the table itself, which pins the
  * direction of the mapping. Sending key[i] instead of key[kAddonKeyWireOrder[i]] -- the
  * bug this replaced -- fails here immediately.
@@ -163,6 +190,7 @@ int main()
 {
     TestScatterOrderIsAPermutation();
     TestScatterOrderMatchesTheClient();
+    TestScatterOrderDigest();
     TestIdentityKeyEmitsTheTable();
     TestClientReconstructsTheModulus();
     TestRawOrderIsWrongAtAlmostEveryPosition();


### PR DESCRIPTION
## The symptom

Every `## Secure:` Blizzard addon loaded **untrusted**, tainting its globals from the first executable line of each file. The visible edge was ESC failing to run its tidy-up calls:

```
Execution tainted by Blizzard_TimeManager while reading TimeManagerFrame
  - Interface\FrameXML\UIParent.lua:3163 ToggleGameMenu()
blocked: SpellStopCasting()  SpellStopTargeting()  ClearTarget()
```

`WorldFrame.lua` reads `TimeManagerClockButton` and `StopwatchTicker` every frame, so the execution path was permanently tainted. `taint.log` ran to 11,610 lines.

## Cause

`SMSG_ADDON_INFO` does not carry the addon public key in modulus order. The client's generated parser (`JamAddonInfo`, `sub_14050D1B0` in the 18414 x64 client) reads the 256 key bytes one at a time and scatters each to a fixed destination in its addon record: **wire byte `i` is stored at `key[P[i]]`**.

We appended the modulus in natural order, so the client reconstructed a key wrong at **254 of 256** positions. The RSA check in `sub_140D0CFD0` failed, `sub_140D0D480` returned 1 (*corrupt signature*) instead of 3, and the addon never became trusted.

Nothing is logged on that path. A wrong key produces no error anywhere — which is why this only ever presented as taint.

## Evidence

The permutation was recovered from the parser and then **confirmed against live client output**. The client caches what it parsed as `Interface\AddOns\<Name>\<Name>.pub` (257 bytes: type byte + key), so those files read back exactly what it received:

| | before | after |
|---|---|---|
| key head | `57 79 D6 3D 0F C3 6D 72` | `C3 5B 50 84 B9 3E 32 42` |
| bytes differing from the modulus | **254 / 256** | **0 / 256** |
| `taint.log` | 11,610 lines | never created |

Before the fix all 44 `.pub` files satisfied `pub[P[i]] == tdata[i]` for all 256 `i` — precisely a raw-order send being scattered. After it they are byte-identical to the modulus, with `taintLog=2` confirmed active and an active negative control (deliberately provoked taint still logs).

The two positions that accidentally matched before are the permutation's only fixed points, 151 and 180. No coincidental collisions.

## Framing is unchanged and was already correct

All 128 `SMSG_ADDON_INFO` bodies in the 18414 capture corpus (238 files, 104,072,070 records) are 286 bytes and decode under the existing bit grammar with **zero residual**: banned count 0, addon count 44, every flag group `0b010`, every per-addon record `01 00 00 00 00 02`. Only the 256 key-byte values are reordered here; packet length is identical.

Retail clears the key bit and ships no key, but **no archive in this client carries a `.pub`** (checked by direct hash lookup across all 427 archives), so a client with no cache has no other source. Sending it is what retail does on a first login.

## Tests

New `mop_addon_packets_test`:

- the table is a bijection over 0–255
- head/tail entries match the client
- an identity key emits the table itself, pinning mapping direction — the previous raw-order bug fails this immediately
- replaying the client's scatter reconstructs the modulus
- exactly 2 fixed points
- **FNV-1a/32 digest over all 256 entries**

The digest exists because the other checks are self-consistent: swapping two interior entries preserves the bijection, fixed-point count, anchors, identity comparison and round trip, and still ships a corrupt modulus. The swapped table digests `0x2102D701` against the expected `0x11A63A0F`.

## Review

Codex reviewed `96205f8dd` and returned BLOCK on two findings, both fixed in `ca43bcba5`:

- **BLOCKING** — the table was a namespace-scope `const` (internal linkage) odr-used by an external-linkage inline function, naming a different object per translation unit. Ill-formed, no diagnostic required. Now `inline constexpr`.
- **IMPORTANT** — only 16 of 256 entries were externally pinned. Hence the digest.

`ca43bcba5` changes no emitted bytes, so the live verification above still stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/59)
<!-- Reviewable:end -->
