### PR TITLE
Restore quest POI loading by not selecting an unshipped column

### DIFF
--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -1304,8 +1304,14 @@ void ObjectMgr::LoadQuestPOI()
 
     uint32 count = 0;
 
-    //                                                0           1        2           3        4            5          6       7       8
-    QueryResult* result = WorldDatabase.Query("SELECT `questId`, `poiId`, `objIndex`, `mapId`, `mapAreaId`, `floorId`, `unk3`, `unk4`, `blobId` FROM `quest_poi`");
+    // Selects only the columns this loader actually uses. A column named here that
+    // the table does not have fails the whole query, and because the failure looks
+    // exactly like an empty table, every quest silently loses its map markers with
+    // nothing in the log to say why. `blobId` was selected here without ever being
+    // used or shipped in a schema, which cost the entire POI feature; add it back
+    // together with the code that consumes it and the migration that creates it.
+    //                                                0           1        2           3        4            5          6       7
+    QueryResult* result = WorldDatabase.Query("SELECT `questId`, `poiId`, `objIndex`, `mapId`, `mapAreaId`, `floorId`, `unk3`, `unk4` FROM `quest_poi`");
 
     if (!result)
     {
@@ -1314,7 +1320,7 @@ void ObjectMgr::LoadQuestPOI()
         bar.step();
 
         sLog.outString();
-        sLog.outErrorDb(">> Loaded 0 quest POI definitions. DB table `quest_poi` is empty.");
+        sLog.outErrorDb(">> Loaded 0 quest POI definitions. Table `quest_poi` is empty, or the query failed - check the SQL error above for a column this core expects and the table does not have.");
         return;
     }
 
@@ -1336,7 +1342,6 @@ void ObjectMgr::LoadQuestPOI()
         uint32 floorId          = fields[5].GetUInt32();
         uint32 unk3             = fields[6].GetUInt32();
         uint32 unk4             = fields[7].GetUInt32();
-		uint32 blobId           = fields[8].GetUInt32();
 
         // An out-of-range floorId crashes the 5.4.8 client the moment it reads
         // SMSG_QUEST_POI_QUERY_RESPONSE, which is sent on quest accept - so one


### PR DESCRIPTION
## The problem

`LoadQuestPOI` selected `blobId`, a column no database has. The query failed outright, so **every quest lost its map markers** — no blue objective area, no tracking — on a live server.

The failure was silent. The loader reported:

```
>> Loaded 0 quest POI definitions. DB table `quest_poi` is empty.
```

while the table held **29,117 rows**. That message sends you looking for missing data instead of a schema mismatch. The real error was one line above:

```
ERROR 1054 (42S22): Unknown column 'blobId' in 'SELECT'
```

## Why removing it is the right fix

`blobId` was read into a local variable that nothing used — it is not a member of `QuestPOI`, is never stored, and never reaches the wire. It appeared exactly twice in the whole source tree: in the `SELECT`, and in the read. Selecting it cost the entire POI feature and bought nothing.

Removing it restores POI on every existing database with **no migration required**. I checked all eight Four databases on this machine — not one has the column.

## Verified in game

Same database, two runs, only the SELECT differing:

| Build | Startup |
|---|---|
| with `blobId` | `ERROR 1054` → `>> Loaded 0 quest POI definitions` |
| without | `>> Loaded 29117 quest POI definitions` |

Before the fix, `SMSG_QUEST_POI_QUERY_RESPONSE` for a freshly accepted quest decoded as a well-formed `questCount=1, poiCount=0` — so the wire layout was fine and the data simply never loaded. After the fix, quest tracking and the blue objective area render correctly in game.

Also corrects the no-result message: a failed query and an empty table are not the same thing.

## Follow-up — the intent behind the column is sound

49 rows on map 860 (the Wandering Isle, 40 quests) carry `floorId` values of **251,732–264,091**, where every other row is **0–7**. Those are per-record blob ids sitting in the wrong column, and the existing guard already forces them to 0 to stop them crashing the client on quest accept.

Giving them a proper home needs three things landed **together**:

1. the migration that creates the column,
2. the data move out of `floorId`,
3. code that actually consumes it,

plus corpus confirmation that the client expects the value on the wire at all — the layout verified against the 400-body retail corpus doesn't obviously carry it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/63)
<!-- Reviewable:end -->
