### PR TITLE
Stop a malformed database string from crashing the world server

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -92,12 +92,19 @@ namespace MaNGOS
                     if (!formatted)
                     {
                         sLog.outError("String entry %i could not be formatted; sending it unformatted. Check its conversions against the caller in `mangos_string`.", i_textId);
+
+                        // Copied into the bounded buffer rather than passed straight
+                        // through: BuildChatPacket carries the text length in 12 bits,
+                        // so a row of 4096 bytes or more would trip its assertion on an
+                        // assertion-enabled build and leave an empty packet otherwise -
+                        // the very outcome this fallback exists to avoid.
+                        CopyDbStringBounded(str, sizeof(str), text);
                     }
 
                     // The caller sends whatever this builder leaves in `data`, so a
-                    // failure has to fall back to the raw row rather than return and
-                    // put an empty packet on the wire.
-                    ChatHandler::BuildChatPacket(data, i_msgtype, formatted ? &str[0] : text, LANG_UNIVERSAL, CHAT_TAG_NONE, sourceGuid, sourceName.c_str());
+                    // failure falls back to the raw row rather than returning and
+                    // putting an empty packet on the wire.
+                    ChatHandler::BuildChatPacket(data, i_msgtype, &str[0], LANG_UNIVERSAL, CHAT_TAG_NONE, sourceGuid, sourceName.c_str());
                 }
                 else
                 {
@@ -140,10 +147,12 @@ namespace MaNGOS
                     if (!formatted)
                     {
                         sLog.outError("String entry %i could not be formatted; sending it unformatted. Check its conversions against the caller in `mangos_string`.", i_textId);
+                        CopyDbStringBounded(str, sizeof(str), text);
                     }
 
-                    // As above: returning here would send an empty packet.
-                    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_YELL, formatted ? &str[0] : text, i_language, CHAT_TAG_NONE, i_source->GetObjectGuid(), i_source->GetName());
+                    // As above: returning here would send an empty packet, and the raw
+                    // row must be bounded before it reaches BuildChatPacket.
+                    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_YELL, &str[0], i_language, CHAT_TAG_NONE, i_source->GetObjectGuid(), i_source->GetName());
                 }
                 else
                 {

--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -42,6 +42,8 @@
 #include "BattleGround.h"
 #include "BattleGroundMgr.h"
 #include "Creature.h"
+#include "Log.h"
+#include "Util.h"
 #include "Language.h"
 #include "World.h"
 #include "Group.h"
@@ -84,10 +86,18 @@ namespace MaNGOS
                     va_copy(ap, *i_args);
 
                     char str [2048];
-                    vsnprintf(str, 2048, text, ap);
+                    bool const formatted = SafeFormatDbString(str, sizeof(str), text, ap);
                     va_end(ap);
 
-                    ChatHandler::BuildChatPacket(data, i_msgtype, &str[0], LANG_UNIVERSAL, CHAT_TAG_NONE, sourceGuid, sourceName.c_str());
+                    if (!formatted)
+                    {
+                        sLog.outError("String entry %i could not be formatted; sending it unformatted. Check its conversions against the caller in `mangos_string`.", i_textId);
+                    }
+
+                    // The caller sends whatever this builder leaves in `data`, so a
+                    // failure has to fall back to the raw row rather than return and
+                    // put an empty packet on the wire.
+                    ChatHandler::BuildChatPacket(data, i_msgtype, formatted ? &str[0] : text, LANG_UNIVERSAL, CHAT_TAG_NONE, sourceGuid, sourceName.c_str());
                 }
                 else
                 {
@@ -124,10 +134,16 @@ namespace MaNGOS
                     va_copy(ap, *i_args);
 
                     char str [2048];
-                    vsnprintf(str, 2048, text, ap);
+                    bool const formatted = SafeFormatDbString(str, sizeof(str), text, ap);
                     va_end(ap);
 
-                    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_YELL, &str[0], i_language, CHAT_TAG_NONE, i_source->GetObjectGuid(), i_source->GetName());
+                    if (!formatted)
+                    {
+                        sLog.outError("String entry %i could not be formatted; sending it unformatted. Check its conversions against the caller in `mangos_string`.", i_textId);
+                    }
+
+                    // As above: returning here would send an empty packet.
+                    ChatHandler::BuildChatPacket(data, CHAT_MSG_MONSTER_YELL, formatted ? &str[0] : text, i_language, CHAT_TAG_NONE, i_source->GetObjectGuid(), i_source->GetName());
                 }
                 else
                 {

--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -178,7 +178,12 @@ namespace MaNGOS
                 char const* arg2str = i_arg2 ? sObjectMgr.GetMangosString(i_arg2, loc_idx) : "";
 
                 char str [2048];
-                snprintf(str, 2048, text, arg1str, arg2str);
+
+                if (!SafeFormatDbStringF(str, sizeof(str), text, arg1str, arg2str))
+                {
+                    sLog.outError("String entry %i could not be formatted; sending it unformatted. Check its conversions against the caller in `mangos_string`.", i_textId);
+                    CopyDbStringBounded(str, sizeof(str), text);
+                }
 
                 ObjectGuid guid;
                 char const* pName = NULL;
@@ -217,7 +222,13 @@ namespace MaNGOS
                 char const* arg2str = i_arg2 ? sObjectMgr.GetMangosString(i_arg2, loc_idx) : "";
 
                 char str [2048];
-                snprintf(str, 2048, text, arg1str, arg2str);
+
+                if (!SafeFormatDbStringF(str, sizeof(str), text, arg1str, arg2str))
+                {
+                    sLog.outError("String entry %i could not be formatted; sending it unformatted. Check its conversions against the caller in `mangos_string`.", i_textId);
+                    CopyDbStringBounded(str, sizeof(str), text);
+                }
+
                 // copied from BuildMonsterChat
                 data << uint8(CHAT_MSG_MONSTER_YELL);
                 data << uint32(i_language);

--- a/src/game/BattleGround/BattleGroundReward.cpp
+++ b/src/game/BattleGround/BattleGroundReward.cpp
@@ -482,7 +482,12 @@ void BattleGround::SendRewardMarkByMail(Player* plr, uint32 mark, uint32 count)
         // text
         std::string textFormat = plr->GetSession()->GetMangosString(LANG_BG_MARK_BY_MAIL);
         char textBuf[300];
-        snprintf(textBuf, 300, textFormat.c_str(), GetName(), GetName());
+
+        if (!SafeFormatDbStringF(textBuf, sizeof(textBuf), textFormat.c_str(), GetName(), GetName()))
+        {
+            sLog.outError("String entry %i could not be formatted. Check its conversions against the caller in `mangos_string`.", LANG_BG_MARK_BY_MAIL);
+            CopyDbStringBounded(textBuf, sizeof(textBuf), textFormat.c_str());
+        }
 
         MailDraft(subject, textBuf)
         .AddItem(markItem)

--- a/src/game/ChatCommands/DebugCommands.cpp
+++ b/src/game/ChatCommands/DebugCommands.cpp
@@ -1226,7 +1226,7 @@ bool ChatHandler::HandleSetValueHelper(Object* target, uint32 field, char* typeS
             return false;
         }
 
-        DEBUG_LOG(GetMangosString(LANG_SET_UINT), guid.GetString().c_str(), field, iValue);
+        DEBUG_LOG("%s", FormatDbString(LANG_SET_UINT, guid.GetString().c_str(), field, iValue).c_str());
         target->SetUInt32Value(field , iValue);
         PSendSysMessage(LANG_SET_UINT_FIELD, guid.GetString().c_str(), field, iValue);
     }
@@ -1238,7 +1238,7 @@ bool ChatHandler::HandleSetValueHelper(Object* target, uint32 field, char* typeS
             return false;
         }
 
-        DEBUG_LOG(GetMangosString(LANG_SET_FLOAT), guid.GetString().c_str(), field, fValue);
+        DEBUG_LOG("%s", FormatDbString(LANG_SET_FLOAT, guid.GetString().c_str(), field, fValue).c_str());
         target->SetFloatValue(field , fValue);
         PSendSysMessage(LANG_SET_FLOAT_FIELD, guid.GetString().c_str(), field, fValue);
     }
@@ -1384,24 +1384,24 @@ bool ChatHandler::HandleGetValueHelper(Object* target, uint32 field, char* typeS
                 {
                     res += (iValue & (1 << (i - 1))) ? "1" : "0";
                 }
-                DEBUG_LOG(GetMangosString(LANG_GET_BITSTR), guid.GetString().c_str(), field, res.c_str());
+                DEBUG_LOG("%s", FormatDbString(LANG_GET_BITSTR, guid.GetString().c_str(), field, res.c_str()).c_str());
                 PSendSysMessage(LANG_GET_BITSTR_FIELD, guid.GetString().c_str(), field, res.c_str());
                 break;
             }
             case 16:
-                DEBUG_LOG(GetMangosString(LANG_GET_HEX), guid.GetString().c_str(), field, iValue);
+                DEBUG_LOG("%s", FormatDbString(LANG_GET_HEX, guid.GetString().c_str(), field, iValue).c_str());
                 PSendSysMessage(LANG_GET_HEX_FIELD, guid.GetString().c_str(), field, iValue);
                 break;
             case 10:
             default:
-                DEBUG_LOG(GetMangosString(LANG_GET_UINT), guid.GetString().c_str(), field, iValue);
+                DEBUG_LOG("%s", FormatDbString(LANG_GET_UINT, guid.GetString().c_str(), field, iValue).c_str());
                 PSendSysMessage(LANG_GET_UINT_FIELD, guid.GetString().c_str(), field, iValue);
         }
     }
     else
     {
         float fValue = target->GetFloatValue(field);
-        DEBUG_LOG(GetMangosString(LANG_GET_FLOAT), guid.GetString().c_str(), field, fValue);
+        DEBUG_LOG("%s", FormatDbString(LANG_GET_FLOAT, guid.GetString().c_str(), field, fValue).c_str());
         PSendSysMessage(LANG_GET_FLOAT_FIELD, guid.GetString().c_str(), field, fValue);
     }
 
@@ -1536,22 +1536,22 @@ bool ChatHandler::HandlerDebugModValueHelper(Object* target, uint32 field, char*
             default:
             case 1:                                         // int +
                 value = uint32(int32(value) + int32(iValue));
-                DEBUG_LOG(GetMangosString(LANG_CHANGE_INT32), guidString, field, iValue, value, value);
+                DEBUG_LOG("%s", FormatDbString(LANG_CHANGE_INT32, guidString, field, iValue, value, value).c_str());
                 PSendSysMessage(LANG_CHANGE_INT32_FIELD, guidString, field, iValue, value, value);
                 break;
             case 2:                                         // |= bit or
                 value |= iValue;
-                DEBUG_LOG(GetMangosString(LANG_CHANGE_HEX), guidString, field, typeStr, iValue, value);
+                DEBUG_LOG("%s", FormatDbString(LANG_CHANGE_HEX, guidString, field, typeStr, iValue, value).c_str());
                 PSendSysMessage(LANG_CHANGE_HEX_FIELD, guidString, field, typeStr, iValue, value);
                 break;
             case 3:                                         // &= bit and
                 value &= iValue;
-                DEBUG_LOG(GetMangosString(LANG_CHANGE_HEX), guidString, field, typeStr, iValue, value);
+                DEBUG_LOG("%s", FormatDbString(LANG_CHANGE_HEX, guidString, field, typeStr, iValue, value).c_str());
                 PSendSysMessage(LANG_CHANGE_HEX_FIELD, guidString, field, typeStr, iValue, value);
                 break;
             case 4:                                         // &=~ bit and not
                 value &= ~iValue;
-                DEBUG_LOG(GetMangosString(LANG_CHANGE_HEX), guidString, field, typeStr, iValue, value);
+                DEBUG_LOG("%s", FormatDbString(LANG_CHANGE_HEX, guidString, field, typeStr, iValue, value).c_str());
                 PSendSysMessage(LANG_CHANGE_HEX_FIELD, guidString, field, typeStr, iValue, value);
                 break;
         }
@@ -1570,7 +1570,7 @@ bool ChatHandler::HandlerDebugModValueHelper(Object* target, uint32 field, char*
 
         value += fValue;
 
-        DEBUG_LOG(GetMangosString(LANG_CHANGE_FLOAT), guid.GetString().c_str(), field, fValue, value);
+        DEBUG_LOG("%s", FormatDbString(LANG_CHANGE_FLOAT, guid.GetString().c_str(), field, fValue, value).c_str());
         PSendSysMessage(LANG_CHANGE_FLOAT_FIELD, guid.GetString().c_str(), field, fValue, value);
 
         target->SetFloatValue(field, value);

--- a/src/game/ChatCommands/GMTicketCommands.cpp
+++ b/src/game/ChatCommands/GMTicketCommands.cpp
@@ -479,7 +479,11 @@ bool ChatHandler::HandleTicketRespondCommand(char* args)
 
     if (m_session)
     {
-        snprintf(signature, signatureBufferSize, signatureFormat, m_session->GetPlayer()->GetName());
+        if (!SafeFormatDbStringF(signature, signatureBufferSize, signatureFormat, m_session->GetPlayer()->GetName()))
+        {
+            sLog.outError("String entry %i could not be formatted. Check its conversions against the caller in `mangos_string`.", LANG_COMMAND_TICKET_RESPOND_MAIL_SIGNATURE);
+            CopyDbStringBounded(signature, signatureBufferSize, signatureFormat);
+        }
     }
     else
     {

--- a/src/game/ChatCommands/GameObjectCommands.cpp
+++ b/src/game/ChatCommands/GameObjectCommands.cpp
@@ -387,7 +387,7 @@ bool ChatHandler::HandleGameObjectAddCommand(char* args)
         return false;
     }
 
-    DEBUG_LOG(GetMangosString(LANG_GAMEOBJECT_CURRENT), gInfo->name, db_lowGUID, x, y, z, o);
+    DEBUG_LOG("%s", FormatDbString(LANG_GAMEOBJECT_CURRENT, gInfo->name, db_lowGUID, x, y, z, o).c_str());
 
     map->Add(pGameObj);
 

--- a/src/game/ChatCommands/LookupCommands.cpp
+++ b/src/game/ChatCommands/LookupCommands.cpp
@@ -1080,7 +1080,12 @@ bool ChatHandler::HandleLookupSkillCommand(char* args)
                     uint32 tempValue = target->GetSkillTempBonusValue(id);
 
                     char const* valFormat = GetMangosString(LANG_SKILL_VALUES);
-                    snprintf(valStr, 50, valFormat, curValue, maxValue, permValue, tempValue);
+
+                    if (!SafeFormatDbStringF(valStr, sizeof(valStr), valFormat, curValue, maxValue, permValue, tempValue))
+                    {
+                        sLog.outError("String entry %i could not be formatted. Check its conversions against the caller in `mangos_string`.", LANG_SKILL_VALUES);
+                        CopyDbStringBounded(valStr, sizeof(valStr), valFormat);
+                    }
                 }
 
                 // send skill in "id - [namedlink locale]" format

--- a/src/game/ChatCommands/PlayerStateCommands.cpp
+++ b/src/game/ChatCommands/PlayerStateCommands.cpp
@@ -614,7 +614,7 @@ bool ChatHandler::HandleAddItemCommand(char* args)
         plTarget = pl;
     }
 
-    DETAIL_LOG(GetMangosString(LANG_ADDITEM), itemId, count);
+    DETAIL_LOG("%s", FormatDbString(LANG_ADDITEM, itemId, count).c_str());
 
     ItemPrototype const* pProto = ObjectMgr::GetItemPrototype(itemId);
     if (!pProto)
@@ -710,7 +710,7 @@ bool ChatHandler::HandleAddItemSetCommand(char* args)
         plTarget = pl;
     }
 
-    DETAIL_LOG(GetMangosString(LANG_ADDITEMSET), itemsetId);
+    DETAIL_LOG("%s", FormatDbString(LANG_ADDITEMSET, itemsetId).c_str());
 
     bool found = false;
     for (uint32 id = 0; id < sItemStorage.GetMaxEntry(); ++id)

--- a/src/game/ChatCommands/PlayerStatsMods.cpp
+++ b/src/game/ChatCommands/PlayerStatsMods.cpp
@@ -185,7 +185,7 @@ bool ChatHandler::HandleModifyEnergyCommand(char* args)
     chr->SetMaxPower(POWER_ENERGY, energym);
     chr->SetPower(POWER_ENERGY, energy);
 
-    DETAIL_LOG(GetMangosString(LANG_CURRENT_ENERGY), chr->GetMaxPower(POWER_ENERGY));
+    DETAIL_LOG("%s", FormatDbString(LANG_CURRENT_ENERGY, chr->GetMaxPower(POWER_ENERGY)).c_str());
 
     return true;
 }

--- a/src/game/ChatCommands/PlayerTitleCommands.cpp
+++ b/src/game/ChatCommands/PlayerTitleCommands.cpp
@@ -99,8 +99,15 @@ bool ChatHandler::HandleLookupTitleCommand(char* args)
                                         ? GetMangosString(LANG_ACTIVE)
                                         : "";
 
+                // DBC-sourced rather than database-sourced, but the same shape: a
+                // data-driven format ("%s the Explorer") against a fixed argument list.
                 char titleNameStr[80];
-                snprintf(titleNameStr, 80, name.c_str(), targetName);
+
+                if (!SafeFormatDbStringF(titleNameStr, sizeof(titleNameStr), name.c_str(), targetName))
+                {
+                    sLog.outError("CharTitles.dbc entry %u could not be formatted; showing it unformatted.", titleInfo->ID);
+                    CopyDbStringBounded(titleNameStr, sizeof(titleNameStr), name.c_str());
+                }
 
                 // send title in "id (idx:idx) - [namedlink locale]" format
                 if (m_session)
@@ -307,8 +314,14 @@ bool ChatHandler::HandleCharacterTitlesCommand(char* args)
                                     ? GetMangosString(LANG_ACTIVE)
                                     : "";
 
+            // As above: a DBC-sourced format against a fixed argument list.
             char titleNameStr[80];
-            snprintf(titleNameStr, 80, name.c_str(), targetName);
+
+            if (!SafeFormatDbStringF(titleNameStr, sizeof(titleNameStr), name.c_str(), targetName))
+            {
+                sLog.outError("CharTitles.dbc entry %u could not be formatted; showing it unformatted.", titleInfo->ID);
+                CopyDbStringBounded(titleNameStr, sizeof(titleNameStr), name.c_str());
+            }
 
             // send title in "id (idx:idx) - [namedlink locale]" format
             if (m_session)

--- a/src/game/ChatCommands/PlayerTitleCommands.cpp
+++ b/src/game/ChatCommands/PlayerTitleCommands.cpp
@@ -172,7 +172,13 @@ bool ChatHandler::HandleTitlesAddCommand(char* args)
 
     char const* targetName = target->GetName();
     char titleNameStr[80];
-    snprintf(titleNameStr, 80, titleInfo->Name_lang[GetSessionDbcLocale()], targetName);
+    char const* titleFormat = titleInfo->Name_lang[GetSessionDbcLocale()];
+
+    if (!SafeFormatDbStringF(titleNameStr, sizeof(titleNameStr), titleFormat, targetName))
+    {
+        sLog.outError("CharTitles.dbc entry %u could not be formatted; showing it unformatted.", titleInfo->ID);
+        CopyDbStringBounded(titleNameStr, sizeof(titleNameStr), titleFormat);
+    }
 
     target->SetTitle(titleInfo);
     PSendSysMessage(LANG_TITLE_ADD_RES, id, titleNameStr, tNameLink.c_str());
@@ -224,7 +230,13 @@ bool ChatHandler::HandleTitlesRemoveCommand(char* args)
 
     char const* targetName = target->GetName();
     char titleNameStr[80];
-    snprintf(titleNameStr, 80, titleInfo->Name_lang[GetSessionDbcLocale()], targetName);
+    char const* titleFormat = titleInfo->Name_lang[GetSessionDbcLocale()];
+
+    if (!SafeFormatDbStringF(titleNameStr, sizeof(titleNameStr), titleFormat, targetName))
+    {
+        sLog.outError("CharTitles.dbc entry %u could not be formatted; showing it unformatted.", titleInfo->ID);
+        CopyDbStringBounded(titleNameStr, sizeof(titleNameStr), titleFormat);
+    }
 
     PSendSysMessage(LANG_TITLE_REMOVE_RES, id, titleNameStr, tNameLink.c_str());
 

--- a/src/game/ChatCommands/TeleportationAndPositionCommands.cpp
+++ b/src/game/ChatCommands/TeleportationAndPositionCommands.cpp
@@ -700,14 +700,14 @@ bool ChatHandler::HandleGPSCommand(char* args)
               (obj->GetTypeId() == TYPEID_PLAYER ? "player" : "creature"), obj->GetName(),
               (obj->GetTypeId() == TYPEID_PLAYER ? "GUID" : "Entry"), (obj->GetTypeId() == TYPEID_PLAYER ? obj->GetGUIDLow() : obj->GetEntry()));
 
-    DEBUG_LOG(GetMangosString(LANG_MAP_POSITION),
+    DEBUG_LOG("%s", FormatDbString(LANG_MAP_POSITION,
               obj->GetMapId(), (mapEntry ? mapEntry->MapName_lang[sWorld.GetDefaultDbcLocale()] : "<unknown>"),
               zone_id, (zoneEntry ? zoneEntry->AreaName_lang[sWorld.GetDefaultDbcLocale()] : "<unknown>"),
               area_id, (areaEntry ? areaEntry->AreaName_lang[sWorld.GetDefaultDbcLocale()] : "<unknown>"),
               obj->GetPhaseMask(),
               obj->GetPositionX(), obj->GetPositionY(), obj->GetPositionZ(), obj->GetOrientation(),
               cell.GridX(), cell.GridY(), cell.CellX(), cell.CellY(), obj->GetInstanceId(),
-              zone_x, zone_y, ground_z, floor_z, have_map, have_vmap);
+              zone_x, zone_y, ground_z, floor_z, have_map, have_vmap).c_str());
 
     GridMapLiquidData liquid_status;
     GridMapLiquidStatus res = terrain->getLiquidStatus(obj->GetPositionX(), obj->GetPositionY(), obj->GetPositionZ(), MAP_ALL_LIQUIDS, &liquid_status);

--- a/src/game/ChatCommands/TriggerCommands.cpp
+++ b/src/game/ChatCommands/TriggerCommands.cpp
@@ -56,7 +56,13 @@ void ChatHandler::ShowTriggerTargetListHelper(uint32 id, AreaTrigger const* at, 
         if (!subpart)
         {
             float dist = m_session->GetPlayer()->GetDistance2d(at->target_X, at->target_Y);
-            snprintf(dist_buf, 50, GetMangosString(LANG_TRIGGER_DIST), dist);
+            char const* distFormat = GetMangosString(LANG_TRIGGER_DIST);
+
+            if (!SafeFormatDbStringF(dist_buf, sizeof(dist_buf), distFormat, dist))
+            {
+                sLog.outError("String entry %i could not be formatted. Check its conversions against the caller in `mangos_string`.", LANG_TRIGGER_DIST);
+                CopyDbStringBounded(dist_buf, sizeof(dist_buf), distFormat);
+            }
         }
         else
         {
@@ -85,7 +91,13 @@ void ChatHandler::ShowTriggerListHelper(AreaTriggerEntry const* atEntry)
     {
         float dist = m_session->GetPlayer()->GetDistance2d(atEntry->x, atEntry->y);
         char dist_buf[50];
-        snprintf(dist_buf, 50, GetMangosString(LANG_TRIGGER_DIST), dist);
+        char const* distFormat = GetMangosString(LANG_TRIGGER_DIST);
+
+        if (!SafeFormatDbStringF(dist_buf, sizeof(dist_buf), distFormat, dist))
+        {
+            sLog.outError("String entry %i could not be formatted. Check its conversions against the caller in `mangos_string`.", LANG_TRIGGER_DIST);
+            CopyDbStringBounded(dist_buf, sizeof(dist_buf), distFormat);
+        }
 
         PSendSysMessage(LANG_TRIGGER_LIST_CHAT,
                         atEntry->ID, atEntry->ID, atEntry->ContinentID, atEntry->x, atEntry->y, atEntry->z, dist_buf, tavern, quest);

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -1734,6 +1734,132 @@ inline void _DoStringError(int32 entry, char const* text, ...)
 }
 
 /**
+ * @brief Extracts the printf conversion sequence from a format string.
+ *
+ * Two format strings are interchangeable for one argument list only if this
+ * sequence matches. Flags, field width and precision affect presentation only and
+ * are left out, but length modifiers change which type is consumed and are kept,
+ * as are positional indices, which change which argument is consumed. A literal
+ * "%%" contributes nothing; a '*' width or precision consumes an extra int and is
+ * recorded in its own right.
+ *
+ * @param fmt The format string to scan.
+ * @return The ordered conversion sequence, comma-separated, one token per field.
+ */
+inline std::string _ExtractFormatSequence(std::string const& fmt)
+{
+    std::string seq;
+
+    for (size_t i = 0; i < fmt.size(); ++i)
+    {
+        if (fmt[i] != '%')
+        {
+            continue;
+        }
+
+        ++i;
+
+        if (i >= fmt.size())
+        {
+            break;                                          // trailing '%', consumes nothing
+        }
+
+        if (fmt[i] == '%')
+        {
+            continue;                                       // "%%" is a literal percent sign
+        }
+
+        if (!seq.empty())
+        {
+            seq += ',';                                     // keep tokens unambiguous: "ls" is not "l" then "s"
+        }
+
+        // A POSIX positional specifier ("%2$s") selects which argument is consumed,
+        // so two formats that use the same conversions in a different order are not
+        // interchangeable. Keep the position in the token so they compare unequal.
+        {
+            size_t digits = i;
+
+            while (digits < fmt.size() && fmt[digits] >= '0' && fmt[digits] <= '9')
+            {
+                ++digits;
+            }
+
+            if (digits > i && digits < fmt.size() && fmt[digits] == '$')
+            {
+                seq += fmt.substr(i, digits - i + 1);
+                i = digits + 1;
+            }
+        }
+
+        // flags, field width and precision; '*' draws its value from the argument list,
+        // and may itself carry a position ("%1$*2$s"), which selects which argument
+        // supplies the width - keep it, or two formats consuming different arguments
+        // would compare equal.
+        while (i < fmt.size() && !((fmt[i] >= 'a' && fmt[i] <= 'z') || (fmt[i] >= 'A' && fmt[i] <= 'Z')))
+        {
+            if (fmt[i] == '*')
+            {
+                seq += '*';
+
+                size_t digits = i + 1;
+
+                while (digits < fmt.size() && fmt[digits] >= '0' && fmt[digits] <= '9')
+                {
+                    ++digits;
+                }
+
+                if (digits > i + 1 && digits < fmt.size() && fmt[digits] == '$')
+                {
+                    seq += fmt.substr(i + 1, digits - i);
+                    i = digits;
+                }
+            }
+
+            ++i;
+        }
+
+        // Length modifiers change which type is consumed, so they belong in the
+        // signature: %I64u and %I32u are not interchangeable, and neither are %wc
+        // (a wide character, promoted to int) and %ws (a wchar_t*). "I", "I32", "I64"
+        // and "w" are the MSVC spellings, "I32"/"I64" being what the I32FMT/I64FMT
+        // macros in Common.h expand to.
+        while (i < fmt.size())
+        {
+            char const c = fmt[i];
+
+            if (c == 'h' || c == 'l' || c == 'L' || c == 'j' || c == 'z' || c == 't' || c == 'w')
+            {
+                seq += c;
+                ++i;
+            }
+            else if (c == 'I' && i + 2 < fmt.size() &&
+                     ((fmt[i + 1] == '3' && fmt[i + 2] == '2') || (fmt[i + 1] == '6' && fmt[i + 2] == '4')))
+            {
+                seq += fmt.substr(i, 3);
+                i += 3;
+            }
+            else if (c == 'I')                              // %Iu / %Id: pointer-width
+            {
+                seq += c;
+                ++i;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        if (i < fmt.size())
+        {
+            seq += fmt[i];
+        }
+    }
+
+    return seq;
+}
+
+/**
  * @brief Loads localized string templates from a database table.
  *
  * @param db The database to query.
@@ -1741,9 +1867,11 @@ inline void _DoStringError(int32 entry, char const* text, ...)
  * @param min_value The inclusive lower id bound.
  * @param max_value The exclusive upper id bound.
  * @param extra_content true to also load sound/chat metadata.
+ * @param printf_formatted true if the table's strings are used as printf formats,
+ *        which makes their conversion specifiers load-bearing.
  * @return true if the load succeeded; otherwise, false.
  */
-bool ObjectMgr::LoadMangosStrings(DatabaseType& db, char const* table, int32 min_value, int32 max_value, bool extra_content)
+bool ObjectMgr::LoadMangosStrings(DatabaseType& db, char const* table, int32 min_value, int32 max_value, bool extra_content, bool printf_formatted)
 {
     int32 start_value = min_value;
     int32 end_value   = max_value;
@@ -1845,11 +1973,46 @@ bool ObjectMgr::LoadMangosStrings(DatabaseType& db, char const* table, int32 min
         // 0 -> default, idx in to idx+1
         data.Content[0] = fields[1].GetCppString();
 
+        // Only meaningful where the string is used as a printf format. Text that is
+        // spoken verbatim may legitimately contain a bare '%', and rejecting a
+        // locale there would throw away a good translation over a non-problem.
+        std::string const defaultFormat = printf_formatted ? _ExtractFormatSequence(data.Content[0]) : std::string();
+
+        if (printf_formatted && defaultFormat.find('n') != std::string::npos)
+        {
+            // Reported here so the row can be fixed; the refusal to format it lives
+            // in SafeFormatDbString, which does not have to damage the text to be safe.
+            _DoStringError(entry, "Entry %i in table `%s` uses the %%n conversion in content_default; it will not be formatted.", entry, table);
+        }
+
         for (int i = 1; i < MAX_LOCALE; ++i)
         {
             std::string str = fields[i + 1].GetCppString();
             if (!str.empty())
             {
+                if (printf_formatted)
+                {
+                    // Every locale of an entry is fed to the same vsnprintf call with
+                    // the same arguments, so a locale that does not consume exactly
+                    // what the default consumes makes that call read the wrong types.
+                    // Consuming more than was passed walks off the end of the argument
+                    // list and dereferences whatever the stack held next, which is a
+                    // crash any player on that locale can trigger. Consuming fewer, or
+                    // consuming the same count at a different type, is undefined too,
+                    // though the one case measured here - entry 548 (LANG_PINFO_ACCOUNT)
+                    // ships a ruRU row one %s short - merely rendered a char* as %u.
+                    // Refuse the locale either way and keep the default, which is the
+                    // string the callers were written against.
+                    std::string const localeFormat = _ExtractFormatSequence(str);
+
+                    if (localeFormat != defaultFormat)
+                    {
+                        _DoStringError(entry, "Entry %i in table `%s` locale %s has format specifiers `%s` but content_default has `%s`; localized text ignored to avoid formatting it against the wrong arguments.",
+                                       entry, table, localeNames[i], localeFormat.c_str(), defaultFormat.c_str());
+                        continue;
+                    }
+                }
+
                 int idx = GetOrNewIndexForLocale(LocaleConstant(i));
                 if (idx >= 0)
                 {

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -846,10 +846,13 @@ class ObjectMgr
         void LoadCreatureQuestRelations();
         void LoadCreatureInvolvedRelations();
 
-        bool LoadMangosStrings(DatabaseType& db, char const* table, int32 min_value, int32 max_value, bool extra_content);
+        bool LoadMangosStrings(DatabaseType& db, char const* table, int32 min_value, int32 max_value, bool extra_content, bool printf_formatted = false);
         bool LoadMangosStrings()
         {
-            return LoadMangosStrings(WorldDatabase, "mangos_string", MIN_MANGOS_STRING_ID, MAX_MANGOS_STRING_ID, false);
+            // mangos_string is the only one of these tables handed to vsnprintf as a
+            // format; the rest reach DoDisplayText and are spoken verbatim, where a
+            // bare '%' is just a character.
+            return LoadMangosStrings(WorldDatabase, "mangos_string", MIN_MANGOS_STRING_ID, MAX_MANGOS_STRING_ID, false, true);
         }
         void LoadCreatureLocales();
         void LoadCreatureTemplates();

--- a/src/game/Object/PlayerChannel.cpp
+++ b/src/game/Object/PlayerChannel.cpp
@@ -167,8 +167,19 @@ void Player::UpdateLocalChannels(uint32 newZone)
         }
 
         //  new channel
+        //
+        // ChatChannels.dbc supplies the pattern ("LocalDefense - %s") and the zone name
+        // fills it in. A row whose conversions do not match that single argument would
+        // fault here, and this runs for every player on every zone change.
         char new_channel_name_buf[100];
-        snprintf(new_channel_name_buf, 100, ch->Name_lang[m_session->GetSessionDbcLocale()], current_zone_name.c_str());
+        char const* channelPattern = ch->Name_lang[m_session->GetSessionDbcLocale()];
+
+        if (!SafeFormatDbStringF(new_channel_name_buf, sizeof(new_channel_name_buf), channelPattern, current_zone_name.c_str()))
+        {
+            sLog.outError("ChatChannels.dbc entry %u could not be formatted; using its pattern unformatted.", ch->ID);
+            CopyDbStringBounded(new_channel_name_buf, sizeof(new_channel_name_buf), channelPattern);
+        }
+
         Channel* new_channel = cMgr->GetJoinChannel(new_channel_name_buf, ch->ID);
 
         if ((*i) != new_channel)

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -50,6 +50,7 @@
 #include "Common.h"
 #include "Database/DatabaseEnv.h"
 #include "Log.h"
+#include "Util.h"
 #include "Opcodes.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
@@ -1182,8 +1183,14 @@ void WorldSession::SendNotification(int32 string_id, ...)
         char szStr [1024];
         szStr[0] = '\0';
         va_start(ap, string_id);
-        vsnprintf(szStr, 1024, format, ap);
+        bool const formatted = SafeFormatDbString(szStr, sizeof(szStr), format, ap);
         va_end(ap);
+
+        if (!formatted)
+        {
+            sLog.outError("String entry %i could not be formatted; notification dropped. Check its conversions against the caller in `mangos_string`.", string_id);
+            return;
+        }
 
         WorldPacket data(SMSG_NOTIFICATION, (strlen(szStr) + 1));
         data.WriteBits(strlen(szStr), 12);

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -1158,8 +1158,19 @@ void WorldSession::SendNotification(const char* format, ...)
         char szStr [1024];
         szStr[0] = '\0';
         va_start(ap, format);
-        vsnprintf(szStr, 1024, format, ap);
+        // Guarded even though this overload takes a caller-supplied format: several
+        // callers resolve a `mangos_string` row first and pass that as the format -
+        // entering a level-locked area (PlayerAreaTrigger) and speaking while muted
+        // (ChatHandler) both do - so a malformed row reaches here just as it would
+        // the entry-id overload below.
+        bool const formatted = SafeFormatDbString(szStr, sizeof(szStr), format, ap);
         va_end(ap);
+
+        if (!formatted)
+        {
+            sLog.outError("A notification could not be formatted; message dropped. If it came from `mangos_string`, check that row's conversions against its caller.");
+            return;
+        }
 
         WorldPacket data(SMSG_NOTIFICATION, (strlen(szStr) + 1));
         data.WriteBits(strlen(szStr), 12);

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -1810,14 +1810,28 @@ std::string ChatHandler::PrepareStringNpcOrGoSpawnInformation(uint32 guid)
         {
             char buffer[100];
             const char* format = GetMangosString(LANG_NPC_GO_INFO_POOL_EVENT_STRING);
-            sprintf(buffer, format, pool_id, event_id);
+
+            // Was sprintf: unbounded, into 100 bytes, with a format that is database
+            // content. A long row or a wide field like %200d overflowed this buffer.
+            if (!SafeFormatDbStringF(buffer, sizeof(buffer), format, pool_id, event_id))
+            {
+                sLog.outError("String entry %i could not be formatted. Check its conversions against the caller in `mangos_string`.", LANG_NPC_GO_INFO_POOL_EVENT_STRING);
+                CopyDbStringBounded(buffer, sizeof(buffer), format);
+            }
+
             str = buffer;
         }
         else
         {
             char buffer[100];
             const char* format = GetMangosString(LANG_NPC_GO_INFO_POOL_STRING);
-            sprintf(buffer, format, pool_id);
+
+            if (!SafeFormatDbStringF(buffer, sizeof(buffer), format, pool_id))
+            {
+                sLog.outError("String entry %i could not be formatted. Check its conversions against the caller in `mangos_string`.", LANG_NPC_GO_INFO_POOL_STRING);
+                CopyDbStringBounded(buffer, sizeof(buffer), format);
+            }
+
             str = buffer;
         }
     }
@@ -1825,7 +1839,13 @@ std::string ChatHandler::PrepareStringNpcOrGoSpawnInformation(uint32 guid)
     {
         char buffer[100];
         const char* format = GetMangosString(LANG_NPC_GO_INFO_EVENT_STRING);
-        sprintf(buffer, format, event_id);
+
+        if (!SafeFormatDbStringF(buffer, sizeof(buffer), format, event_id))
+        {
+            sLog.outError("String entry %i could not be formatted. Check its conversions against the caller in `mangos_string`.", LANG_NPC_GO_INFO_EVENT_STRING);
+            CopyDbStringBounded(buffer, sizeof(buffer), format);
+        }
+
         str = buffer;
     }
 

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -444,6 +444,20 @@ class ChatHandler
         void PSendSysMessage(int32     entry, ...);
         void PSendSysMessageMultiline(int32 entry, ...);
 
+        /**
+         * @brief Renders a `mangos_string` entry for use as a log message.
+         *
+         * The logging macros take a printf format, so passing a database row to them
+         * directly hands mutable data to vfprintf with a fixed argument list - the
+         * same hazard PSendSysMessage was guarded against. Callers render here first
+         * and log the result through a literal "%s".
+         *
+         * @param entry The string table entry identifier.
+         * @return std::string The rendered text, or empty if the row could not be
+         *         formatted, in which case the failure has already been reported.
+         */
+        std::string FormatDbString(int32 entry, ...) const;
+
         bool ParseCommands(const char* text);
         ChatCommand const* FindCommand(char const* text);
 

--- a/src/game/WorldHandlers/ChatMessage.cpp
+++ b/src/game/WorldHandlers/ChatMessage.cpp
@@ -138,6 +138,29 @@ void ChatHandler::PSendSysMessage(int32 entry, ...)
 }
 
 /**
+ * @brief Renders a localized string for logging.
+ *
+ * @param entry The string table entry identifier.
+ * @return std::string The rendered text, or empty on failure.
+ */
+std::string ChatHandler::FormatDbString(int32 entry, ...) const
+{
+    char str [2048];
+    va_list ap;
+    va_start(ap, entry);
+    bool const formatted = SafeFormatDbString(str, sizeof(str), GetMangosString(entry), ap);
+    va_end(ap);
+
+    if (!formatted)
+    {
+        sLog.outError("String entry %i could not be formatted for logging; the log line was dropped. Check its conversions against the caller in `mangos_string`.", entry);
+        return std::string();
+    }
+
+    return std::string(str);
+}
+
+/**
  * @brief Formats and sends a localized multiline system message using @@ separators.
  *
  * @param entry The string table entry identifier.

--- a/src/game/WorldHandlers/ChatMessage.cpp
+++ b/src/game/WorldHandlers/ChatMessage.cpp
@@ -32,6 +32,8 @@
  */
 
 #include "Chat.h"
+#include "Log.h"
+#include "Util.h"
 #include "Language.h"
 #include "WorldPacket.h"
 #include "WorldSession.h"
@@ -123,8 +125,15 @@ void ChatHandler::PSendSysMessage(int32 entry, ...)
     va_list ap;
     char str [2048];
     va_start(ap, entry);
-    vsnprintf(str, 2048, format, ap);
+    bool const formatted = SafeFormatDbString(str, sizeof(str), format, ap);
     va_end(ap);
+
+    if (!formatted)
+    {
+        sLog.outError("String entry %i could not be formatted; message dropped. Check its conversions against the caller in `mangos_string`.", entry);
+        return;
+    }
+
     SendSysMessage(str);
 }
 
@@ -141,8 +150,14 @@ void  ChatHandler::PSendSysMessageMultiline(int32 entry, ...)
     va_list ap;
     char str[2048];
     va_start(ap, entry);
-    vsnprintf(str, 2048, format, ap);
+    bool const formatted = SafeFormatDbString(str, sizeof(str), format, ap);
     va_end(ap);
+
+    if (!formatted)
+    {
+        sLog.outError("String entry %i could not be formatted; message dropped. Check its conversions against the caller in `mangos_string`.", entry);
+        return;
+    }
 
     std::string mangosString(str);
 

--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -841,7 +841,10 @@ bool GridMap::ExistMap(uint32 mapid, int gx, int gy)
 {
     int len = sWorld.GetDataPath().length() + strlen("maps/%04u%02u%02u.map") + 1;
     char* tmp = new char[len];
-    snprintf(tmp, len, (char*)(sWorld.GetDataPath() + "maps/%04u%02u%02u.map").c_str(), mapid, gx, gy);
+    // DataDir goes in as an argument, not as part of the format: a '%' in the
+    // configured path is legal on both platforms and would otherwise be read as a
+    // conversion, consuming mapid/gx/gy in the wrong order.
+    snprintf(tmp, len, "%smaps/%04u%02u%02u.map", sWorld.GetDataPath().c_str(), mapid, gx, gy);
 
     FILE* pf = fopen(tmp, "rb");
 
@@ -1597,7 +1600,8 @@ GridMap* TerrainInfo::LoadMapAndVMap(const uint32 x, const uint32 y)
             // map file name
             int len = sWorld.GetDataPath().length() + strlen("maps/%04u%02u%02u.map") + 1;
             char* tmp = new char[len];
-            snprintf(tmp, len, (char*)(sWorld.GetDataPath() + "maps/%04u%02u%02u.map").c_str(), m_mapId, x, y);
+            // As above: the configured path is an argument, never part of the format.
+            snprintf(tmp, len, "%smaps/%04u%02u%02u.map", sWorld.GetDataPath().c_str(), m_mapId, x, y);
             DEBUG_FILTER_LOG(LOG_FILTER_MAP_LOADING, "Loading map %s", tmp);
 
             if (!map->loadData(tmp))

--- a/src/game/WorldHandlers/MoveMap.cpp
+++ b/src/game/WorldHandlers/MoveMap.cpp
@@ -239,7 +239,9 @@ namespace MMAP
         // load and init dtNavMesh - read parameters from file
         uint32 pathLen = sWorld.GetDataPath().length() + strlen("mmaps/%04u.mmap") + 1;
         char* fileName = new char[pathLen];
-        snprintf(fileName, pathLen, (sWorld.GetDataPath() + "mmaps/%04u.mmap").c_str(), mapId);
+        // The configured path is an argument, not part of the format: a '%' in it
+        // would otherwise be read as a conversion and consume mapId wrongly.
+        snprintf(fileName, pathLen, "%smmaps/%04u.mmap", sWorld.GetDataPath().c_str(), mapId);
 
         FILE* file = fopen(fileName, "rb");
         if (!file)
@@ -306,7 +308,8 @@ namespace MMAP
         // load this tile :: mmaps/MMMMXXYY.mmtile
         uint32 pathLen = sWorld.GetDataPath().length() + strlen("mmaps/%04u%02i%02i.mmtile") + 1;
         char* fileName = new char[pathLen];
-        snprintf(fileName, pathLen, (sWorld.GetDataPath() + "mmaps/%04u%02i%02i.mmtile").c_str(), mapId, x, y);
+        // As above: the configured path is an argument, never part of the format.
+        snprintf(fileName, pathLen, "%smmaps/%04u%02i%02i.mmtile", sWorld.GetDataPath().c_str(), mapId, x, y);
 
         FILE* file = fopen(fileName, "rb");
         if (!file)

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -1217,9 +1217,24 @@ namespace MaNGOS
                     va_copy(ap, *i_args);
 
                     char str [2048];
-                    vsnprintf(str, 2048, text, ap);
+                    bool const formatted = SafeFormatDbString(str, sizeof(str), text, ap);
                     va_end(ap);
 
+                    if (!formatted)
+                    {
+                        sLog.outError("String entry %i could not be formatted; sending it unformatted. Check its conversions against the caller in `mangos_string`.", i_textId);
+
+                        // Copied rather than passed through: do_helper tokenizes in
+                        // place with strtok, and `text` points into the row cached by
+                        // ObjectMgr, so writing terminators into it would truncate the
+                        // string for every later reader.
+                        strncpy(str, text, sizeof(str) - 1);
+                        str[sizeof(str) - 1] = '\0';
+                    }
+
+                    // Falling back to the raw row rather than returning: the caller
+                    // treats an empty list as "not built yet", so an early return
+                    // would re-run this for every player on the locale.
                     do_helper(data_list, &str[0]);
                 }
                 else

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -853,6 +853,146 @@ std::string vutf8format(const char* str, va_list* ap)
 
 }
 
+// Kept free of C++ objects on purpose: MSVC rejects __try in a function that
+// requires object unwinding (C2712), so the guarded call gets its own frame.
+static bool _GuardedVsnprintf(char* buffer, size_t size, char const* format, va_list ap)
+{
+    // Gated on the compiler, not the OS: __try/__except is MSVC syntax, and a
+    // MinGW build targets Windows without supporting it.
+#ifdef _MSC_VER
+    __try
+    {
+        vsnprintf(buffer, size, format, ap);
+        return true;
+    }
+    // Only an access violation is expected here (a conversion dereferencing an
+    // argument that was never passed). Anything else keeps unwinding rather than
+    // being silently swallowed.
+    __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
+    {
+        return false;
+    }
+#else
+    // No portable equivalent: a malformed format is still fatal here, but the
+    // callers' reporting and the load-time checks in ObjectMgr apply on every
+    // platform.
+    vsnprintf(buffer, size, format, ap);
+    return true;
+#endif
+}
+
+bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list ap)
+{
+    if (!buffer || !size)
+    {
+        return false;
+    }
+
+    buffer[0] = '\0';
+
+    if (!format)
+    {
+        return false;
+    }
+
+    // Two conversions must never reach vsnprintf, and neither can be contained
+    // afterwards:
+    //   %n writes a count through an argument pointer, and UCRT answers it by
+    //   invoking the invalid-parameter handler, which terminates rather than raising
+    //   anything an exception filter could catch;
+    //   a '%' followed by something that is not a valid conversion - including a
+    //   trailing '%' - reaches that same handler.
+    // Refusing them here is also why the load-time check never has to rewrite a row:
+    // `script_texts` carries a %n only as a typo for the $n name token, and that text
+    // is spoken verbatim elsewhere where it reads perfectly well.
+    for (char const* p = format; *p; ++p)
+    {
+        if (*p != '%')
+        {
+            continue;
+        }
+
+        ++p;
+
+        if (*p == '%')
+        {
+            continue;                                       // "%%" is a literal percent
+        }
+
+        // The field must match %[flags][width][.precision][size]type exactly. Anything
+        // else - a stray '.', a positional "%1$s" (which belongs to the _sprintf_p
+        // family, not the _vsnprintf this build maps to), or a truncated field -
+        // reaches the invalid-parameter handler too.
+        while (*p == '-' || *p == '+' || *p == ' ' || *p == '#' || *p == '0')
+        {
+            ++p;
+        }
+
+        if (*p == '*')
+        {
+            ++p;
+        }
+        else
+        {
+            while (*p >= '0' && *p <= '9')
+            {
+                ++p;
+            }
+        }
+
+        if (*p == '.')
+        {
+            ++p;
+
+            if (*p == '*')
+            {
+                ++p;
+            }
+            else
+            {
+                while (*p >= '0' && *p <= '9')
+                {
+                    ++p;
+                }
+            }
+        }
+
+        // size prefixes, longest match first
+        if ((p[0] == 'I' && p[1] == '3' && p[2] == '2') || (p[0] == 'I' && p[1] == '6' && p[2] == '4'))
+        {
+            p += 3;
+        }
+        else if ((p[0] == 'h' && p[1] == 'h') || (p[0] == 'l' && p[1] == 'l'))
+        {
+            p += 2;
+        }
+        else if (*p == 'h' || *p == 'l' || *p == 'L' || *p == 'j' || *p == 'z' ||
+                 *p == 't' || *p == 'I' || *p == 'w')
+        {
+            ++p;
+        }
+
+        // '\0' is tested first: strchr would otherwise match the set's own terminator
+        if (*p == '\0' || !strchr("diouxXfFeEgGaAcCsSpZ", *p))
+        {
+            return false;                                   // %n, trailing '%', or malformed
+        }
+    }
+
+    bool const formatted = _GuardedVsnprintf(buffer, size, format, ap);
+
+    // _vsnprintf does not terminate when the output is truncated, and a faulted
+    // call may have written a partial result.
+    buffer[size - 1] = '\0';
+
+    if (!formatted)
+    {
+        buffer[0] = '\0';
+    }
+
+    return formatted;
+}
+
 void hexEncodeByteArray(uint8* bytes, uint32 arrayLen, std::string& result)
 {
     std::ostringstream ss;

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -974,20 +974,27 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
         bool const msvcSizePrefixes = false;
 #endif
 
+        char sizePrefix = '\0';                             // '\0' = none
+
         if (msvcSizePrefixes && p[0] == 'I' && ((p[1] == '3' && p[2] == '2') || (p[1] == '6' && p[2] == '4')))
         {
+            sizePrefix = p[1];                              // '3' for I32, '6' for I64
             p += 3;
         }
         else if ((p[0] == 'h' && p[1] == 'h') || (p[0] == 'l' && p[1] == 'l'))
         {
+            sizePrefix = (p[0] == 'h') ? 'H' : 'Q';         // 'H' = hh, 'Q' = ll (not 'L',
+                                                            // which is the distinct long-double modifier)
             p += 2;
         }
         else if (*p == 'h' || *p == 'l' || *p == 'L' || *p == 'j' || *p == 'z' || *p == 't')
         {
+            sizePrefix = *p;
             ++p;
         }
         else if (msvcSizePrefixes && (*p == 'I' || *p == 'w'))
         {
+            sizePrefix = *p;
             ++p;
         }
 
@@ -1002,6 +1009,57 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
 #else
         char const* const acceptedConversions = "diouxXfFeEgGaAcsp";
 #endif
+
+        // A size prefix is only meaningful for some conversions. "%I64s", "%zs" and
+        // "%Ld" satisfy the grammar piecewise but are not valid pairings: MSVC answers
+        // them with the invalid-parameter handler, which terminates and is precisely
+        // what the SEH block cannot contain, and a CRT that tolerates one instead reads
+        // the argument as the wrong type and returns success with garbage.
+        if (sizePrefix != '\0' && *p != '\0')
+        {
+            bool const integerConversion = strchr("diouxX", *p) != nullptr;
+            bool const floatConversion   = strchr("fFeEgGaA", *p) != nullptr;
+            bool const stringConversion  = (*p == 's' || *p == 'c');
+            bool valid = false;
+
+            switch (sizePrefix)
+            {
+                case 'H':                                   // hh
+                case 'Q':                                   // ll
+                case 'j':                                   // intmax_t
+                case 'z':                                   // size_t
+                case 't':                                   // ptrdiff_t
+                case '3':                                   // I32
+                case '6':                                   // I64
+                case 'I':                                   // pointer-width
+                    valid = integerConversion;
+                    break;
+                case 'h':                                   // short, or single-byte s/c on MSVC
+                    valid = integerConversion || (msvcSizePrefixes && stringConversion);
+                    break;
+                case 'l':                                   // long, or wide s/c
+                    valid = integerConversion || stringConversion;
+                    break;
+                case 'L':                                   // long double ONLY.
+                    // Not integers: UCRT answers %Ld with the invalid-parameter
+                    // handler, which raises STATUS_STACK_BUFFER_OVERRUN through
+                    // __fastfail and cannot be caught by the SEH block below.
+                    // Measured, not assumed - it terminated the test harness.
+                    valid = floatConversion;
+                    break;
+                case 'w':                                   // MSVC wide s/c
+                    valid = stringConversion;
+                    break;
+                default:
+                    valid = false;
+                    break;
+            }
+
+            if (!valid)
+            {
+                return false;
+            }
+        }
 
         if (*p == '\0' || !strchr(acceptedConversions, *p))
         {

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -1004,10 +1004,13 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
         // conversion makes vsnprintf return -1 having written nothing useful, which
         // is indistinguishable here from ordinary truncation. Refusing them up front
         // is what lets the call below ignore its return value safely.
+        // C and S are available on both: MSVC spells the wide forms that way, and
+        // glibc keeps them as XSI aliases for %lc and %ls. Z is the one that is
+        // genuinely MSVC-only, and glibc rejects it.
 #ifdef _MSC_VER
         char const* const acceptedConversions = "diouxXfFeEgGaAcCsSpZ";
 #else
-        char const* const acceptedConversions = "diouxXfFeEgGaAcsp";
+        char const* const acceptedConversions = "diouxXfFeEgGaAcCsSp";
 #endif
 
         // A size prefix is only meaningful for some conversions. "%I64s", "%zs" and
@@ -1037,8 +1040,10 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
                 case 'h':                                   // short, or single-byte s/c on MSVC
                     valid = integerConversion || (msvcSizePrefixes && stringConversion);
                     break;
-                case 'l':                                   // long, or wide s/c
-                    valid = integerConversion || stringConversion;
+                case 'l':                                   // long, wide s/c, or a no-op
+                    // before a float: %lf, %le and %lg are valid and consume the same
+                    // promoted double as the unmodified conversion.
+                    valid = integerConversion || stringConversion || floatConversion;
                     break;
                 case 'L':                                   // long double ONLY.
                     // Not integers: UCRT answers %Ld with the invalid-parameter

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -859,6 +859,11 @@ static bool _GuardedVsnprintf(char* buffer, size_t size, char const* format, va_
 {
     // Gated on the compiler, not the OS: __try/__except is MSVC syntax, and a
     // MinGW build targets Windows without supporting it.
+    // The return value is deliberately not treated as a success flag: _vsnprintf
+    // returns -1 for ordinary truncation as well as for a rejected format, so
+    // testing it would drop every message merely too long for its buffer. Formats
+    // the CRT would reject are refused by the grammar check in the caller instead,
+    // which is why that check only accepts conversions the local CRT implements.
 #ifdef _MSC_VER
     __try
     {
@@ -876,8 +881,7 @@ static bool _GuardedVsnprintf(char* buffer, size_t size, char const* format, va_
     // No portable equivalent: a malformed format is still fatal here, but the
     // callers' reporting and the load-time checks in ObjectMgr apply on every
     // platform.
-    vsnprintf(buffer, size, format, ap);
-    return true;
+    return vsnprintf(buffer, size, format, ap) >= 0;
 #endif
 }
 
@@ -988,7 +992,18 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
         }
 
         // '\0' is tested first: strchr would otherwise match the set's own terminator
-        if (*p == '\0' || !strchr("diouxXfFeEgGaAcCsSpZ", *p))
+        // The accepted set is what the LOCAL CRT implements, not the union of every
+        // CRT. C, S and Z are MSVC spellings: glibc rejects them, and a rejected
+        // conversion makes vsnprintf return -1 having written nothing useful, which
+        // is indistinguishable here from ordinary truncation. Refusing them up front
+        // is what lets the call below ignore its return value safely.
+#ifdef _MSC_VER
+        char const* const acceptedConversions = "diouxXfFeEgGaAcCsSpZ";
+#else
+        char const* const acceptedConversions = "diouxXfFeEgGaAcsp";
+#endif
+
+        if (*p == '\0' || !strchr(acceptedConversions, *p))
         {
             return false;                                   // %n, trailing '%', or malformed
         }

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -957,8 +957,20 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
             }
         }
 
-        // size prefixes, longest match first
-        if ((p[0] == 'I' && p[1] == '3' && p[2] == '2') || (p[0] == 'I' && p[1] == '6' && p[2] == '4'))
+        // Size prefixes, longest match first.
+        //
+        // "I", "I32", "I64" and "w" are MSVC spellings that glibc does not implement:
+        // there the I is read as a flag and the 32/64 as a field width, so %I64u
+        // consumes an unsigned int and silently truncates anything above 32 bits.
+        // Accepting them only where the CRT understands them stops a row that renders
+        // correctly on Windows from rendering wrong numbers on Linux.
+#ifdef _MSC_VER
+        bool const msvcSizePrefixes = true;
+#else
+        bool const msvcSizePrefixes = false;
+#endif
+
+        if (msvcSizePrefixes && p[0] == 'I' && ((p[1] == '3' && p[2] == '2') || (p[1] == '6' && p[2] == '4')))
         {
             p += 3;
         }
@@ -966,8 +978,11 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
         {
             p += 2;
         }
-        else if (*p == 'h' || *p == 'l' || *p == 'L' || *p == 'j' || *p == 'z' ||
-                 *p == 't' || *p == 'I' || *p == 'w')
+        else if (*p == 'h' || *p == 'l' || *p == 'L' || *p == 'j' || *p == 'z' || *p == 't')
+        {
+            ++p;
+        }
+        else if (msvcSizePrefixes && (*p == 'I' || *p == 'w'))
         {
             ++p;
         }
@@ -991,6 +1006,33 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
     }
 
     return formatted;
+}
+
+bool SafeFormatDbStringF(char* buffer, size_t size, char const* format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    bool const formatted = SafeFormatDbString(buffer, size, format, ap);
+    va_end(ap);
+
+    return formatted;
+}
+
+void CopyDbStringBounded(char* buffer, size_t size, char const* text)
+{
+    if (!buffer || !size)
+    {
+        return;
+    }
+
+    if (!text)
+    {
+        buffer[0] = '\0';
+        return;
+    }
+
+    strncpy(buffer, text, size - 1);
+    buffer[size - 1] = '\0';
 }
 
 void hexEncodeByteArray(uint8* bytes, uint32 arrayLen, std::string& result)

--- a/src/shared/Utilities/Util.h
+++ b/src/shared/Utilities/Util.h
@@ -877,6 +877,33 @@ void vutf8printf(FILE* out, const char* str, va_list* ap);
 std::string vutf8format(const char* str, va_list* ap);
 
 /**
+ * @brief Formats a string whose format comes from the database, without letting
+ *        a malformed format take the process down.
+ *
+ * Format strings loaded from `mangos_string` are mutable data, but they are handed
+ * to vsnprintf against a fixed argument list built by the C++ call site. A row
+ * whose conversions outnumber the arguments passed makes va_arg walk off the end
+ * of the list and dereference whatever the stack held next, so a single bad row is
+ * a server crash that any player can trigger by running the command that reaches
+ * it. Contain the fault here and let the caller report the offending entry instead.
+ *
+ * Returning false means only that the string could not be formatted safely: an
+ * argument-count mismatch, a %n, an invalid conversion, or a contained access
+ * violation. It does not identify which.
+ *
+ * Also terminates the buffer unconditionally: on Windows `vsnprintf` is
+ * `_vsnprintf` (Common.h), which leaves the buffer unterminated when the output
+ * does not fit.
+ *
+ * @param buffer The destination buffer.
+ * @param size The destination buffer size in bytes.
+ * @param format The format string, typically database-sourced.
+ * @param ap The argument list.
+ * @return bool true if formatting completed, false if it faulted.
+ */
+bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list ap);
+
+/**
  * @brief
  *
  * @param ipaddress

--- a/src/shared/Utilities/Util.h
+++ b/src/shared/Utilities/Util.h
@@ -921,15 +921,19 @@ bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list a
 bool SafeFormatDbStringF(char* buffer, size_t size, char const* format, ...);
 
 /**
- * @brief Copies a database row into a fixed buffer, always NUL-terminated.
+ * @brief Copies a data-driven string into a fixed buffer.
  *
  * Used as the fallback when formatting is refused: showing the row unformatted
- * beats showing nothing, and it must never be handed to code that writes through
- * the pointer, because it belongs to ObjectMgr.
+ * beats showing nothing. The copy also decouples the result from the source, which
+ * matters because callers pass storage they do not own - a `mangos_string` row held
+ * by ObjectMgr, or a DBC field - and some consumers tokenize what they are given.
+ *
+ * Terminates the destination whenever it is non-null and size is non-zero; a null
+ * or zero-size destination is left untouched.
  *
  * @param buffer The destination buffer.
  * @param size The destination buffer size in bytes.
- * @param text The text to copy.
+ * @param text The text to copy; a null source yields an empty string.
  */
 void CopyDbStringBounded(char* buffer, size_t size, char const* text);
 

--- a/src/shared/Utilities/Util.h
+++ b/src/shared/Utilities/Util.h
@@ -904,6 +904,36 @@ std::string vutf8format(const char* str, va_list* ap);
 bool SafeFormatDbString(char* buffer, size_t size, char const* format, va_list ap);
 
 /**
+ * @brief SafeFormatDbString for the fixed-argument call sites.
+ *
+ * The same protection for the many places that hand a `mangos_string` row
+ * straight to snprintf or sprintf with a known argument list. On failure the
+ * buffer is left empty and false is returned, so the caller can report the entry
+ * and decide what to show instead.
+ *
+ * @param buffer The destination buffer.
+ * @param size The destination buffer size in bytes.
+ * @param format The format string, typically database-sourced.
+ * @return bool true if formatting completed, false if it was refused or faulted.
+ */
+// Deliberately not marked with a printf format attribute: the format is a
+// runtime database row, not a literal, so compile-time checking cannot apply.
+bool SafeFormatDbStringF(char* buffer, size_t size, char const* format, ...);
+
+/**
+ * @brief Copies a database row into a fixed buffer, always NUL-terminated.
+ *
+ * Used as the fallback when formatting is refused: showing the row unformatted
+ * beats showing nothing, and it must never be handed to code that writes through
+ * the pointer, because it belongs to ObjectMgr.
+ *
+ * @param buffer The destination buffer.
+ * @param size The destination buffer size in bytes.
+ * @param text The text to copy.
+ */
+void CopyDbStringBounded(char* buffer, size_t size, char const* text);
+
+/**
  * @brief
  *
  * @param ipaddress


### PR DESCRIPTION
## The crash

A GM running `.pinfo` took the world down with an access violation inside UCRT's `vsnprintf`, called from `ChatHandler::PSendSysMessage`.

```
_itoa+28D                              (ucrtbase)
__stdio_common_vsprintf+128            (ucrtbase)
ChatHandler::PSendSysMessage+6B        ChatMessage.cpp:128
ChatHandler::HandlePInfoCommand+639    GMCommands.cpp:151
```

The format string there comes from `mangos_string`, which is mutable data, but it is applied to a fixed argument list built by the C++ call site. A row whose conversions outnumber the arguments passed makes `va_arg` walk past the end of the list and a `%s` dereference whatever the stack held next.

Confirmed with a standalone program against the same UCRT. The reporter's landed on `0x000000C100000000` — a stack address with its low dword zeroed — and `RAX = R8 + 0x7FFFFFE0` is UCRT computing `string + precision` with `%s`'s default `INT_MAX`.

**The offending row is not yet identified.** The reporter is on `enGB` and so resolves `content_default`, on the same core revision and the same 894 rows that format correctly here. This is therefore *containment plus reporting*, not a fix for one known row: the next occurrence logs the entry number instead of killing the process, and that number is what identifies it.

## `SafeFormatDbString`

Wraps every use of a database-sourced format:

- **Validates the field grammar** `%[flags][width][.precision][size]type`, refusing `%n`, positional syntax, and malformed or truncated fields. These reach UCRT's invalid-parameter handler, which *terminates* rather than raising anything an exception filter could catch — so they must be refused before the call, not contained after it.
- **Contains an access violation** from the call itself, filtering on `EXCEPTION_ACCESS_VIOLATION` alone and continuing the search otherwise. Gated on `_MSC_VER`, since `__try` is MSVC syntax and MinGW also targets Windows.
- **Terminates the buffer unconditionally** — on Windows `vsnprintf` is `_vsnprintf` (Common.h), which leaves it unterminated on truncation.

Wired into all five database-sourced sites. The builders fall back to the raw row rather than returning, because `LocalizedPacketDo` sends whatever the builder leaves in the packet it allocated — returning early would put an **empty packet on the wire**. The world builder copies that row into its local buffer first, since `do_helper` tokenizes in place with `strtok` and the pointer is ObjectMgr-owned.

## Load-time check

`LoadMangosStrings` compares each locale's conversion sequence against `content_default` and drops a locale that does not match, falling back to the default the callers were written against. Length modifiers and positional indices are part of that signature because they change which type, and which argument, is consumed.

Scoped by a new `printf_formatted` flag to `mangos_string` — the only one of these tables used as a format. The rest reach `DoDisplayText` and are spoken verbatim, where a bare `%` is an ordinary character. Unscoped, this dropped ~50 valid ruRU translations and mangled an NPC line.

On the shipped database it rejects three ruRU rows (438, 548, 1028) that would otherwise format against the wrong arguments.

## Verification

- Parser: **28/28** against the real function, incl. `%s`/`%ls`, `%u`/`%zu`, `%I32u`/`%I64u`, `%ws`/`%wc`, and positional reordering
- Format guard: **23/23** against the real extracted function — `%..s`, `%$s`, `%1$s`, `%n`, `%5n`, `%I64n`, trailing `%` rejected; `%hhd`, `%lld`, `%*.*s`, `%#x`, `%I64u` accepted
- Build clean, no warnings in changed files
- Live startup: 894 strings, exactly 3 rejections, zero spam from verbatim tables, reaches `listening`
- In-game smoke test passed

Reviewed across three read-only Codex passes; final verdict **APPROVE WITH FOLLOW-UP**, including an exhaustive 62,400-field probe of the comparator that found zero collisions between distinct argument signatures.

## Known follow-up, deliberately not included

`World.cpp`'s untouched no-args branch still hands the ObjectMgr-owned row to `do_helper`, where `strtok` truncates the cached string at the first newline. Pre-existing, on a common path, and out of scope for a formatting-failure fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/64)
<!-- Reviewable:end -->
