### PR TITLE
Generate revision_data.h into the build tree, not the source tree

### DIFF
--- a/cmake/GenRevision.cmake
+++ b/cmake/GenRevision.cmake
@@ -193,11 +193,20 @@ if(
   OR NOT "${dep_eluna_rev_branch_cached}" MATCHES "${dep_eluna_rev_branch}"
   OR NOT "${dep_sd3_rev_hash_cached}"     MATCHES "${dep_sd3_rev_hash}"
   OR NOT "${dep_sd3_rev_branch_cached}"   MATCHES "${dep_sd3_rev_branch}"
-  OR NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/src/shared/revision_data.h"
+  OR NOT EXISTS "${BUILDDIR}/src/shared/revision_data.h"
 )
+  # BUILDDIR, not CMAKE_CURRENT_BINARY_DIR. This script also runs at build time via
+  # `cmake -P` from the revision_data.h target, and in script mode
+  # CMAKE_CURRENT_BINARY_DIR is simply the working directory - which that target sets
+  # to CMAKE_SOURCE_DIR. The generated header therefore landed in the source tree,
+  # which nothing compiles, while the copy the compiler actually includes was only
+  # ever refreshed when CMake re-configured. A database version bump could then sit
+  # in revision_data.h.in for hours without reaching the binary, leaving the
+  # db_version check comparing against stale constants and silently accepting an
+  # out-of-date database.
   configure_file(
     "${CMAKE_SOURCE_DIR}/src/shared/revision_data.h.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/src/shared/revision_data.h"
+    "${BUILDDIR}/src/shared/revision_data.h"
     @ONLY
   )
   set(rev_hash_cached             "${rev_hash}"             CACHE INTERNAL "Cached commit-hash"       )

--- a/src/genrev/CMakeLists.txt
+++ b/src/genrev/CMakeLists.txt
@@ -18,7 +18,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+# `cmake -P` runs with no project cache, so nothing configured here reaches the
+# script unless it is passed explicitly. GIT_EXECUTABLE is the important one:
+# without it GenRevision.cmake skips revision discovery entirely and falls back to
+# "unknown"/"Archived" with empty submodule fields. That was survivable only while
+# the script wrote somewhere nothing compiles; now that it writes the header the
+# compiler reads, those values would be stamped into every build.
 add_custom_target(revision_data.h ALL
-  COMMAND "${CMAKE_COMMAND}" -DBUILDDIR="${CMAKE_BINARY_DIR}" -P "${CMAKE_SOURCE_DIR}/cmake/GenRevision.cmake" "${CMAKE_BINARY_DIR}"
+  COMMAND "${CMAKE_COMMAND}"
+    -DBUILDDIR="${CMAKE_BINARY_DIR}"
+    -DGIT_EXECUTABLE="${GIT_EXECUTABLE}"
+    -DWITHOUT_GIT=${WITHOUT_GIT}
+    -DSCRIPT_LIB_ELUNA=${SCRIPT_LIB_ELUNA}
+    -DSCRIPT_LIB_SD3=${SCRIPT_LIB_SD3}
+    -P "${CMAKE_SOURCE_DIR}/cmake/GenRevision.cmake" "${CMAKE_BINARY_DIR}"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
 )
+
+# Without an explicit edge this is just another ALL target, so the build tool is
+# free to compile the consumers before - or alongside - the command that rewrites
+# the header, letting one invocation finish carrying the previous revision. shared
+# is the root of the link graph here (game, mangosd and the modules all reach it),
+# so ordering shared after the generator orders every consumer with it. `shared` is
+# already defined at this point: src/CMakeLists.txt adds it before genrev.
+if(TARGET shared)
+  add_dependencies(shared revision_data.h)
+endif()

--- a/src/genrev/CMakeLists.txt
+++ b/src/genrev/CMakeLists.txt
@@ -24,16 +24,39 @@
 # "unknown"/"Archived" with empty submodule fields. That was survivable only while
 # the script wrote somewhere nothing compiles; now that it writes the header the
 # compiler reads, those values would be stamped into every build.
+#
+# CMAKE_HOST_SYSTEM_VERSION is in the same category and easy to miss: script mode
+# leaves it empty, and revision_data.h.in substitutes it into CMAKE_HOST_SYSTEM,
+# so without it the build-time run degrades "Windows 10.0.26200" to "Windows ".
+# CMAKE_VERSION and CMAKE_HOST_SYSTEM_NAME are the only other substituted values
+# not computed inside the script, and cmake -P does set both.
+#
+# VERBATIM matters here because two of these are paths that routinely contain
+# spaces - a default Windows Git lives under "C:/Program Files/Git" - and without
+# it the escaping is generator-specific and can arrive as literal data.
+set(REVISION_DATA_HEADER "${CMAKE_BINARY_DIR}/src/shared/revision_data.h")
+
 add_custom_target(revision_data.h ALL
   COMMAND "${CMAKE_COMMAND}"
-    -DBUILDDIR="${CMAKE_BINARY_DIR}"
-    -DGIT_EXECUTABLE="${GIT_EXECUTABLE}"
+    -DBUILDDIR=${CMAKE_BINARY_DIR}
+    -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
     -DWITHOUT_GIT=${WITHOUT_GIT}
     -DSCRIPT_LIB_ELUNA=${SCRIPT_LIB_ELUNA}
     -DSCRIPT_LIB_SD3=${SCRIPT_LIB_SD3}
+    -DCMAKE_HOST_SYSTEM_VERSION=${CMAKE_HOST_SYSTEM_VERSION}
     -P "${CMAKE_SOURCE_DIR}/cmake/GenRevision.cmake" "${CMAKE_BINARY_DIR}"
+  BYPRODUCTS "${REVISION_DATA_HEADER}"
   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  COMMENT "Generating revision_data.h"
+  VERBATIM
 )
+
+# Declaring the header a byproduct is what tells the generator this command is the
+# thing that produces it, rather than leaving it an untracked file that happens to
+# appear. Ninja in particular needs that edge: without it the header is unknown to
+# the graph, and the ordering edge below only sequences the command, it does not
+# mark anything dirty.
+set_source_files_properties("${REVISION_DATA_HEADER}" PROPERTIES GENERATED TRUE)
 
 # Without an explicit edge this is just another ALL target, so the build tool is
 # free to compile the consumers before - or alongside - the command that rewrites


### PR DESCRIPTION
## What was wrong

`GenRevision.cmake` wrote through `CMAKE_CURRENT_BINARY_DIR`. That is correct while CMake is configuring, but the script **also runs on every build** via `cmake -P` from the `revision_data.h` target — and in script mode `CMAKE_CURRENT_BINARY_DIR` is simply the working directory, which that target sets to `CMAKE_SOURCE_DIR`.

So the per-build regeneration landed in the **source** tree, where nothing compiles it, while the copy the compiler actually includes was refreshed only when CMake re-configured.

`BUILDDIR` is already passed in by the target and defaulted at the top of the script for exactly this purpose. It just wasn't used at the two places that matter.

## Why it isn't cosmetic

`WORLD_DB_STRUCTURE_NR` and `WORLD_DB_CONTENT_NR` live in this header. A database version bump can therefore sit in `revision_data.h.in` for hours without reaching the binary.

That happened here. On this machine:

| | |
|---|---|
| `GitRevision.obj` | 2026-07-28 11:04 |
| build-tree `revision_data.h` | 2026-07-29 03:44 (last *configure*) |
| source-tree `revision_data.h` | 2026-07-29 12:32 (last *build*) |

The binary still asked for `23/2/31`. The world database was `23/2/81`. Version and structure matched and content was ahead, so `Database::CheckDatabaseVersion` reported:

```
The table `db_version` indicates that your [World] database has the same version as the core requirements.
Using World DB: Version: 23, Structure: 2, Content: 81
```

and started normally — against a database **seven content updates behind**, missing a `quest_poi.blobId` column the core had begun selecting. The result was a total, silent loss of quest POI that read as a core bug rather than an un-migrated database.

The gate itself is fine. Once the constants are current it refuses correctly:

```
  [A] You have database Version: 23  Structure: 2  Content: 81
  [B] The core needs database Version: 23  Structure: 3  Content: 1
You must apply all updates after [A] to [B] to use MaNGOS with this database.
Halting process...                                    (exit 255)
```

## Verification

Removed the build-tree header and ran the `revision_data.h` target: it is recreated **there**, with the current values —

```
#define WORLD_DB_STRUCTURE_NR       "3"
#define WORLD_DB_CONTENT_NR         "1"
```

Before this change that path was never written at build time.

Note `cmake -P` has no CMake cache, so the `*_cached` guard variables are always empty in script mode and the block always evaluates. `configure_file` skips the write when content is identical, so the header's mtime only moves when the contents actually change, and dependent objects rebuild only when they should.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/65)
<!-- Reviewable:end -->
