### PR TITLE
Move the world-DB requirement pin to the declared tuple (unbreaks the suite)

### DIFF
--- a/src/game/Server/tests/mop_world_quest_interaction_packets_source_test.cmake
+++ b/src/game/Server/tests/mop_world_quest_interaction_packets_source_test.cmake
@@ -96,9 +96,12 @@ if(DEFINED MUTATION)
             "data << \"Greetings $N\""
             gossip_def "${gossip_def}")
     elseif(MUTATION STREQUAL "npc_db_content")
+        # Must track the declared value. When the tuple advanced to 23.3.1 this arm still
+        # searched for "31", matched nothing, and silently became a no-op -- so it passed, and
+        # the stale pin it was meant to protect went unnoticed.
         string(REPLACE
-            "WORLD_DB_CONTENT_NR         \"31\""
-            "WORLD_DB_CONTENT_NR         \"30\""
+            "WORLD_DB_CONTENT_NR         \"1\""
+            "WORLD_DB_CONTENT_NR         \"0\""
             revision_data "${revision_data}")
     elseif(MUTATION STREQUAL "npc_reference_status")
         string(REPLACE
@@ -267,8 +270,8 @@ endforeach()
 # with it or the check silently asserts an obsolete database.
 foreach(requirement IN ITEMS
         "WORLD_DB_VERSION_NR[ \t]+\"23\""
-        "WORLD_DB_STRUCTURE_NR[ \t]+\"2\""
-        "WORLD_DB_CONTENT_NR[ \t]+\"31\"")
+        "WORLD_DB_STRUCTURE_NR[ \t]+\"3\""
+        "WORLD_DB_CONTENT_NR[ \t]+\"1\"")
     require_once("${revision_data}"
         "${requirement}"
         "BroadcastText-aware world database requirement")


### PR DESCRIPTION
`mop_world_quest_interaction_packets_source` has been failing on master since `fd7786da5`
advanced `WORLD_DB_STRUCTURE_NR`/`CONTENT_NR` to 23.3.1. The gate still pinned 23.2.31 —
exactly what its own comment warns about:

> the declared tuple has since advanced and this pin must move with it or the check silently
> asserts an obsolete database

Two changes, both needed to go green:

- **The pin** now reads structure `"3"`, content `"1"`, matching `revision_data.h.in`.
- **The `npc_db_content` mutation arm** searched for `WORLD_DB_CONTENT_NR "31"` and replaced it
  with `"30"`. Once the declared value became `"1"` that match found nothing, so the arm mutated
  nothing, the gate passed, and the `WILL_FAIL` test reported a failure. It now mutates
  `"1"` → `"0"`.

The dead arm is the more interesting half: it was the specific guard protecting the pin that went
stale, so the arm dying and the pin rotting were the same event — visible only as one red test
with a misleading message.

**Follow-up, not included:** this gate has no dead-arm guard, unlike
`mop_char_response_codes_source`, which exits 0 with a diagnostic when an arm changes nothing so
the failure names the real cause. Adding one here means snapshotting the dozen source blobs this
gate reads, so it is better as its own change.

## Verification

- Baseline green; `npc_db_content` and `npc_reference_status` arms both fail on their own assertions
- **Full suite 1140/1140** — first fully green run since the pin went stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/66)
<!-- Reviewable:end -->
