### PR TITLE
Stop the crash reporter corrupting its own stack while writing the report

### DIFF
--- a/src/shared/Win/WheatyExceptionReport.cpp
+++ b/src/shared/Win/WheatyExceptionReport.cpp
@@ -693,7 +693,7 @@ WheatyExceptionReport::EnumerateSymbolsCallback(
     ULONG         SymbolSize,
     PVOID         UserContext)
 {
-    char szBuffer[2048];
+    char szBuffer[kSymbolBufferSize];
 
     __try
     {
@@ -1027,17 +1027,21 @@ char* WheatyExceptionReport::AppendFormat(char* pszCurrBuffer, char const* pszEn
 //============================================================================
 int __cdecl WheatyExceptionReport::_tprintf(const TCHAR* format, ...)
 {
-    TCHAR szBuff[1024];
+    TCHAR szBuff[kReportLineSize];
     int retValue;
     DWORD cbWritten;
     va_list argptr;
 
     // vsprintf here was unbounded, and the WriteFile below then wrote the length it
     // returned - so a symbol dump longer than the buffer both smashed this frame and
-    // flushed the overrun to disk. That is why every crash report this handler has
-    // produced stops mid-symbol: the report survives to the truncation point because
-    // the file is opened FILE_FLAG_WRITE_THROUGH, and nothing after it is ever
-    // written. Bounded, and the length clamped to what the buffer actually holds.
+    // flushed the overrun to disk. Bounded now, with the length clamped to what the
+    // buffer actually holds.
+    //
+    // The buffer is sized from kSymbolBufferSize rather than picked independently:
+    // callers hand this a whole formatted symbol plus their own wrapping, and a sink
+    // smaller than that would trade the overflow for silent truncation - dropping the
+    // tail of exactly the deep types this change exists to handle, line break
+    // included, so the next symbol would run onto the same line.
     va_start(argptr, format);
     retValue = _vsnprintf(szBuff, ARRAYSIZE(szBuff) - 1, format, argptr);
     va_end(argptr);

--- a/src/shared/Win/WheatyExceptionReport.cpp
+++ b/src/shared/Win/WheatyExceptionReport.cpp
@@ -723,15 +723,16 @@ bool WheatyExceptionReport::FormatSymbolValue(
     unsigned cbBuffer)
 {
     char* pszCurrBuffer = pszBuffer;
+    char const* const pszEnd = pszBuffer + cbBuffer;
 
     // Indicate if the variable is a local or parameter
     if (pSym->Flags & IMAGEHLP_SYMBOL_INFO_PARAMETER)
     {
-        pszCurrBuffer += sprintf(pszCurrBuffer, "Parameter ");
+        pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, "Parameter ");
     }
     else if (pSym->Flags & IMAGEHLP_SYMBOL_INFO_LOCAL)
     {
-        pszCurrBuffer += sprintf(pszCurrBuffer, "Local ");
+        pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, "Local ");
     }
 
     // If it's a function, don't do anything.
@@ -765,7 +766,7 @@ bool WheatyExceptionReport::FormatSymbolValue(
     // Determine if the variable is a user defined type (UDT).  IF so, bHandled
     // will return true.
     bool bHandled;
-    pszCurrBuffer = DumpTypeIndex(pszCurrBuffer, pSym->ModBase, pSym->TypeIndex,
+    pszCurrBuffer = DumpTypeIndex(pszCurrBuffer, pszEnd, pSym->ModBase, pSym->TypeIndex,
                                   0, pVariable, bHandled, pSym->Name);
 
     if (!bHandled)
@@ -774,12 +775,12 @@ bool WheatyExceptionReport::FormatSymbolValue(
         // variable.  Based on the size, we're assuming it's a char, WORD, or
         // DWORD.
         BasicType basicType = GetBasicType(pSym->TypeIndex, pSym->ModBase);
-        pszCurrBuffer += sprintf(pszCurrBuffer, rgBaseType[basicType]);
+        pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, rgBaseType[basicType]);
 
         // Emit the variable name
-        pszCurrBuffer += sprintf(pszCurrBuffer, "\'%s\'", pSym->Name);
+        pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, "\'%s\'", pSym->Name);
 
-        pszCurrBuffer = FormatOutputValue(pszCurrBuffer, basicType, pSym->Size,
+        pszCurrBuffer = FormatOutputValue(pszCurrBuffer, pszEnd, basicType, pSym->Size,
                                           (PVOID)pVariable);
     }
 
@@ -793,6 +794,7 @@ bool WheatyExceptionReport::FormatSymbolValue(
 //////////////////////////////////////////////////////////////////////////////
 char* WheatyExceptionReport::DumpTypeIndex(
     char* pszCurrBuffer,
+    char const* pszEnd,
     DWORD64 modBase,
     DWORD dwTypeIndex,
     unsigned nestingLevel,
@@ -808,7 +810,7 @@ char* WheatyExceptionReport::DumpTypeIndex(
     if (SymGetTypeInfo(m_hProcess, modBase, dwTypeIndex, TI_GET_SYMNAME,
                        &pwszTypeName))
     {
-        pszCurrBuffer += sprintf(pszCurrBuffer, " %ls", pwszTypeName);
+        pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " %ls", pwszTypeName);
         LocalFree(pwszTypeName);
     }
 
@@ -845,7 +847,7 @@ char* WheatyExceptionReport::DumpTypeIndex(
     }
 
     // Append a line feed
-    pszCurrBuffer += sprintf(pszCurrBuffer, "\r\n");
+    pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, "\r\n");
 
     // Iterate through each of the children
     for (unsigned i = 0; i < dwChildrenCount; ++i)
@@ -853,15 +855,15 @@ char* WheatyExceptionReport::DumpTypeIndex(
         // Add appropriate indentation level (since this routine is recursive)
         for (unsigned j = 0; j <= nestingLevel + 1; ++j)
         {
-            pszCurrBuffer += sprintf(pszCurrBuffer, "\t");
+            pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, "\t");
         }
 
         // Recurse for each of the child types
         bool bHandled2;
         BasicType basicType = GetBasicType(children.ChildId[i], modBase);
-        pszCurrBuffer += sprintf(pszCurrBuffer, rgBaseType[basicType]);
+        pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, rgBaseType[basicType]);
 
-        pszCurrBuffer = DumpTypeIndex(pszCurrBuffer, modBase,
+        pszCurrBuffer = DumpTypeIndex(pszCurrBuffer, pszEnd, modBase,
                                       children.ChildId[i], nestingLevel + 1,
                                       offset, bHandled2, ""/*Name */);
 
@@ -893,10 +895,10 @@ char* WheatyExceptionReport::DumpTypeIndex(
             // Emit the variable name
             //          pszCurrBuffer += sprintf( pszCurrBuffer, "\'%s\'", Name );
 
-            pszCurrBuffer = FormatOutputValue(pszCurrBuffer, basicType,
+            pszCurrBuffer = FormatOutputValue(pszCurrBuffer, pszEnd, basicType,
                                               length, (PVOID)dwFinalOffset);
 
-            pszCurrBuffer += sprintf(pszCurrBuffer, "\r\n");
+            pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, "\r\n");
         }
     }
 
@@ -905,6 +907,7 @@ char* WheatyExceptionReport::DumpTypeIndex(
 }
 
 char* WheatyExceptionReport::FormatOutputValue(char* pszCurrBuffer,
+    char const* pszEnd,
         BasicType basicType,
         DWORD64 length,
         PVOID pAddress)
@@ -912,43 +915,47 @@ char* WheatyExceptionReport::FormatOutputValue(char* pszCurrBuffer,
     // Format appropriately (assuming it's a 1, 2, or 4 bytes (!!!)
     if (length == 1)
     {
-        pszCurrBuffer += sprintf(pszCurrBuffer, " = %X", *(PBYTE)pAddress);
+        pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " = %X", *(PBYTE)pAddress);
     }
     else if (length == 2)
     {
-        pszCurrBuffer += sprintf(pszCurrBuffer, " = %X", *(PWORD)pAddress);
+        pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " = %X", *(PWORD)pAddress);
     }
     else if (length == 4)
     {
         if (basicType == btFloat)
         {
-            pszCurrBuffer += sprintf(pszCurrBuffer, " = %f", *(PFLOAT)pAddress);
+            pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " = %f", *(PFLOAT)pAddress);
         }
         else if (basicType == btChar)
         {
             if (!IsBadStringPtr(*(PSTR*)pAddress, 32))
             {
-                pszCurrBuffer += sprintf(pszCurrBuffer, " = \"%.31s\"",
-                                         *(PDWORD)pAddress);
+                // Was *(PDWORD)pAddress: the pointer is validated as a PSTR and then
+                // only its low 32 bits were passed to %s, so on x64 the formatter was
+                // handed a truncated address that the check above never vetted. The
+                // compiler has been warning about this (C4313) the whole time.
+                pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " = \"%.31s\"",
+                                         *(PSTR*)pAddress);
             }
             else
-                pszCurrBuffer += sprintf(pszCurrBuffer, " = %X",
+                pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " = %X",
                                          *(PDWORD)pAddress);
         }
         else
         {
-            pszCurrBuffer += sprintf(pszCurrBuffer, " = %X", *(PDWORD)pAddress);
+            pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " = %X", *(PDWORD)pAddress);
         }
     }
     else if (length == 8)
     {
         if (basicType == btFloat)
         {
-            pszCurrBuffer += sprintf(pszCurrBuffer, " = %lf",
+            pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " = %lf",
                                      *(double*)pAddress);
         }
         else
-            pszCurrBuffer += sprintf(pszCurrBuffer, " = %I64X",
+            pszCurrBuffer = AppendFormat(pszCurrBuffer, pszEnd, " = %I64X",
                                      *(DWORD64*)pAddress);
     }
 
@@ -985,6 +992,36 @@ WheatyExceptionReport::GetBasicType(DWORD typeIndex, DWORD64 modBase)
 }
 
 //============================================================================
+// Bounded append into the symbol-formatting buffer. Returns the new write
+// position, never past pszEnd, with the buffer always terminated.
+//============================================================================
+char* WheatyExceptionReport::AppendFormat(char* pszCurrBuffer, char const* pszEnd, char const* format, ...)
+{
+    if (!pszCurrBuffer || !pszEnd || pszCurrBuffer >= pszEnd)
+    {
+        return pszCurrBuffer;
+    }
+
+    size_t const remaining = size_t(pszEnd - pszCurrBuffer);
+
+    va_list argptr;
+    va_start(argptr, format);
+    int const written = _vsnprintf(pszCurrBuffer, remaining, format, argptr);
+    va_end(argptr);
+
+    // _vsnprintf returns -1 when the output did not fit, and leaves the buffer
+    // unterminated in that case.
+    if (written < 0 || size_t(written) >= remaining)
+    {
+        pszCurrBuffer[remaining - 1] = '\0';
+        return pszCurrBuffer + remaining - 1;
+    }
+
+    pszCurrBuffer[written] = '\0';
+    return pszCurrBuffer + written;
+}
+
+//============================================================================
 // Helper function that writes to the report file, and allows the user to use
 // printf style formating
 //============================================================================
@@ -995,9 +1032,23 @@ int __cdecl WheatyExceptionReport::_tprintf(const TCHAR* format, ...)
     DWORD cbWritten;
     va_list argptr;
 
+    // vsprintf here was unbounded, and the WriteFile below then wrote the length it
+    // returned - so a symbol dump longer than the buffer both smashed this frame and
+    // flushed the overrun to disk. That is why every crash report this handler has
+    // produced stops mid-symbol: the report survives to the truncation point because
+    // the file is opened FILE_FLAG_WRITE_THROUGH, and nothing after it is ever
+    // written. Bounded, and the length clamped to what the buffer actually holds.
     va_start(argptr, format);
-    retValue = vsprintf(szBuff, format, argptr);
+    retValue = _vsnprintf(szBuff, ARRAYSIZE(szBuff) - 1, format, argptr);
     va_end(argptr);
+
+    // _vsnprintf returns -1 when the output did not fit, and does not terminate.
+    if (retValue < 0 || retValue > (int)(ARRAYSIZE(szBuff) - 1))
+    {
+        retValue = ARRAYSIZE(szBuff) - 1;
+    }
+
+    szBuff[retValue] = _T('\0');
 
     WriteFile(m_hReportFile, szBuff, retValue * sizeof(TCHAR), &cbWritten, 0);
 

--- a/src/shared/Win/WheatyExceptionReport.h
+++ b/src/shared/Win/WheatyExceptionReport.h
@@ -122,9 +122,16 @@ class WheatyExceptionReport
 
         static bool FormatSymbolValue(PSYMBOL_INFO, STACKFRAME*, char* pszBuffer, unsigned cbBuffer);
 
-        static char* DumpTypeIndex(char*, DWORD64, DWORD, unsigned, DWORD_PTR, bool& , char*);
+        static char* DumpTypeIndex(char*, char const* pszEnd, DWORD64, DWORD, unsigned, DWORD_PTR, bool& , char*);
 
-        static char* FormatOutputValue(char* pszCurrBuffer, BasicType basicType, DWORD64 length, PVOID pAddress);
+        static char* FormatOutputValue(char* pszCurrBuffer, char const* pszEnd, BasicType basicType, DWORD64 length, PVOID pAddress);
+
+        // Bounded replacement for the `p += sprintf(p, ...)` pattern these three used
+        // to share. pszEnd points one past the last writable byte; the result never
+        // advances beyond it, and the buffer is always left terminated. Symbol dumps
+        // are recursive and attacker-shaped - a deeply nested UDT produces arbitrarily
+        // long output - so the unbounded form reliably smashed the caller's frame.
+        static char* AppendFormat(char* pszCurrBuffer, char const* pszEnd, char const* format, ...);
 
         static BasicType GetBasicType(DWORD typeIndex, DWORD64 modBase);
 

--- a/src/shared/Win/WheatyExceptionReport.h
+++ b/src/shared/Win/WheatyExceptionReport.h
@@ -120,6 +120,14 @@ class WheatyExceptionReport
 
         static BOOL CALLBACK EnumerateSymbolsCallback(PSYMBOL_INFO, ULONG, PVOID);
 
+        // One formatted symbol, and one line of report output. The second must be able
+        // to hold the first plus whatever the caller wraps around it, or the sink
+        // silently drops the tail - including the line break, which runs symbols
+        // together. Deep user-defined types are exactly the input that reaches these
+        // sizes, so the two are defined together rather than left to drift apart.
+        static const unsigned kSymbolBufferSize = 2048;
+        static const unsigned kReportLineSize   = kSymbolBufferSize + 64;
+
         static bool FormatSymbolValue(PSYMBOL_INFO, STACKFRAME*, char* pszBuffer, unsigned cbBuffer);
 
         static char* DumpTypeIndex(char*, char const* pszEnd, DWORD64, DWORD, unsigned, DWORD_PTR, bool& , char*);


### PR DESCRIPTION
## The problem

`WheatyExceptionReport` builds its output with two unbounded patterns inherited from the 2002 MSDN sample it originates from.

**`_tprintf`** formatted into `TCHAR szBuff[1024]` with plain `vsprintf`, then passed the length `vsprintf` returned straight to `WriteFile`:

```cpp
retValue = vsprintf(szBuff, format, argptr);
WriteFile(m_hReportFile, szBuff, retValue * sizeof(TCHAR), &cbWritten, 0);
```

So output longer than the buffer both smashed the frame **and** flushed the overrun to disk. Symbol dumps are recursive — `DumpTypeIndex` expands user-defined types member by member — so a single line's length is bounded only by how deep the type is.

**Its callers** appended with `pszCurrBuffer += sprintf(...)` into a 2048-byte buffer, **seventeen times** across `FormatSymbolValue`, `DumpTypeIndex` and `FormatOutputValue`, none checking the space left. `FormatSymbolValue` was already being handed the buffer size and simply never used it; the other two had no way to know it.

This matters more than a normal overflow because it happens *in the crash handler*, so it corrupts exactly the diagnostic you are relying on to understand the original fault.

## Demonstrated, not argued

A harness linking the **real** reporter and faulting with a deliberate null dereference, compiled twice from identical source differing only in this file:

| | exit code | meaning |
|---|---|---|
| **before** | `0xC0000409` | `STATUS_STACK_BUFFER_OVERRUN` — the `/GS` cookie fired; the reporter destroyed its own frame while writing the report |
| **after** | `0xC0000005` | only the access violation the harness asked for |

That the failure is a **fastfail** rather than an ordinary fault also explains why the `__except(1)` wrapper around the symbol dumper never caught it and no `punting on symbol` line appears — `__fastfail` bypasses SEH entirely.

## The fix

Both patterns now go through a single `AppendFormat` helper that takes an end pointer, never advances past it, and always leaves the buffer terminated. The bound is threaded through `DumpTypeIndex` and `FormatOutputValue`. `_tprintf` uses `_vsnprintf` and clamps the `WriteFile` length to what the buffer actually holds (its return value is used by no caller, verified).

## A second defect the rebuild surfaced

`FormatOutputValue` validates a string pointer and then passes a different expression to `%s`:

```cpp
if (!IsBadStringPtr(*(PSTR*)pAddress, 32))                  // validates a char*
    ... sprintf(..., " = \"%.31s\"", *(PDWORD)pAddress);    // passes a DWORD
```

On x64 that hands `%s` the **low 32 bits** of the pointer — an address the check above never vetted. Every string-valued symbol went through it. The compiler has been emitting **C4313** for this the whole time; the warning is gone with the fix.

## Not claimed

This does **not** reproduce the specific truncation seen in shipped `mangosd` reports, where the report stops before the `Global Variables` banner. The harness has far fewer symbols to dump and completed the report in both builds. What is shown is the corruption itself, and that it is gone.

## Follow-ups identified but not included

Scoped separately, in dependency order: a re-entrancy guard (the filter writes to statics `m_szLogFileName`/`m_hReportFile` with no serialisation, so concurrent faults race); `MiniDumpWriteDump` written **before** the `.txt` work begins; and a dedicated dump thread so stack-overflow crashes still produce a dump.

Also noted, not addressed here: `m_previousFilter` ends up aliased to the handler itself, because a global instance and an explicit install in `mangosd.cpp` share the same static — currently masked only because the handler dies first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/67)
<!-- Reviewable:end -->
