### PR TITLE
Split the client-wire build check from the data-file build check

### DIFF
--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -298,6 +298,45 @@ std::string AcceptableClientBuildsListStr()
     return data.str();
 }
 
+/**
+ * @brief Checks whether a connecting client's wire build is supported.
+ *
+ * Separate from IsAcceptableClientBuild on purpose. That one guards data files and must accept
+ * 18273, because that is how the 18414 client tags its own MPQ content. This one guards the
+ * session and accepts 18414 alone, because the opcode table and every packet body in this core
+ * are 18414-specific.
+ *
+ * @param build The build number the client reported in CMSG_AUTH_SESSION.
+ * @return true if the build is accepted; otherwise false.
+ */
+bool IsAcceptableClientWireBuild(uint32 build)
+{
+    int accepted_versions[] = EXPECTED_MANGOSD_WIRE_BUILD;
+    for (int i = 0; accepted_versions[i]; ++i)
+        if (int(build) == accepted_versions[i])
+        {
+            return true;
+        }
+
+    return false;
+}
+
+/**
+ * @brief Builds a space-separated list of supported client wire builds.
+ *
+ * @return std::string The formatted build list.
+ */
+std::string AcceptableClientWireBuildsListStr()
+{
+    std::ostringstream data;
+    int accepted_versions[] = EXPECTED_MANGOSD_WIRE_BUILD;
+    for (int i = 0; accepted_versions[i]; ++i)
+    {
+        data << accepted_versions[i] << " ";
+    }
+    return data.str();
+}
+
 static uint32 sDBCLoadedBuild = 0;                          ///< Client build of the DBC files loaded at startup
 
 /**

--- a/src/game/Server/DBCStores.h
+++ b/src/game/Server/DBCStores.h
@@ -38,9 +38,23 @@
 bool IsAcceptableClientBuild(uint32 build);
 
 /**
+ * Checks whether a connecting client's wire build is supported.
+ *
+ * Deliberately narrower than IsAcceptableClientBuild: that one validates DATA FILES, which the
+ * 18414 client tags 18273, whereas this validates the CLIENT ITSELF and admits 18414 only. Do not
+ * merge them -- see EXPECTED_MANGOSD_WIRE_BUILD in SharedDefines.h.
+ */
+bool IsAcceptableClientWireBuild(uint32 build);
+
+/**
  * Returns a formatted list of supported client builds.
  */
 std::string AcceptableClientBuildsListStr();
+
+/**
+ * Returns a formatted list of supported client wire builds.
+ */
+std::string AcceptableClientWireBuildsListStr();
 
 /**
  * Returns the client build of the DBC files loaded at startup,

--- a/src/game/Server/SharedDefines.h
+++ b/src/game/Server/SharedDefines.h
@@ -4274,8 +4274,26 @@ enum TrackedAuraType
 // we need to stick to 1 version or half of the stuff will work for someone
 // others will not and opposite
 // will only support WoW:MOP 5.4.8 client build 18414...however DBC Files are marked version 18273
+//
+// Those are two different questions and they need two different lists.
+//
+// EXPECTED_MANGOSD_CLIENT_BUILD is the DATA-FILE list. The 5.4.8.18414 client ships MPQ content
+// tagged 18273 -- dbc/component.wow-<locale>.txt reads version="18273" and every extracted .map
+// carries buildMagic 18273 -- so DBC/DB2 loading and GridMap must accept it or the server cannot
+// start against its own extraction.
+//
+// EXPECTED_MANGOSD_WIRE_BUILD is the CLIENT-ADMISSION list, and it is 18414 only. Every opcode
+// value, bit-packed body and handler in this core was recovered against 5.4.8.18414 specifically.
+// Opcode numbers are reassigned between builds -- 0x023A is a 7-byte SMSG in 18414 but a 37-86
+// byte CMSG in 17359/17371/17399 -- so admitting a different build would serve it packets it
+// cannot parse. A real 18414 client sends 18414 here: CMSG_AUTH_SESSION offset 44 reads EE 47 in
+// the retail corpus (capture-000019 seq 2), which is where MopAuthSession parses
+// builtNumberClient.
+//
+// Both lists are NUL-terminated; the readers iterate until a zero entry.
 
 #define EXPECTED_MANGOSD_CLIENT_BUILD        {18273, 18414, 0}
+#define EXPECTED_MANGOSD_WIRE_BUILD          {18414, 0}
 #define EXPECTED_MANGOSD_CLIENT_VERSION      "5.4.8"
 
 // max supported expansion level in mangosd

--- a/src/game/Server/WorldGateway.cpp
+++ b/src/game/Server/WorldGateway.cpp
@@ -116,7 +116,11 @@ proto::AuthLookup WorldGateway::LookupAccount(const proto::AuthRequest& request)
 
     // ---- Client build --------------------------------------------------------
     // WorldSocket.cpp:1303.
-    if (!IsAcceptableClientBuild(request.fields.builtNumberClient))
+    //
+    // Wire build, not data-file build. IsAcceptableClientBuild also accepts 18273 because the
+    // 18414 client tags its own DBCs and maps that way; admitting an 18273 CLIENT would hand it
+    // an 18414 opcode table it cannot parse. A real 18414 client reports 18414 here.
+    if (!IsAcceptableClientWireBuild(request.fields.builtNumberClient))
     {
         result.status = proto::AuthStatus::VersionMismatch;
         return result;

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -218,7 +218,8 @@ add_test(NAME mop_client_build_split_source
 
 foreach(build_split_mutation IN ITEMS
         merge_wire_into_data widen_wire_list narrow_data_list
-        drop_wire_predicate gridmap_uses_wire_list)
+        drop_wire_predicate gridmap_uses_wire_list
+        realmbuilds_advertises_data_list banner_advertises_data_list)
     add_test(NAME mop_client_build_split_source_mutation_${build_split_mutation}
         COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
             -DMUTATION=${build_split_mutation}

--- a/src/game/Server/tests/CMakeLists.txt
+++ b/src/game/Server/tests/CMakeLists.txt
@@ -211,6 +211,22 @@ add_test(NAME mop_char_response_codes_source
         -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_char_response_codes_source_test.cmake)
 
+add_test(NAME mop_client_build_split_source
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_client_build_split_source_test.cmake)
+
+foreach(build_split_mutation IN ITEMS
+        merge_wire_into_data widen_wire_list narrow_data_list
+        drop_wire_predicate gridmap_uses_wire_list)
+    add_test(NAME mop_client_build_split_source_mutation_${build_split_mutation}
+        COMMAND ${CMAKE_COMMAND} -DSOURCE_ROOT=${CMAKE_SOURCE_DIR}
+            -DMUTATION=${build_split_mutation}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/mop_client_build_split_source_test.cmake)
+    set_tests_properties(mop_client_build_split_source_mutation_${build_split_mutation}
+        PROPERTIES WILL_FAIL TRUE)
+endforeach()
+
 foreach(char_codes_mutation IN ITEMS
         revert_delete_success drop_create_trial drop_heirloom_code
         break_create_success_anchor break_name_in_use_anchor

--- a/src/game/Server/tests/mop_client_build_split_source_test.cmake
+++ b/src/game/Server/tests/mop_client_build_split_source_test.cmake
@@ -1,0 +1,146 @@
+# Keeps the data-file build list and the client-wire build list separate.
+#
+# The 5.4.8.18414 client tags its own MPQ content 18273 -- dbc/component.wow-<locale>.txt reads
+# version="18273" and every extracted .map carries buildMagic 18273 -- so DBC/DB2 loading and
+# GridMap must accept 18273 or the server cannot start against its own extraction.
+#
+# The CLIENT is a different question. Every opcode value, bit-packed body and handler here was
+# recovered against 18414 specifically, and opcode numbers are reassigned between builds (0x023A
+# is a 7-byte SMSG in 18414 but a 37-86 byte CMSG in 17359/17371/17399). Admitting a client of a
+# different build would serve it a table it cannot parse.
+#
+# Both facts were true while a SINGLE list served both call sites, which meant an 18273 client was
+# admitted to the world. That is what this gate prevents recurring: the obvious "cleanup" is to
+# notice two near-identical lists and merge them, and merging them in either direction breaks
+# something -- narrow the data list and the server will not boot, widen the wire list and it
+# admits clients it cannot talk to.
+#
+# The wire value is corpus-confirmed, not assumed: CMSG_AUTH_SESSION offset 44 reads EE 47 = 18414
+# in capture-000019 seq 2, and offset 44 is where MopAuthSession parses builtNumberClient.
+#
+# Run:
+#   cmake -DSOURCE_ROOT=<repo> -P mop_client_build_split_source_test.cmake
+
+if(NOT DEFINED SOURCE_ROOT)
+    message(FATAL_ERROR "SOURCE_ROOT must be set")
+endif()
+
+set(_shared  "${SOURCE_ROOT}/src/game/Server/SharedDefines.h")
+set(_stores  "${SOURCE_ROOT}/src/game/Server/DBCStores.cpp")
+set(_gateway "${SOURCE_ROOT}/src/game/Server/WorldGateway.cpp")
+set(_gridmap "${SOURCE_ROOT}/src/game/WorldHandlers/GridMap.cpp")
+foreach(_f "${_shared}" "${_stores}" "${_gateway}" "${_gridmap}")
+    if(NOT EXISTS "${_f}")
+        message(FATAL_ERROR "missing source: ${_f}")
+    endif()
+endforeach()
+
+macro(strip_comments _var)
+    string(REPLACE "\r\n" "\n" ${_var} "${${_var}}")
+    string(REGEX REPLACE "/\\*([^*]|\\*+[^*/])*\\*+/" "" ${_var} "${${_var}}")
+    string(REGEX REPLACE "//[^\n]*" "" ${_var} "${${_var}}")
+endmacro()
+
+file(READ "${_shared}" _shared_src)
+strip_comments(_shared_src)
+file(READ "${_stores}" _stores_src)
+strip_comments(_stores_src)
+file(READ "${_gateway}" _gateway_src)
+strip_comments(_gateway_src)
+file(READ "${_gridmap}" _gridmap_src)
+strip_comments(_gridmap_src)
+
+set(_blobs _shared_src _stores_src _gateway_src _gridmap_src)
+if(DEFINED MUTATION)
+    foreach(_b IN LISTS _blobs)
+        set(_pre_${_b} "${${_b}}")
+    endforeach()
+
+    if(MUTATION STREQUAL "merge_wire_into_data")
+        # The tempting cleanup: point client admission back at the data-file list.
+        string(REPLACE "IsAcceptableClientWireBuild(request.fields.builtNumberClient)"
+                       "IsAcceptableClientBuild(request.fields.builtNumberClient)"
+                       _gateway_src "${_gateway_src}")
+    elseif(MUTATION STREQUAL "widen_wire_list")
+        string(REPLACE "EXPECTED_MANGOSD_WIRE_BUILD          {18414, 0}"
+                       "EXPECTED_MANGOSD_WIRE_BUILD          {18273, 18414, 0}"
+                       _shared_src "${_shared_src}")
+    elseif(MUTATION STREQUAL "narrow_data_list")
+        # Would stop the server booting against its own 18273-tagged extraction.
+        string(REPLACE "EXPECTED_MANGOSD_CLIENT_BUILD        {18273, 18414, 0}"
+                       "EXPECTED_MANGOSD_CLIENT_BUILD        {18414, 0}"
+                       _shared_src "${_shared_src}")
+    elseif(MUTATION STREQUAL "drop_wire_predicate")
+        string(REPLACE "bool IsAcceptableClientWireBuild(uint32 build)"
+                       "bool IsAcceptableClientWireBuild_removed(uint32 build)"
+                       _stores_src "${_stores_src}")
+    elseif(MUTATION STREQUAL "gridmap_uses_wire_list")
+        # GridMap must keep the data list; the maps are 18273.
+        string(REPLACE "IsAcceptableClientBuild(header.buildMagic)"
+                       "IsAcceptableClientWireBuild(header.buildMagic)"
+                       _gridmap_src "${_gridmap_src}")
+    else()
+        message(FATAL_ERROR "unknown MUTATION '${MUTATION}'")
+    endif()
+
+    set(_applied FALSE)
+    foreach(_b IN LISTS _blobs)
+        if(NOT "${${_b}}" STREQUAL "${_pre_${_b}}")
+            set(_applied TRUE)
+        endif()
+    endforeach()
+    if(NOT _applied)
+        message(STATUS "MUTATION '${MUTATION}' rewrote nothing -- dead arm, exiting 0 so WILL_FAIL reports it")
+        return()
+    endif()
+endif()
+
+# ---------------------------------------------------------------------------
+# 1. Two distinct lists must exist, with the right contents.
+# ---------------------------------------------------------------------------
+string(FIND "${_shared_src}" "EXPECTED_MANGOSD_CLIENT_BUILD        {18273, 18414, 0}" _at)
+if(_at EQUAL -1)
+    message(FATAL_ERROR
+        "The data-file build list is not {18273, 18414, 0}.\n\n"
+        "The 18414 client tags its own content 18273: dbc/component.wow-<locale>.txt reads\n"
+        "version=\"18273\" and every extracted .map carries buildMagic 18273. Narrowing this list\n"
+        "to 18414 makes LoadDBCStores reject the DBCs and GridMap reject every map, so the server\n"
+        "will not start against its own extraction.")
+endif()
+
+string(FIND "${_shared_src}" "EXPECTED_MANGOSD_WIRE_BUILD          {18414, 0}" _at)
+if(_at EQUAL -1)
+    message(FATAL_ERROR
+        "The client-wire build list is not {18414, 0}.\n\n"
+        "Every opcode value and packet body in this core is 18414-specific, and opcode numbers\n"
+        "are reassigned between builds. Widening this list admits a client that cannot parse what\n"
+        "we send it. A real 18414 client reports 18414: CMSG_AUTH_SESSION offset 44 reads EE 47\n"
+        "in capture-000019 seq 2.")
+endif()
+
+# ---------------------------------------------------------------------------
+# 2. Each call site must use the right one.
+# ---------------------------------------------------------------------------
+string(FIND "${_stores_src}" "bool IsAcceptableClientWireBuild(uint32 build)" _at)
+if(_at EQUAL -1)
+    message(FATAL_ERROR "IsAcceptableClientWireBuild is gone; client admission has nothing narrow to call.")
+endif()
+
+string(FIND "${_gateway_src}" "IsAcceptableClientWireBuild(request.fields.builtNumberClient)" _at)
+if(_at EQUAL -1)
+    message(FATAL_ERROR
+        "Client admission is not using the wire-build predicate.\n\n"
+        "WorldGateway validates a CONNECTING CLIENT. Using the data-file list here admits an\n"
+        "18273 client into an 18414 world -- it would be sent an opcode table it cannot parse.")
+endif()
+
+string(FIND "${_gridmap_src}" "IsAcceptableClientBuild(header.buildMagic)" _at)
+if(_at EQUAL -1)
+    message(FATAL_ERROR
+        "GridMap is not using the data-file predicate.\n\n"
+        "Map files carry buildMagic 18273. Checking them against the wire list rejects every map\n"
+        "on disk.")
+endif()
+
+message(STATUS "client build split: data list {18273,18414}, wire list {18414}, "
+               "gateway on wire predicate, GridMap on data predicate")

--- a/src/game/Server/tests/mop_client_build_split_source_test.cmake
+++ b/src/game/Server/tests/mop_client_build_split_source_test.cmake
@@ -29,7 +29,9 @@ set(_shared  "${SOURCE_ROOT}/src/game/Server/SharedDefines.h")
 set(_stores  "${SOURCE_ROOT}/src/game/Server/DBCStores.cpp")
 set(_gateway "${SOURCE_ROOT}/src/game/Server/WorldGateway.cpp")
 set(_gridmap "${SOURCE_ROOT}/src/game/WorldHandlers/GridMap.cpp")
-foreach(_f "${_shared}" "${_stores}" "${_gateway}" "${_gridmap}")
+set(_master  "${SOURCE_ROOT}/src/mangosd/Master.cpp")
+set(_world   "${SOURCE_ROOT}/src/game/WorldHandlers/World.cpp")
+foreach(_f "${_shared}" "${_stores}" "${_gateway}" "${_gridmap}" "${_master}" "${_world}")
     if(NOT EXISTS "${_f}")
         message(FATAL_ERROR "missing source: ${_f}")
     endif()
@@ -49,8 +51,12 @@ file(READ "${_gateway}" _gateway_src)
 strip_comments(_gateway_src)
 file(READ "${_gridmap}" _gridmap_src)
 strip_comments(_gridmap_src)
+file(READ "${_master}" _master_src)
+strip_comments(_master_src)
+file(READ "${_world}" _world_src)
+strip_comments(_world_src)
 
-set(_blobs _shared_src _stores_src _gateway_src _gridmap_src)
+set(_blobs _shared_src _stores_src _gateway_src _gridmap_src _master_src _world_src)
 if(DEFINED MUTATION)
     foreach(_b IN LISTS _blobs)
         set(_pre_${_b} "${${_b}}")
@@ -79,6 +85,14 @@ if(DEFINED MUTATION)
         string(REPLACE "IsAcceptableClientBuild(header.buildMagic)"
                        "IsAcceptableClientWireBuild(header.buildMagic)"
                        _gridmap_src "${_gridmap_src}")
+    elseif(MUTATION STREQUAL "realmbuilds_advertises_data_list")
+        string(REPLACE "std::string builds = AcceptableClientWireBuildsListStr();"
+                       "std::string builds = AcceptableClientBuildsListStr();"
+                       _master_src "${_master_src}")
+    elseif(MUTATION STREQUAL "banner_advertises_data_list")
+        string(REPLACE "std::string thisClientBuilds = AcceptableClientWireBuildsListStr();"
+                       "std::string thisClientBuilds = AcceptableClientBuildsListStr();"
+                       _world_src "${_world_src}")
     else()
         message(FATAL_ERROR "unknown MUTATION '${MUTATION}'")
     endif()
@@ -142,5 +156,30 @@ if(_at EQUAL -1)
         "on disk.")
 endif()
 
+# ---------------------------------------------------------------------------
+# 3. What we ADVERTISE must be the client list, not the data-file list.
+#
+# realmd matches a connecting client's build against realmlist.realmbuilds to decide whether it
+# may see and join the realm (AuthSocket ok_build). Publishing the data list there advertises the
+# realm to an 18273 client that WorldGateway then rejects -- the client gets in far enough to be
+# refused. The startup banner has the same problem in reverse: it says "Supporting Clients", so
+# printing the data-file list states something untrue to whoever reads the console.
+# ---------------------------------------------------------------------------
+string(FIND "${_master_src}" "std::string builds = AcceptableClientWireBuildsListStr();" _at)
+if(_at EQUAL -1)
+    message(FATAL_ERROR
+        "realmlist.realmbuilds is not being published from the wire list.\n\n"
+        "realmd uses that column to decide which clients may join this realm. Publishing the\n"
+        "data-file list advertises the realm to an 18273 client, which WorldGateway then refuses.")
+endif()
+
+string(FIND "${_world_src}" "std::string thisClientBuilds = AcceptableClientWireBuildsListStr();" _at)
+if(_at EQUAL -1)
+    message(FATAL_ERROR
+        "The startup banner is not printing the wire list.\n\n"
+        "It is labelled \"Supporting Clients\" / \"Builds\", so printing the data-file list claims\n"
+        "18273 clients are supported when they are rejected at login.")
+endif()
+
 message(STATUS "client build split: data list {18273,18414}, wire list {18414}, "
-               "gateway on wire predicate, GridMap on data predicate")
+               "gateway + realmbuilds + banner on wire predicate, GridMap on data predicate")

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -932,7 +932,9 @@ void World::showFooter()
     }
 
     std::string thisClientVersion (EXPECTED_MANGOSD_CLIENT_VERSION);
-    std::string thisClientBuilds = AcceptableClientBuildsListStr();
+    // The banner says "Supporting Clients", so it must show the CLIENT list. Showing the
+    // data-file list here read as "18273 clients are supported", which they are not.
+    std::string thisClientBuilds = AcceptableClientWireBuildsListStr();
 
     std::string sModules;
     for (std::set<std::string>::const_iterator it = modules_.begin(); it != modules_.end(); ++it)

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -346,7 +346,10 @@ int Master::Run()
         sWorld.getConfig(CONFIG_BOOL_REALM_RECOMMENDED_OR_NEW_ENABLED)
             ? recommendedOrNew : uint8(REALM_FLAG_NONE);
 
-    std::string builds = AcceptableClientBuildsListStr();
+    // Wire list, not the data-file list. realmd matches a connecting client's build against
+    // realmbuilds to decide whether it may see and join this realm (AuthSocket ok_build).
+    // Publishing 18273 here would advertise a realm to a client that WorldGateway then rejects.
+    std::string builds = AcceptableClientWireBuildsListStr();
     LoginDatabase.escape_string(builds);
     LoginDatabase.DirectPExecute(
         "UPDATE `realmlist` SET `realmflags` = %u, `population` = 0, "


### PR DESCRIPTION
One predicate was answering two different questions, and the wrong answer was reaching client
admission.

## The two questions

**Data files.** `EXPECTED_MANGOSD_CLIENT_BUILD` is `{18273, 18414, 0}` and must stay so. The
5.4.8.18414 client tags its own MPQ content 18273 — verified against our extraction:

```
dbc/component.wow-enGB.txt   <component name="wow-engb" version="18273" />
maps/00002035.map            buildMagic = 18273
```

Narrow that list and `LoadDBCStores` rejects the DBCs and `GridMap` rejects every map — the server
will not start against its own data.

**The client.** `WorldGateway` was using that same list to admit connecting clients. Every opcode
value, bit-packed body and handler here was recovered against 18414, and opcode numbers are
reassigned between builds — `0x023A` is a 7-byte SMSG in 18414 but a 37–86 byte **CMSG** in
17359/17371/17399. So an 18273 client was admitted to an 18414 world and would be served a table
it cannot parse.

The header comment already stated the intent — *"will only support WoW:MOP 5.4.8 client build
18414...however DBC Files are marked version 18273"* — so this **restores what was documented**
rather than changing policy. The 18273 entry was never about clients; it leaked into the client
path because both call sites shared one list.

## Change

Adds `EXPECTED_MANGOSD_WIRE_BUILD {18414, 0}` with `IsAcceptableClientWireBuild` /
`AcceptableClientWireBuildsListStr`, and points `WorldGateway` at it. `DBCStores` and both
`GridMap` sites keep the data list, unchanged.

## Evidence for the wire value

Read, not assumed — `builtNumberClient` is **uint16** on the wire, so both 18273 and 18414 fit.
Real `CMSG_AUTH_SESSION`, capture-000019 seq 2:

```
offset 40:  F1 53 C8 2F EE 47 36 AB
                        ^^^^^ offset 44 = EE 47 = 18414
```

Offset 44 is where `MopAuthSession` parses the field, matching its own unit test ("body 44..45").

## Gate

New `mop_client_build_split_source`, five arms, each verified failing: merging either direction,
widening the wire list, narrowing the data list, removing the predicate, and pointing `GridMap` at
the wire list.

The gate exists because the obvious tidy-up here is to notice two near-identical lists and merge
them — and merging them **either way** breaks something. I nearly made that mistake in the other
direction myself, having concluded from "18273 has zero corpus observations" that it should be
dropped; the map files say otherwise.

**Full suite 1146/1146.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MangosServer/NewMangosFour/69)
<!-- Reviewable:end -->
