### PR TITLE
Fix bundled OpenSSL legacy provider startup on Windows

### DIFF
--- a/src/shared/Auth/OpenSSLProvider.cpp
+++ b/src/shared/Auth/OpenSSLProvider.cpp
@@ -160,19 +160,26 @@ bool ConvertWideToAnsi(const std::wstring& value, std::string& converted)
     if (value.empty())
         return false;
 
+    constexpr UINT GB18030_CODE_PAGE = 54936;
+    UINT const codePage = GetACP();
+    bool const restrictedCodePage =
+        codePage == CP_UTF8 || codePage == GB18030_CODE_PAGE;
+    DWORD const flags = restrictedCodePage ?
+        WC_ERR_INVALID_CHARS : WC_NO_BEST_FIT_CHARS;
     BOOL usedDefault = FALSE;
+    BOOL* usedDefaultPointer = restrictedCodePage ? nullptr : &usedDefault;
     int required = WideCharToMultiByte(
-        CP_ACP, WC_NO_BEST_FIT_CHARS, value.c_str(), -1,
-        nullptr, 0, nullptr, &usedDefault);
-    if (required <= 0 || usedDefault)
+        codePage, flags, value.c_str(), -1,
+        nullptr, 0, nullptr, usedDefaultPointer);
+    if (required <= 0 || (!restrictedCodePage && usedDefault))
         return false;
 
     std::vector<char> buffer(static_cast<std::size_t>(required));
     usedDefault = FALSE;
     int written = WideCharToMultiByte(
-        CP_ACP, WC_NO_BEST_FIT_CHARS, value.c_str(), -1,
-        buffer.data(), required, nullptr, &usedDefault);
-    if (written <= 0 || usedDefault)
+        codePage, flags, value.c_str(), -1,
+        buffer.data(), required, nullptr, usedDefaultPointer);
+    if (written <= 0 || (!restrictedCodePage && usedDefault))
         return false;
 
     converted.assign(buffer.data(), static_cast<std::size_t>(written - 1));

--- a/src/shared/Auth/OpenSSLProvider.cpp
+++ b/src/shared/Auth/OpenSSLProvider.cpp
@@ -28,8 +28,22 @@
  * @brief Implementation of RAII wrappers for OpenSSL providers
  */
 
+#include <string>
 #include "OpenSSLProvider.h"
 #include "Log/Log.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cstdlib>
+#include <filesystem>
+#include <openssl/core_names.h>
+#include <openssl/params.h>
+#include <utility>
+#include <vector>
+
+#ifdef WIN32
+#include <windows.h>
+#endif
 
 /**
  * Creates a new OpenSSL cipher context wrapper.
@@ -81,6 +95,194 @@ OpenSSLCipherContext& OpenSSLCipherContext::operator=(OpenSSLCipherContext&& oth
 
 #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
 
+namespace
+{
+bool ParseProviderMajor(const std::string& version, unsigned& major)
+{
+    std::size_t separator = version.find('.');
+    if (separator == std::string::npos || separator == 0)
+        return false;
+
+    const char* begin = version.data();
+    const char* end = begin + separator;
+    std::from_chars_result parsed = std::from_chars(begin, end, major);
+    return parsed.ec == std::errc{} && parsed.ptr == end;
+}
+
+#ifdef WIN32
+std::wstring ReadWindowsEnvironment(const wchar_t* name)
+{
+    DWORD required = GetEnvironmentVariableW(name, nullptr, 0);
+    if (required == 0)
+        return {};
+
+    std::vector<wchar_t> buffer(required);
+    while (true)
+    {
+        DWORD written = GetEnvironmentVariableW(
+            name, buffer.data(), static_cast<DWORD>(buffer.size()));
+        if (written == 0)
+            return {};
+        if (written < buffer.size())
+            return std::wstring(buffer.data(), written);
+        buffer.resize(static_cast<std::size_t>(written) + 1);
+    }
+}
+
+std::filesystem::path GetExecutableDirectory()
+{
+    constexpr std::size_t MAX_WINDOWS_PATH = 32768;
+    std::vector<wchar_t> buffer(MAX_PATH);
+
+    while (buffer.size() <= MAX_WINDOWS_PATH)
+    {
+        DWORD written = GetModuleFileNameW(
+            nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
+        if (written == 0)
+            return {};
+        if (written < buffer.size())
+        {
+            return std::filesystem::path(
+                std::wstring(buffer.data(), written)).parent_path();
+        }
+
+        if (buffer.size() == MAX_WINDOWS_PATH)
+            break;
+        buffer.resize((std::min)(buffer.size() * 2, MAX_WINDOWS_PATH));
+    }
+
+    return {};
+}
+
+bool ConvertWideToAnsi(const std::wstring& value, std::string& converted)
+{
+    converted.clear();
+    if (value.empty())
+        return false;
+
+    BOOL usedDefault = FALSE;
+    int required = WideCharToMultiByte(
+        CP_ACP, WC_NO_BEST_FIT_CHARS, value.c_str(), -1,
+        nullptr, 0, nullptr, &usedDefault);
+    if (required <= 0 || usedDefault)
+        return false;
+
+    std::vector<char> buffer(static_cast<std::size_t>(required));
+    usedDefault = FALSE;
+    int written = WideCharToMultiByte(
+        CP_ACP, WC_NO_BEST_FIT_CHARS, value.c_str(), -1,
+        buffer.data(), required, nullptr, &usedDefault);
+    if (written <= 0 || usedDefault)
+        return false;
+
+    converted.assign(buffer.data(), static_cast<std::size_t>(written - 1));
+    return true;
+}
+
+bool IsUsableOpenSSLPath(const std::wstring& path, std::string& converted)
+{
+    if (!ConvertWideToAnsi(path, converted))
+        return false;
+
+    constexpr std::size_t LEGACY_SUFFIX_LENGTH = sizeof("\\legacy.dll") - 1;
+    return converted.size() + LEGACY_SUFFIX_LENGTH < MAX_PATH;
+}
+
+bool ConvertForOpenSSL(
+    const std::filesystem::path& directory, std::string& converted)
+{
+    const std::wstring& nativePath = directory.native();
+    if (IsUsableOpenSSLPath(nativePath, converted))
+        return true;
+
+    DWORD required = GetShortPathNameW(nativePath.c_str(), nullptr, 0);
+    if (required == 0)
+        return false;
+
+    std::vector<wchar_t> shortPath(required);
+    DWORD written = GetShortPathNameW(
+        nativePath.c_str(), shortPath.data(), required);
+    if (written == 0 || written >= shortPath.size())
+        return false;
+
+    return IsUsableOpenSSLPath(
+        std::wstring(shortPath.data(), written), converted);
+}
+
+void ConfigureBundledProviderSearchPath()
+{
+    if (!ReadWindowsEnvironment(L"OPENSSL_MODULES").empty())
+        return;
+
+    try
+    {
+        std::filesystem::path executableDirectory = GetExecutableDirectory();
+        if (executableDirectory.empty())
+        {
+            sLog.outError(
+                "OpenSSLProvider: Failed to resolve the executable directory");
+            return;
+        }
+
+        std::filesystem::path providerDirectory =
+            executableDirectory / L"ossl-modules";
+        std::filesystem::path legacyProvider =
+            providerDirectory / L"legacy.dll";
+        std::error_code fileError;
+        if (!std::filesystem::is_regular_file(legacyProvider, fileError))
+            return;
+
+        std::string providerPath;
+        if (!ConvertForOpenSSL(providerDirectory, providerPath))
+        {
+            sLog.outError(
+                "OpenSSLProvider: Bundled provider path cannot be represented "
+                "for the OpenSSL Windows loader");
+            return;
+        }
+
+        if (OSSL_PROVIDER_set_default_search_path(
+                nullptr, providerPath.c_str()) != 1)
+        {
+            sLog.outError(
+                "OpenSSLProvider: Failed to configure bundled provider path '%s'",
+                providerPath.c_str());
+        }
+    }
+    catch (const std::filesystem::filesystem_error& error)
+    {
+        sLog.outError(
+            "OpenSSLProvider: Failed to inspect bundled provider path: %s",
+            error.what());
+    }
+}
+#endif
+
+OpenSSLProvider LoadLegacyProvider()
+{
+#ifdef WIN32
+    ConfigureBundledProviderSearchPath();
+#endif
+    return OpenSSLProvider("legacy");
+}
+
+std::string OpenSSLModulesForDiagnostic()
+{
+#ifdef WIN32
+    std::wstring modules = ReadWindowsEnvironment(L"OPENSSL_MODULES");
+    if (modules.empty())
+        return "<unset>";
+
+    std::string converted;
+    return ConvertWideToAnsi(modules, converted)
+        ? converted : "<unrepresentable>";
+#else
+    const char* modules = std::getenv("OPENSSL_MODULES");
+    return modules ? std::string(modules) : std::string("<unset>");
+#endif
+}
+}
+
 /**
  * Loads the named OpenSSL provider into the specified library context.
  */
@@ -112,6 +314,22 @@ OpenSSLProvider::~OpenSSLProvider()
     }
 }
 
+std::string OpenSSLProvider::Version() const
+{
+    if (!m_provider)
+        return {};
+
+    char* version = nullptr;
+    OSSL_PARAM params[] = {
+        OSSL_PARAM_construct_utf8_ptr(
+            OSSL_PROV_PARAM_VERSION, &version, 0),
+        OSSL_PARAM_construct_end()
+    };
+    if (OSSL_PROVIDER_get_params(m_provider, params) != 1 || !version)
+        return {};
+    return version;
+}
+
 OpenSSLProvider::OpenSSLProvider(OpenSSLProvider&& other) noexcept
     : m_provider(other.m_provider), m_providerName(std::move(other.m_providerName))
 {
@@ -140,15 +358,11 @@ OpenSSLProvider& OpenSSLProvider::operator=(OpenSSLProvider&& other) noexcept
  * Initializes the OpenSSL provider manager and loads required providers.
  */
 OpenSSLProviderManager::OpenSSLProviderManager()
-    : m_legacyProvider("legacy"), m_defaultProvider("default"), m_initialized(false)
+    : m_legacyProvider(LoadLegacyProvider()),
+      m_defaultProvider("default"),
+      m_initialized(false)
 {
-    // Check if both providers loaded successfully
-    if (m_legacyProvider.IsLoaded() && m_defaultProvider.IsLoaded())
-    {
-        m_initialized = true;
-        sLog.outString("OpenSSL 3.x providers loaded successfully: legacy, default");
-    }
-    else
+    if (!m_legacyProvider.IsLoaded() || !m_defaultProvider.IsLoaded())
     {
         sLog.outError("Failed to load OpenSSL 3.x providers");
 
@@ -156,9 +370,9 @@ OpenSSLProviderManager::OpenSSLProviderManager()
         {
             sLog.outError("  - Legacy provider failed to load");
 #ifdef WIN32
-            sLog.outError("    Please check you have set the following Environment Variable:");
-            sLog.outError("    OPENSSL_MODULES=C:\\OpenSSL-Win64\\bin");
-            sLog.outError("    (where C:\\OpenSSL-Win64\\bin is the location you installed OpenSSL");
+            sLog.outError("    Use a complete release with ossl-modules\\legacy.dll");
+            sLog.outError("    beside the daemon, or set OPENSSL_MODULES to the");
+            sLog.outError("    directory containing a matching legacy.dll.");
 #endif
         }
 
@@ -166,7 +380,46 @@ OpenSSLProviderManager::OpenSSLProviderManager()
         {
             sLog.outError("  - Default provider failed to load");
         }
+        return;
     }
+
+    std::string legacyVersion = m_legacyProvider.Version();
+    std::string defaultVersion = m_defaultProvider.Version();
+    unsigned legacyMajor = 0;
+    unsigned defaultMajor = 0;
+    bool parsedLegacy = ParseProviderMajor(legacyVersion, legacyMajor);
+    bool parsedDefault = ParseProviderMajor(defaultVersion, defaultMajor);
+
+    unsigned runtimeMajor = unsigned((OpenSSL_version_num() >> 28) & 0x0f);
+    if (runtimeMajor != 3
+        || !parsedLegacy || legacyMajor != runtimeMajor
+        || !parsedDefault || defaultMajor != runtimeMajor)
+    {
+        std::string modules = OpenSSLModulesForDiagnostic();
+        sLog.outError(
+            "OpenSSL 3.x provider/runtime validation failed: "
+            "runtime='%s', legacy provider='%s', default provider='%s', "
+            "OPENSSL_MODULES='%s'",
+            OpenSSL_version(OPENSSL_VERSION),
+            legacyVersion.empty() ? "<unavailable>" : legacyVersion.c_str(),
+            defaultVersion.empty() ? "<unavailable>" : defaultVersion.c_str(),
+            modules.c_str());
+        return;
+    }
+
+    EVP_CIPHER* rc4 = EVP_CIPHER_fetch(nullptr, "RC4", nullptr);
+    if (!rc4)
+    {
+        sLog.outError(
+            "OpenSSL legacy provider is loaded but RC4 is unavailable");
+        return;
+    }
+    EVP_CIPHER_free(rc4);
+
+    m_initialized = true;
+    sLog.outString(
+        "OpenSSL 3.x providers loaded successfully: legacy %s, default %s",
+        legacyVersion.c_str(), defaultVersion.c_str());
 }
 
 /**

--- a/src/shared/Auth/OpenSSLProvider.cpp
+++ b/src/shared/Auth/OpenSSLProvider.cpp
@@ -171,7 +171,7 @@ bool ConvertWideToAnsi(const std::wstring& value, std::string& converted)
     int required = WideCharToMultiByte(
         codePage, flags, value.c_str(), -1,
         nullptr, 0, nullptr, usedDefaultPointer);
-    if (required <= 0 || (!restrictedCodePage && usedDefault))
+    if (required <= 0 || usedDefault)
         return false;
 
     std::vector<char> buffer(static_cast<std::size_t>(required));
@@ -179,7 +179,7 @@ bool ConvertWideToAnsi(const std::wstring& value, std::string& converted)
     int written = WideCharToMultiByte(
         codePage, flags, value.c_str(), -1,
         buffer.data(), required, nullptr, usedDefaultPointer);
-    if (written <= 0 || (!restrictedCodePage && usedDefault))
+    if (written <= 0 || usedDefault)
         return false;
 
     converted.assign(buffer.data(), static_cast<std::size_t>(written - 1));

--- a/src/shared/Auth/OpenSSLProvider.h
+++ b/src/shared/Auth/OpenSSLProvider.h
@@ -36,6 +36,7 @@
 #define _AUTH_OPENSSL_PROVIDER_H
 
 #include "Common/Common.h"
+#include <string>
 #include <openssl/evp.h>
 
 /**
@@ -117,6 +118,12 @@ public:
      * @return true if provider is loaded, false otherwise
      */
     bool IsLoaded() const { return m_provider != nullptr; }
+
+    /**
+     * @brief Get the version reported by the loaded provider
+     * @return Provider version, or an empty string if unavailable
+     */
+    std::string Version() const;
 
     /**
      * @brief Get the underlying provider handle

--- a/src/shared/Auth/tests/CMakeLists.txt
+++ b/src/shared/Auth/tests/CMakeLists.txt
@@ -1,0 +1,50 @@
+add_executable(openssl_provider_release_layout_test
+    OpenSSLProviderReleaseLayoutTest.cpp)
+
+target_link_libraries(openssl_provider_release_layout_test
+    PRIVATE
+        shared
+        mangos_openssl)
+
+add_test(
+    NAME openssl_provider_release_layout
+    COMMAND openssl_provider_release_layout_test)
+
+set_tests_properties(openssl_provider_release_layout PROPERTIES
+    ENVIRONMENT "OPENSSL_MODULES="
+    WORKING_DIRECTORY "$<TARGET_FILE_DIR:openssl_provider_release_layout_test>")
+
+if(WIN32)
+    get_filename_component(MANGOS_SSL_ROOT "${OPENSSL_INCLUDE_DIR}" DIRECTORY)
+
+    find_file(MANGOS_TEST_OPENSSL_CRYPTO_DLL
+        NAMES libcrypto-3-x64.dll libcrypto-3.dll
+        HINTS "${MANGOS_SSL_ROOT}" "${OPENSSL_ROOT_DIR}"
+        PATH_SUFFIXES bin ""
+        NO_DEFAULT_PATH)
+
+    find_file(MANGOS_TEST_OPENSSL_LEGACY_DLL
+        NAMES legacy.dll
+        HINTS "${MANGOS_SSL_ROOT}" "${OPENSSL_ROOT_DIR}"
+        PATH_SUFFIXES bin/ossl-modules bin ossl-modules lib/ossl-modules ""
+        NO_DEFAULT_PATH)
+
+    if(MANGOS_TEST_OPENSSL_CRYPTO_DLL)
+        add_custom_command(TARGET openssl_provider_release_layout_test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${MANGOS_TEST_OPENSSL_CRYPTO_DLL}"
+                "$<TARGET_FILE_DIR:openssl_provider_release_layout_test>")
+    endif()
+
+    if(MANGOS_TEST_OPENSSL_LEGACY_DLL)
+        add_custom_command(TARGET openssl_provider_release_layout_test POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E make_directory
+                "$<TARGET_FILE_DIR:openssl_provider_release_layout_test>/ossl-modules"
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${MANGOS_TEST_OPENSSL_LEGACY_DLL}"
+                "$<TARGET_FILE_DIR:openssl_provider_release_layout_test>/ossl-modules/legacy.dll")
+    else()
+        message(WARNING
+            "OpenSSL legacy.dll was not found; openssl_provider_release_layout will fail on Windows")
+    endif()
+endif()

--- a/src/shared/Auth/tests/CMakeLists.txt
+++ b/src/shared/Auth/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT WIN32)
+    return()
+endif()
+
 add_executable(openssl_provider_release_layout_test
     OpenSSLProviderReleaseLayoutTest.cpp)
 

--- a/src/shared/Auth/tests/OpenSSLProviderReleaseLayoutTest.cpp
+++ b/src/shared/Auth/tests/OpenSSLProviderReleaseLayoutTest.cpp
@@ -1,0 +1,36 @@
+/**
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Copyright (C) 2005-2026 MaNGOS <https://www.getmangos.eu>
+ */
+
+#include "Auth/OpenSSLProvider.h"
+
+#include <openssl/evp.h>
+
+#include <cstdlib>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+int main()
+{
+#ifdef _WIN32
+    SetEnvironmentVariableW(L"OPENSSL_MODULES", nullptr);
+#endif
+
+    OpenSSLProviderManager providerManager;
+    if (!providerManager.IsInitialized())
+    {
+        return 1;
+    }
+
+    const char* modules = std::getenv("OPENSSL_MODULES");
+    if (modules && modules[0] != '\0')
+    {
+        return 2;
+    }
+
+    return EVP_rc4() ? 0 : 3;
+}

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -298,4 +298,5 @@ endif()
 
 if(WITH_TESTS)
     add_subdirectory(Database/tests)
+    add_subdirectory(Auth/tests)
 endif()


### PR DESCRIPTION
## Summary

- discover a bundled `ossl-modules\legacy.dll` relative to the running daemon on Windows
- preserve an explicitly configured `OPENSSL_MODULES` value
- validate provider/runtime major versions and confirm RC4 is available
- add a focused CTest that runs the real provider manager from a release-style directory

## Root cause

OpenSSL 3 loads the legacy provider as a separate module. Release users could have `libcrypto-3-x64.dll` beside the daemons but still fail to start because the provider search path pointed at a machine-local OpenSSL installation rather than the extracted release.

## User impact

Windows release ZIPs can run `realmd` and `mangosd` without requiring a system-wide OpenSSL installation, provided the release contains the matching `ossl-modules\legacy.dll`.

The AppVeyor packaging changes that place `libcrypto-3-x64.dll` and `ossl-modules\legacy.dll` in the ZIP are maintained separately from this repository.

## Validation

- rebased onto current `master`
- MSVC `realmd` and release-layout test targets built successfully
- focused release-layout CTest: 1/1 passed
- scoped cross-model review completed with no blocking or important findings
- no database changes required