### PR TITLE
[Console] Restore live world status title

### DIFF
--- a/src/game/Server/WorldNetwork.cpp
+++ b/src/game/Server/WorldNetwork.cpp
@@ -25,6 +25,7 @@
 
 #include "WorldNetwork.h"
 
+#include "ClientConnection.h"
 #include "Log/Log.h"
 #include "Opcodes.h"
 
@@ -67,4 +68,9 @@ bool WorldNetwork::Start(uint16 port, const std::string& bindIp)
 void WorldNetwork::Stop()
 {
     m_listener.Stop();
+}
+
+uint32 WorldNetwork::GetOpenConnectionCount() const
+{
+    return proto::ClientConnection::GetOpenConnectionCount();
 }

--- a/src/game/Server/WorldNetwork.h
+++ b/src/game/Server/WorldNetwork.h
@@ -62,6 +62,9 @@ class WorldNetwork : public MaNGOS::Singleton<WorldNetwork>
         /// Stop accepting and tear down every live connection.
         void Stop();
 
+        /// Number of accepted world connections that have not been destroyed.
+        uint32 GetOpenConnectionCount() const;
+
     private:
 
         WorldNetwork();

--- a/src/mangosd/Master.cpp
+++ b/src/mangosd/Master.cpp
@@ -35,6 +35,7 @@
 #include "Log.h"
 #include "MapManager.h"
 #include "MassMailMgr.h"
+#include "SystemConfig.h"
 #include "WorldNetwork.h"
 #include "Timer.h"
 #include "World.h"
@@ -61,6 +62,27 @@ extern int m_ServiceStatus;
 #endif
 
 extern uint32 realmID;
+
+namespace
+{
+#ifdef _WIN32
+    void UpdateConsoleTitle(uint32 players, uint32 connections)
+    {
+        static std::string lastTitle;
+
+        char title[128];
+        snprintf(title, sizeof(title), "%s (%u Players - %u Connections)",
+                 MANGOS_PACKAGENAME, players, connections);
+
+        std::string const newTitle(title);
+        if (lastTitle != newTitle)
+        {
+            lastTitle = newTitle;
+            SetConsoleTitleA(title);
+        }
+    }
+#endif
+}
 
 Master::Master()
 {
@@ -265,6 +287,9 @@ void Master::WorldLoop()
     sLog.outString("World Updater Thread started (%dms min update interval)", WORLD_SLEEP_CONST);
 
     uint32 realPrevTime = getMSTime();
+#ifdef _WIN32
+    uint32 lastStatusTime = realPrevTime;
+#endif
 
     while (!World::IsStopped())
     {
@@ -277,6 +302,15 @@ void Master::WorldLoop()
         realPrevTime = realCurrTime;
 
         const uint32 executionTimeDiff = getMSTimeDiff(realCurrTime, getMSTime());
+
+#ifdef _WIN32
+        if (getMSTimeDiff(lastStatusTime, realCurrTime) >= 1000)
+        {
+            lastStatusTime = realCurrTime;
+            UpdateConsoleTitle(sWorld.GetActiveSessionCount(),
+                               sWorldNetwork.GetOpenConnectionCount());
+        }
+#endif
 
         if (executionTimeDiff < WORLD_SLEEP_CONST)
         {

--- a/src/proto/ClientConnection.cpp
+++ b/src/proto/ClientConnection.cpp
@@ -37,6 +37,8 @@
 
 namespace proto
 {
+    std::atomic<uint32> ClientConnection::s_openConnections{0};
+
     namespace
     {
         // The handful of transport opcodes this file speaks. Re-derived from (grepped
@@ -79,10 +81,12 @@ namespace proto
           m_fastPingRun(0),
           m_lastDecodeLogSec(0)
     {
+        s_openConnections.fetch_add(1, std::memory_order_relaxed);
     }
 
     ClientConnection::~ClientConnection()
     {
+        s_openConnections.fetch_sub(1, std::memory_order_relaxed);
     }
 
     std::vector<uint8_t> ClientConnection::EncodeForSend(const WorldPacket& packet, bool& fatal)

--- a/src/proto/ClientConnection.h
+++ b/src/proto/ClientConnection.h
@@ -116,6 +116,11 @@ namespace proto
 
             bool IsClosed() const override { return closed(); }
 
+            static uint32 GetOpenConnectionCount()
+            {
+                return s_openConnections.load(std::memory_order_relaxed);
+            }
+
         private:
 
             /// Encode one packet to wire bytes: MopWire::BuildServerHeader, then
@@ -197,6 +202,8 @@ namespace proto
             /// m_lastDecodeLog), shared across the frame-level and dispatch-level
             /// decode-failure paths. Seconds since epoch; 0 means "never logged".
             std::atomic<int64_t> m_lastDecodeLogSec;
+
+            static std::atomic<uint32> s_openConnections;
     };
 }
 


### PR DESCRIPTION
## Summary

- show live active-session and open-connection counts in the Windows `mangosd` console title
- expose the proven sibling-core `ClientConnection` lifecycle counter through `WorldNetwork`
- refresh on a one-second cadence and avoid redundant `SetConsoleTitleA` calls when the title is unchanged

## Why

The directly launched Four world server lost the useful sibling-core title status that lets an operator see player/session and socket counts while the console is minimised or obscured. Four's newer network boundary did not expose its accepted connection count, so this ports Zero's proven lifecycle counter along with the title publisher.

The resulting title is:

`MaNGOS Four (N Players - N Connections)`

`Players` retains the existing sibling behavior of reporting active authenticated sessions, including the character screen. `Connections` reports all live accepted world connection objects, including unauthenticated peers.

## Verification

- `git diff --check`
- x64 RelWithDebInfo `mangosd` target built successfully
- built PE machine verified as `0x8664`
- exact committed binary deployed with matching EXE/PDB SHA-256 hashes
- live Windows smoke passed: `0/0` at startup, `1/1` at character screen and in world, then `0/0` after disconnect, all within the one-second cadence

A bounded SWE-1.7 Max review found no BLOCKING, IMPORTANT, or MINOR issues and
returned `APPROVE WITH FOLLOW-UP`. Its only follow-up was the direct Windows
visual smoke recorded above, which passed before publication.
