### PR TITLE
[CI] Fix build workflows and stale CI references

### DIFF
--- a/.github/workflows/core_linux_build.yml
+++ b/.github/workflows/core_linux_build.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build (${{ matrix.name }})
 
     env:
-      BUILD_DIR: ${{ runner.temp }}/build-${{ matrix.name }}
+      BUILD_DIR: ${{ github.workspace }}/../build-${{ matrix.name }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/core_linux_build.yml
+++ b/.github/workflows/core_linux_build.yml
@@ -32,8 +32,7 @@ jobs:
     name: Build (${{ matrix.name }})
 
     env:
-      BUILD_DIR: ${{ github.workspace }}/../build-${{ matrix.name }}
-      CCACHE_DIR: ${{ github.workspace }}/../ccache
+      BUILD_DIR: ${{ runner.temp }}/build-${{ matrix.name }}
 
     steps:
       - name: Checkout repository
@@ -53,6 +52,8 @@ jobs:
           key: linux-${{ matrix.name }}
           max-size: 500M
 
+      # Never the socket tests: they bind real listeners and dominate the
+      # suite's wall-clock. A human asks for them, CI does not.
       - name: Configure
         run: >
           cmake -S . -B "$BUILD_DIR" -G Ninja
@@ -66,8 +67,6 @@ jobs:
           -DBUILD_MANGOSD=1
           -DBUILD_REALMD=1
           -DWITH_TESTS=1
-          # Never the socket tests: they bind real listeners and dominate the
-          # suite's wall-clock. A human asks for them, CI does not.
           -DWITH_NET_TESTS=0
           -DSOAP=1
           -DSCRIPT_LIB_ELUNA=1

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: windows-2022
 
     env:
-      BUILD_DIR: ${{ runner.temp }}\build-msvc
+      BUILD_DIR: ${{ github.workspace }}\..\build-msvc
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -22,9 +22,7 @@ jobs:
     runs-on: windows-2022
 
     env:
-      BUILD_DIR: ${{ github.workspace }}\..\build-msvc
-      CCACHE_DIR: ${{ github.workspace }}\..\ccache
-      SCCACHE_DIR: ${{ github.workspace }}\..\sccache
+      BUILD_DIR: ${{ runner.temp }}\build-msvc
 
     steps:
       - name: Checkout repository
@@ -112,6 +110,8 @@ jobs:
           key: windows-msvc
           max-size: 500M
 
+      # Never the socket tests: they bind real listeners and dominate the
+      # suite's wall-clock. A human asks for them, CI does not.
       - name: Configure
         shell: bash
         run: >
@@ -125,8 +125,6 @@ jobs:
           -DBUILD_MANGOSD=1
           -DBUILD_REALMD=1
           -DWITH_TESTS=1
-          # Never the socket tests: they bind real listeners and dominate the
-          # suite's wall-clock. A human asks for them, CI does not.
           -DWITH_NET_TESTS=0
           -DSOAP=1
           -DSCRIPT_LIB_ELUNA=1

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 # Placeholder files for directories needed to be inside git but empty
 !.gitignore
 !.gitattributes
-!.travis.yml
 
 # JetBrains - project settings
 /.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,9 @@ msbuild.cmd
 
 # File generated during compile
 /dep/libmpq/compile
+
+# Compiler caches. The cache action picks its own directory inside the
+# checkout, so without these the "working tree is clean" guard fails on the
+# cache rather than on a real change.
+.ccache/
+.sccache/

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ World of Warcraft, and all related art, images, and lore are copyright [Blizzard
 [7]: http://www.cppreference.com/ "C / C++ reference"
 [8]: https://github.com/mangos/MaNGOS/blob/master/mangosFamily.md "The MaNGOS family of Icons"
 [9]: https://discord.gg/fPxMjHS8xs "Our community hub on Discord"
-[10]: https://github.com/mangosfour/server/actions/workflows/core_build.yml "Github Actions - Linux/MAC build status"
+[10]: https://github.com/mangosfour/server/actions/workflows/core_linux_build.yml "Github Actions - Linux/MAC build status"
 [11]: https://ci.appveyor.com/project/MaNGOS/server-four/history "AppVeyor Scan - Windows build status"
 [12]: https://app.codacy.com/gh/mangosfour/server/dashboard "Codacy Code Status"
 [13]: https://www.codefactor.io/repository/github/mangosfour/server "Codefactor Code Status"

--- a/src/game/Object/ObjectMgrPhases.cpp
+++ b/src/game/Object/ObjectMgrPhases.cpp
@@ -27,6 +27,7 @@
 
 #include "Database/DatabaseEnv.h"
 #include "Log.h"
+#include "SQLStorages.h"
 
 namespace
 {


### PR DESCRIPTION
Three defects in the GitHub Actions build workflows, plus two fixes they exposed. No AppVeyor configuration is touched.

**1. Six configure flags are silently discarded.**
The `Configure` step uses a YAML folded scalar (`run: >`), which joins every line into a single shell command. bash then treats the embedded `#` comment — and everything after it — as a comment, so these never reach cmake:

```
-DWITH_NET_TESTS=0 -DSOAP=1 -DSCRIPT_LIB_ELUNA=1 -DSCRIPT_LIB_SD3=1 -DPLAYERBOTS=0 -DPCH=0
```

Confirmed in this repo's own job log: the executed configure command ends at `-DWITH_TESTS=1`, and the summary prints `Support for SOAP : No (default)`. Fixed by moving the comment above the step; the wording is unchanged and `run: >` is kept.

**2. The compiler cache has never persisted.**
`CCACHE_DIR` / `SCCACHE_DIR` contained `..`, which `actions/cache` rejects at save time:

```
Saving cache failed: Invalid pattern '/home/runner/work/Server/Server/../ccache'.
Relative pathing '.' and '..' is not allowed.
```

Every subsequent run reported `No cache found` and rebuilt cold — measured here at ccache 1.46% hits and sccache 0.00% (`Non-cacheable reasons: /Fp 887, /Yc 2`). The overrides are removed so `ccache-action` manages its own directory. `BUILD_DIR` keeps the `github.workspace` form: it is never handed to `actions/cache`, so its `..` was never the problem, and the `runner` context is not available in `jobs.<job_id>.env`.

**3. Stale references.** The README links `core_build.yml`, which does not exist (`core_linux_build.yml`), and `.gitignore` still carries a `!.travis.yml` exception for a file removed years ago.

---

### Two fixes the above exposed

**`.gitignore`: ignore the compiler cache directories.**
With the `SCCACHE_DIR` override gone, `ccache-action` uses its own default — `<workspace>/.sccache` — and the "Verify the working tree is clean" step then fails with `?? .sccache/`. The other four cores already carry `.ccache/` and `.sccache/` entries for exactly this reason; m4 was the only one missing them. This brings it into line.

**`ObjectMgrPhases.cpp`: include `SQLStorages.h`.**
Once `-DPCH=0` actually reaches cmake, gcc reports:

```
src/game/Object/ObjectMgrPhases.cpp:90:35: error: 'sConditionStorage' was not declared in this scope
```

The file calls `sConditionStorage` but never included the header declaring it (`src/game/Server/SQLStorages.h:41`). It has only ever compiled because the precompiled header supplied the declaration. `ObjectMgr.cpp`, which this file was split out of, includes it at line 33 — the include was not carried across in the split. This file exists only in this core.

It is included here rather than split out because it is caused by change 1 and this PR cannot go green without it.
