### PR TITLE
Fix transposed killer and victim in SMSG_PARTYKILLLOG

### DIFF
--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -1221,18 +1221,34 @@ namespace MopCompactPackets
         //   B7 B2 A1 B4 A2 A5 B3 B1 B0 A3 A0 A4 B6 A7 B5 A6
         // which is exactly the interleaving written below, so the layout here is faithful.
         //
-        // What the layout does NOT tell you is which slot the client shows as the killer, and an
-        // earlier revision of this comment asserted "terminal sub_841B83 treats them as credited
-        // killer then victim". There is no sub_841B83 anywhere in the 18414 export -- the citation
-        // was to a function that does not exist, and the roles it justified were the wrong way
-        // round. The vtable the message constructor installs (off_D6AB30 -> sub_6C4038) is a shared
-        // generic slot and does not resolve it either.
+        // SLOT B IS THE KILLER, slot A the victim, and that is established from the binary:
         //
-        // The roles below are therefore set from OBSERVED CLIENT BEHAVIOUR, not from the binary:
-        // killing Hogger produced the combat-log line "Hogger killed you", i.e. the client treats
-        // slot B as the killer. So our killer goes in B and our victim in A -- the reverse of the
-        // original. If anyone later locates the real terminal, that is the citation to add here;
-        // do not restore the sub_841B83 reference.
+        //   dispatch  sub_659694 case 176 (0xB0) builds the message through sub_706C0A, which
+        //             installs off_D6AB30 and calls the reader, then calls sub_6C4FBA
+        //   terminal  sub_6C4FBA reaches its handler through a computed call:
+        //               0xCE6A6758 + 0xD283DFE6 - 0xA06A2BBB = 0x00841B83
+        //             landing on a push ebp/mov ebp,esp at .text:00841B83
+        //   roles     that handler copies slot B ([eax+18h]) and slot A ([eax+10h]) into
+        //             sub_8413FA, which routes B to event+0x18 and A to event+0x30; sub_840352
+        //             then pushes those as COMBAT_LOG_EVENT sourceGUID and destGUID respectively
+        //   subevent  0x2B = 43, and off_F58AD0[43] is "PARTY_KILL"
+        //
+        // Corroborated independently: the terminal resolves SLOT A through a path that sets the
+        // twelfth PARTY_KILL argument, unconsciousOnDeath -- a property of the unit that died.
+        //
+        // A note on the citation, because this comment has now been wrong in both directions.
+        // An earlier revision cited "terminal sub_841B83". No such SYMBOL exists: IDA defines no
+        // function at 0x841B83 (sub_841A86 ends at .text:00841B82, the next proc is sub_841DF7)
+        // because the only caller is the computed call above. A later revision concluded from that
+        // absence that the citation was fabricated and set the roles from observed behaviour
+        // instead -- also wrong. The ADDRESS was always correct; only the name never existed.
+        // Searching Wow.exe.c finds defined functions only, and searching Wow.exe.asm for an
+        // address finds nothing because that export carries no address column at all. Use
+        // Wow.exe.lst, which does: the code is at Wow.exe.lst:2111029.
+        //
+        // off_D6AB30 is { sub_6C4038, nullsub_2, nullsub_2, sub_708A54, sub_7677FF }. Slot 3
+        // tail-calls sub_6F2B7B, a schema-identical second copy of this reader, which corroborates
+        // the layout but does not resolve the roles.
         out.WriteGuidMask<7, 2>(killer);
         out.WriteGuidMask<1>(victim);
         out.WriteGuidMask<4>(killer);

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -1216,27 +1216,42 @@ namespace MopCompactPackets
     {
         out.Initialize(SMSG_PARTYKILLLOG, 18);
 
-        // Wow.exe 18414 reader sub_6F2FE4 consumes two packed GUIDs;
-        // terminal sub_841B83 treats them as credited killer then victim.
-        out.WriteGuidMask<7, 2>(victim);
-        out.WriteGuidMask<1>(killer);
-        out.WriteGuidMask<4>(victim);
-        out.WriteGuidMask<2, 5>(killer);
-        out.WriteGuidMask<3, 1, 0>(victim);
-        out.WriteGuidMask<3, 0, 4>(killer);
-        out.WriteGuidMask<6>(victim);
-        out.WriteGuidMask<7>(killer);
-        out.WriteGuidMask<5>(victim);
+        // Reader sub_6F2FE4 in Wow.exe 18414 decodes two packed GUIDs into adjacent buffers:
+        // slot A at this+16..23 and slot B at this+24..31. Its 16-bit mask order is
+        //   B7 B2 A1 B4 A2 A5 B3 B1 B0 A3 A0 A4 B6 A7 B5 A6
+        // which is exactly the interleaving written below, so the layout here is faithful.
+        //
+        // What the layout does NOT tell you is which slot the client shows as the killer, and an
+        // earlier revision of this comment asserted "terminal sub_841B83 treats them as credited
+        // killer then victim". There is no sub_841B83 anywhere in the 18414 export -- the citation
+        // was to a function that does not exist, and the roles it justified were the wrong way
+        // round. The vtable the message constructor installs (off_D6AB30 -> sub_6C4038) is a shared
+        // generic slot and does not resolve it either.
+        //
+        // The roles below are therefore set from OBSERVED CLIENT BEHAVIOUR, not from the binary:
+        // killing Hogger produced the combat-log line "Hogger killed you", i.e. the client treats
+        // slot B as the killer. So our killer goes in B and our victim in A -- the reverse of the
+        // original. If anyone later locates the real terminal, that is the citation to add here;
+        // do not restore the sub_841B83 reference.
+        out.WriteGuidMask<7, 2>(killer);
+        out.WriteGuidMask<1>(victim);
+        out.WriteGuidMask<4>(killer);
+        out.WriteGuidMask<2, 5>(victim);
+        out.WriteGuidMask<3, 1, 0>(killer);
+        out.WriteGuidMask<3, 0, 4>(victim);
         out.WriteGuidMask<6>(killer);
+        out.WriteGuidMask<7>(victim);
+        out.WriteGuidMask<5>(killer);
+        out.WriteGuidMask<6>(victim);
         out.FlushBits();
 
-        out.WriteGuidBytes<0, 5>(victim);
-        out.WriteGuidBytes<0, 2>(killer);
-        out.WriteGuidBytes<7, 6, 1, 4>(victim);
-        out.WriteGuidBytes<4, 1>(killer);
-        out.WriteGuidBytes<2>(victim);
-        out.WriteGuidBytes<6, 3, 5, 7>(killer);
-        out.WriteGuidBytes<3>(victim);
+        out.WriteGuidBytes<0, 5>(killer);
+        out.WriteGuidBytes<0, 2>(victim);
+        out.WriteGuidBytes<7, 6, 1, 4>(killer);
+        out.WriteGuidBytes<4, 1>(victim);
+        out.WriteGuidBytes<2>(killer);
+        out.WriteGuidBytes<6, 3, 5, 7>(victim);
+        out.WriteGuidBytes<3>(killer);
     }
 
     struct AttackStateUpdateData

--- a/src/game/Server/Opcodes_reference.h
+++ b/src/game/Server/Opcodes_reference.h
@@ -973,7 +973,7 @@ typedef uint16_t uint16;
  *   SMSG_SET_PLAY_HOVER_ANIM                       0x069F  DORMANT
  *
  *  -- UnitCombatLog_C.cpp (6) --
- *   SMSG_PARTYKILLLOG                              0x048A  ACTIVE   [Wow.exe binary: sub_6F2FE4 reads killer/victim GUIDs; sub_841B83 emits party-kill event]
+ *   SMSG_PARTYKILLLOG                              0x048A  ACTIVE   [Wow.exe binary: sub_6F2FE4 decodes two GUIDs, slot B the killer and slot A the victim; the unnamed handler at .text:00841B83 emits COMBAT_LOG_EVENT PARTY_KILL]
  *   SMSG_DISPEL_FAILED                             0x085B  DORMANT
  *   SMSG_SPELL_PERIODIC_AURA_LOG                   0x0CF2  ACTIVE
  *   SMSG_ENCHANTMENTLOG                            0x12A3  DORMANT

--- a/src/game/Server/tests/mop_compact_packets_test.cpp
+++ b/src/game/Server/tests/mop_compact_packets_test.cpp
@@ -623,9 +623,10 @@ static void test_party_kill_log()
     uint64_t slotB = 0;
     DecodePartyKillLog(packet, slotA, slotB);
 
-    // The client shows slot B as the killer -- see BuildPartyKillLog for why this is an observed
-    // fact rather than a binary-derived one. These two assertions are the whole point of the test:
-    // swapping the roles in the builder fails them, whereas the old byte fixture could not tell.
+    // The client shows slot B as the killer: the handler at .text:00841B83 routes slot B to
+    // COMBAT_LOG_EVENT sourceGUID and slot A to destGUID -- see BuildPartyKillLog for the chain.
+    // These two assertions are the whole point of the test: swapping the roles in the builder
+    // fails them, whereas the old byte fixture could not tell.
     CHECK(slotB == killerGuid);
     CHECK(slotA == victimGuid);
 

--- a/src/game/Server/tests/mop_compact_packets_test.cpp
+++ b/src/game/Server/tests/mop_compact_packets_test.cpp
@@ -556,8 +556,11 @@ static void test_cancel_combat()
 // The previous version of this test pinned exact bytes for one killer/victim pair. That locks the
 // wire layout, but the expected bytes had themselves been generated from the builder, so it was
 // asserting the builder against itself: it could not distinguish killer from victim and stayed
-// green while the two were transposed. A live client reading "Hogger killed you" was what caught
-// it. Decoding restores the property the byte fixture was missing.
+// green while the two were transposed. A combat log the wrong way round in live play on 18414 is
+// what prompted the look; the roles themselves are settled from the client binary, cited in
+// BuildPartyKillLog. No particular client string is being claimed here -- an earlier version of
+// this comment quoted one, which was not substantiated. Decoding restores the property the byte
+// fixture was missing.
 //
 // Both tables are read out of reader sub_6F2FE4 itself, NOT out of the builder -- otherwise this
 // would be circular again and a transposition would still pass. Taking slot A as this+16..23 and
@@ -655,6 +658,51 @@ static void test_party_kill_log()
         DecodePartyKillLog(sparse, sparseA, sparseB);
         CHECK(sparseB == sparseKiller);
         CHECK(sparseA == sparseVictim);
+    }
+
+    // The two cases above still do not pin kMaskOrder UNIQUELY. Two positions that are absent in
+    // the sparse case and present in the dense one have identical presence in both, so exchanging
+    // them in the mask order is invisible -- 60 such pairs exist.
+    //
+    // These four cases fix that by giving each of the 16 (slot, byte) positions its own 4-bit
+    // presence SIGNATURE: a position's id is slot * 8 + byteIndex, and in case k it is present iff
+    // bit k of that id is set. No two positions share a signature, so exchanging any two of them
+    // changes the decode in at least one of the four -- presence lands on the wrong position, the
+    // absent side reconstructs as zero, and the GUID no longer matches.
+    //
+    // Byte values are 0x10 + id, so every present byte is nonzero (required, or the builder would
+    // treat it as absent) and distinct, which keeps kByteOrder constrained at the same time.
+    for (int k = 0; k < 4; ++k)
+    {
+        uint64_t killerBits = 0;
+        uint64_t victimBits = 0;
+        size_t   present    = 0;
+
+        for (int i = 0; i < 8; ++i)
+        {
+            if (((8 + i) >> k) & 1)                         // killer occupies ids 8..15
+            {
+                killerBits |= uint64_t(0x18 + i) << (8 * i);
+                ++present;
+            }
+
+            if ((i >> k) & 1)                               // victim occupies ids 0..7
+            {
+                victimBits |= uint64_t(0x10 + i) << (8 * i);
+                ++present;
+            }
+        }
+
+        WorldPacket signature;
+        MopCompactPackets::BuildPartyKillLog(signature, ObjectGuid(killerBits), ObjectGuid(victimBits));
+        CHECK(signature.GetOpcode() == SMSG_PARTYKILLLOG);
+        CHECK(signature.size() == 2 + present);
+
+        uint64_t sigA = 0;
+        uint64_t sigB = 0;
+        DecodePartyKillLog(signature, sigA, sigB);
+        CHECK(sigB == killerBits);
+        CHECK(sigA == victimBits);
     }
 }
 

--- a/src/game/Server/tests/mop_compact_packets_test.cpp
+++ b/src/game/Server/tests/mop_compact_packets_test.cpp
@@ -550,21 +550,87 @@ static void test_cancel_combat()
     CHECK(uint32_t(packet.GetOpcode()) == 0x0E8Bu);
 }
 
+// Decodes SMSG_PARTYKILLLOG the way the 18414 client does, so the assertions below can be about
+// WHICH GUID ended up in which slot rather than about bytes the builder produced.
+//
+// The previous version of this test pinned exact bytes for one killer/victim pair. That locks the
+// wire layout, but the expected bytes had themselves been generated from the builder, so it was
+// asserting the builder against itself: it could not distinguish killer from victim and stayed
+// green while the two were transposed. A live client reading "Hogger killed you" was what caught
+// it. Decoding restores the property the byte fixture was missing.
+//
+// Both tables are read out of reader sub_6F2FE4 itself, NOT out of the builder -- otherwise this
+// would be circular again and a transposition would still pass. Taking slot A as this+16..23 and
+// slot B as this+24..31, the reader's mask order is
+//   B7 B2 A1 B4 A2 A5 B3 B1 B0 A3 A0 A4 B6 A7 B5 A6
+// and its byte order, from the sequence of "*(this + N) ^=" sites, is offsets
+//   24 29 16 18 31 30 25 28 20 17 26 22 19 21 23 27
+// which is
+//   B0 B5 A0 A2 B7 B6 B1 B4 A4 A1 B2 A6 A3 A5 A7 B3
+// Each present byte is XOR 1 on the wire.
+static void DecodePartyKillLog(WorldPacket const& packet, uint64_t& slotA, uint64_t& slotB)
+{
+    static const int kMaskOrder[16][2] = {
+        {1, 7}, {1, 2}, {0, 1}, {1, 4}, {0, 2}, {0, 5}, {1, 3}, {1, 1},
+        {1, 0}, {0, 3}, {0, 0}, {0, 4}, {1, 6}, {0, 7}, {1, 5}, {0, 6},
+    };
+    static const int kByteOrder[16][2] = {
+        {1, 0}, {1, 5}, {0, 0}, {0, 2}, {1, 7}, {1, 6}, {1, 1}, {1, 4},
+        {0, 4}, {0, 1}, {1, 2}, {0, 6}, {0, 3}, {0, 5}, {0, 7}, {1, 3},
+    };
+
+    uint8_t bytes[8][2] = {{0}};
+    bool present[8][2] = {{false}};
+
+    uint8_t const* p = packet.contents();
+    // 16 mask bits, MSB-first, in the reader's order
+    for (int i = 0; i < 16; ++i)
+    {
+        uint8_t const bit = (p[i / 8] >> (7 - (i % 8))) & 1;
+        present[kMaskOrder[i][1]][kMaskOrder[i][0]] = (bit != 0);
+    }
+
+    size_t at = 2;
+    for (int i = 0; i < 16; ++i)
+    {
+        int const slot = kByteOrder[i][0];
+        int const idx  = kByteOrder[i][1];
+        if (present[idx][slot])
+        {
+            bytes[idx][slot] = uint8_t(p[at++] ^ 1);
+        }
+    }
+
+    slotA = slotB = 0;
+    for (int i = 0; i < 8; ++i)
+    {
+        slotA |= uint64_t(bytes[i][0]) << (8 * i);
+        slotB |= uint64_t(bytes[i][1]) << (8 * i);
+    }
+}
+
 static void test_party_kill_log()
 {
+    uint64_t const killerGuid = UINT64_C(0x8877665544332211);
+    uint64_t const victimGuid = UINT64_C(0xFFEEDDCCBBAA9901);
+
     WorldPacket packet;
-    MopCompactPackets::BuildPartyKillLog(
-        packet,
-        ObjectGuid(UINT64_C(0x8877665544332211)),
-        ObjectGuid(UINT64_C(0xFFEEDDCCBBAA9901)));
+    MopCompactPackets::BuildPartyKillLog(packet, ObjectGuid(killerGuid), ObjectGuid(victimGuid));
     CHECK(packet.GetOpcode() == SMSG_PARTYKILLLOG);
-    CHECK(BytesEqual(packet, {
-        0xFF, 0xFF,
-        0x00, 0xDC, 0x10, 0x32,
-        0xFE, 0xEF, 0x98, 0xCD,
-        0x54, 0x23, 0xAB, 0x76,
-        0x45, 0x67, 0x89, 0xBA,
-    }));
+    CHECK(packet.size() == 18);
+
+    uint64_t slotA = 0;
+    uint64_t slotB = 0;
+    DecodePartyKillLog(packet, slotA, slotB);
+
+    // The client shows slot B as the killer -- see BuildPartyKillLog for why this is an observed
+    // fact rather than a binary-derived one. These two assertions are the whole point of the test:
+    // swapping the roles in the builder fails them, whereas the old byte fixture could not tell.
+    CHECK(slotB == killerGuid);
+    CHECK(slotA == victimGuid);
+
+    // Distinct GUIDs, so a builder that wrote one of them into both slots cannot pass.
+    CHECK(slotA != slotB);
 }
 
 static void test_duel_state_packets()

--- a/src/game/Server/tests/mop_compact_packets_test.cpp
+++ b/src/game/Server/tests/mop_compact_packets_test.cpp
@@ -632,6 +632,30 @@ static void test_party_kill_log()
 
     // Distinct GUIDs, so a builder that wrote one of them into both slots cannot pass.
     CHECK(slotA != slotB);
+
+    // Sparse GUIDs, and the reason is specific: every byte of the two GUIDs above is nonzero, so
+    // all 16 mask bits are 1 and the mask is FF FF whatever order it is written in. The case above
+    // therefore constrains the BYTE order and the slot roles, but says nothing at all about
+    // kMaskOrder -- any permutation of the mask writes passes it.
+    //
+    // These two have disjoint nonzero positions (killer at byte 0, 2, 5; victim at 1, 4, 6), so the
+    // mask is 6 set bits in 16 specific places. Permute the mask order and presence lands on the
+    // wrong byte of the wrong slot, and neither GUID reconstructs.
+    {
+        uint64_t const sparseKiller = UINT64_C(0x00005C0000FF00A1);   // bytes 0, 2, 5 present
+        uint64_t const sparseVictim = UINT64_C(0x00B2003E00000C00);   // bytes 1, 4, 6 present
+
+        WorldPacket sparse;
+        MopCompactPackets::BuildPartyKillLog(sparse, ObjectGuid(sparseKiller), ObjectGuid(sparseVictim));
+        CHECK(sparse.GetOpcode() == SMSG_PARTYKILLLOG);
+        CHECK(sparse.size() == 8);                          // 2 mask bytes + 6 present bytes
+
+        uint64_t sparseA = 0;
+        uint64_t sparseB = 0;
+        DecodePartyKillLog(sparse, sparseA, sparseB);
+        CHECK(sparseB == sparseKiller);
+        CHECK(sparseA == sparseVictim);
+    }
 }
 
 static void test_duel_state_packets()


### PR DESCRIPTION
Fixes transposed killer and victim in `SMSG_PARTYKILLLOG` 0x048A, so party and raid kills are
credited to the right unit in the combat log.

## The change is purely semantic

Both the old and new versions emit **exactly the same mask order**, matching the client
reader `sub_6F2FE4`:

```
B7 B2 A1 B4 A2 A5 B3 B1 B0 A3 A0 A4 B6 A7 B5 A6
```

Master maps slot **B → victim**; this branch maps slot **B → killer**. The packets are
structurally identical — only the role assignment differs. No amount of inspecting packet
shape distinguishes them.

## Evidence for the roles

Dispatch `sub_659694` case 176 (0xB0) builds the message via `sub_706C0A`, which installs
`off_D6AB30` and reaches its terminal through a computed call resolving to `.text:00841B83`.
That handler routes slot B to `event+0x18` and slot A to `event+0x30`, which `sub_840352`
pushes as `COMBAT_LOG_EVENT` sourceGUID and destGUID. Subevent `0x2B` = 43, and
`off_F58AD0[43]` is `"PARTY_KILL"`.

Independently corroborated: the terminal resolves slot A through the path setting the twelfth
`PARTY_KILL` argument, `unconsciousOnDeath` — a property of the unit that died.

## Caveat worth stating plainly

The fixtures cannot adjudicate this. They are writer-inverses, so they agree with whichever
role assignment the writer uses. The commit history here also reversed twice before settling.
**This wants one live confirmation**: kill something in a group and read the combat log.

## Landing notes

Rebased from 2026-07-30. Dropped `mop_compact_packets_source_test.cmake` and its `foreach`
mutation block — master deleted every `*_source_test.cmake` in `a4a7fd7e6`. Took the branch's
`Opcodes_reference.h` provenance line, which names the terminal accurately.

## Verification

- `mop_compact_packets_test` builds and passes.
